### PR TITLE
refactor: combine initial and final rows in PersistentBoundaryAir

### DIFF
--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -14,12 +14,15 @@ template <size_t CHUNK, size_t BLOCKS> struct BoundaryRecord {
 };
 
 template <typename T> struct PersistentBoundaryCols {
-    T expand_direction;
+    T is_valid;
+    T is_dirty;
     T address_space;
     T leaf_label;
-    T values[DIGEST_WIDTH];
-    T hash[DIGEST_WIDTH];
-    T timestamps[BLOCKS_PER_LEAF];
+    T initial_values[DIGEST_WIDTH];
+    T final_values[DIGEST_WIDTH];
+    T initial_hash[DIGEST_WIDTH];
+    T final_hash[DIGEST_WIDTH];
+    T final_timestamps[BLOCKS_PER_LEAF];
 };
 
 __global__ void cukernel_persistent_boundary_tracegen(
@@ -34,12 +37,16 @@ __global__ void cukernel_persistent_boundary_tracegen(
     size_t poseidon2_capacity
 ) {
     size_t row_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    size_t record_idx = row_idx / 2;
     RowSlice row = RowSlice(trace + row_idx, height);
 
-    if (record_idx < num_records) {
-        BoundaryRecord<DIGEST_WIDTH, BLOCKS_PER_LEAF> record = records[record_idx];
+    if (row_idx < num_records) {
+        BoundaryRecord<DIGEST_WIDTH, BLOCKS_PER_LEAF> record = records[row_idx];
         Poseidon2Buffer poseidon2(poseidon2_buffer, poseidon2_buffer_idx, poseidon2_capacity);
+        COL_WRITE_VALUE(row, PersistentBoundaryCols, is_valid, Fp::one());
+        // TODO(follow-up): set real dirtiness (`final_values != init_values`) once
+        // MemoryMerkleAir supports skipping clean leaves in the final expansion. Until
+        // then every touched leaf is treated as dirty, matching the CPU tracegen.
+        COL_WRITE_VALUE(row, PersistentBoundaryCols, is_dirty, Fp::one());
         COL_WRITE_VALUE(row, PersistentBoundaryCols, address_space, record.address_space);
         COL_WRITE_VALUE(
             row,
@@ -47,57 +54,53 @@ __global__ void cukernel_persistent_boundary_tracegen(
             leaf_label,
             record.ptr / DIGEST_WIDTH
         );
-        if (row_idx % 2 == 0) {
-            FpArray<DIGEST_WIDTH> init_values;
-            uint32_t addr_space_idx = record.address_space - 1;
-            if (initial_mem[addr_space_idx]) {
-                // `ptr` is an address-space pointer:
-                //   - DEFERRAL_AS: pointer into F cells; initial memory is already raw Montgomery Fp.
-                //   - Non-deferral ASes: pointer into u16 cells; initial memory is little-endian bytes,
-                //     so convert the pointer to a byte offset with `U16_CELL_SIZE`.
-                if (record.address_space == DEFERRAL_AS) {
-                    init_values = FpArray<DIGEST_WIDTH>::from_raw_array(
-                        reinterpret_cast<uint32_t const *>(initial_mem[addr_space_idx]) +
-                        record.ptr
-                    );
-                } else {
-                    uint8_t const *bytes =
-                        initial_mem[addr_space_idx] + U16_CELL_SIZE * record.ptr;
-                    uint16_t cells[DIGEST_WIDTH];
-                    #pragma unroll
-                    for (int i = 0; i < DIGEST_WIDTH; ++i) {
-                        cells[i] = u16_from_bytes_le(bytes + U16_CELL_SIZE * i);
-                    }
-                    init_values = FpArray<DIGEST_WIDTH>::from_u16_array(cells);
-                }
+
+        FpArray<DIGEST_WIDTH> init_values;
+        uint32_t addr_space_idx = record.address_space - 1;
+        if (initial_mem[addr_space_idx]) {
+            // `ptr` is an address-space pointer:
+            //   - DEFERRAL_AS: pointer into F cells; initial memory is already raw Montgomery Fp.
+            //   - Non-deferral ASes: pointer into u16 cells; initial memory is little-endian bytes,
+            //     so convert the pointer to a byte offset with `U16_CELL_SIZE`.
+            if (record.address_space == DEFERRAL_AS) {
+                init_values = FpArray<DIGEST_WIDTH>::from_raw_array(
+                    reinterpret_cast<uint32_t const *>(initial_mem[addr_space_idx]) +
+                    record.ptr
+                );
             } else {
+                uint8_t const *bytes =
+                    initial_mem[addr_space_idx] + U16_CELL_SIZE * record.ptr;
+                uint16_t cells[DIGEST_WIDTH];
                 #pragma unroll
                 for (int i = 0; i < DIGEST_WIDTH; ++i) {
-                    init_values.v[i] = 0;
+                    cells[i] = u16_from_bytes_le(bytes + U16_CELL_SIZE * i);
                 }
+                init_values = FpArray<DIGEST_WIDTH>::from_u16_array(cells);
             }
-            FpArray<DIGEST_WIDTH> init_hash = poseidon2.hash_and_record(init_values);
-            COL_WRITE_VALUE(row, PersistentBoundaryCols, expand_direction, Fp::one());
-            COL_WRITE_ARRAY(
-                row, PersistentBoundaryCols, values, reinterpret_cast<Fp const *>(init_values.v)
-            );
-            COL_WRITE_ARRAY(
-                row, PersistentBoundaryCols, hash, reinterpret_cast<Fp const *>(init_hash.v)
-            );
-            row.fill_zero(COL_INDEX(PersistentBoundaryCols, timestamps), BLOCKS_PER_LEAF);
         } else {
-            // record.values are already Montgomery-encoded (see read_initial_chunk in inventory.cu)
-            FpArray<DIGEST_WIDTH> final_values = FpArray<DIGEST_WIDTH>::from_raw_array(record.values);
-            FpArray<DIGEST_WIDTH> final_hash = poseidon2.hash_and_record(final_values);
-            COL_WRITE_VALUE(row, PersistentBoundaryCols, expand_direction, Fp::neg_one());
-            COL_WRITE_ARRAY(
-                row, PersistentBoundaryCols, values, reinterpret_cast<Fp const *>(final_values.v)
-            );
-            COL_WRITE_ARRAY(
-                row, PersistentBoundaryCols, hash, reinterpret_cast<Fp const *>(final_hash.v)
-            );
-            COL_WRITE_ARRAY(row, PersistentBoundaryCols, timestamps, record.timestamps);
+            #pragma unroll
+            for (int i = 0; i < DIGEST_WIDTH; ++i) {
+                init_values.v[i] = 0;
+            }
         }
+        FpArray<DIGEST_WIDTH> init_hash = poseidon2.hash_and_record(init_values);
+        COL_WRITE_ARRAY(
+            row, PersistentBoundaryCols, initial_values, reinterpret_cast<Fp const *>(init_values.v)
+        );
+        COL_WRITE_ARRAY(
+            row, PersistentBoundaryCols, initial_hash, reinterpret_cast<Fp const *>(init_hash.v)
+        );
+
+        // record.values are already Montgomery-encoded (see read_initial_chunk in inventory.cu)
+        FpArray<DIGEST_WIDTH> final_values = FpArray<DIGEST_WIDTH>::from_raw_array(record.values);
+        FpArray<DIGEST_WIDTH> final_hash = poseidon2.hash_and_record(final_values);
+        COL_WRITE_ARRAY(
+            row, PersistentBoundaryCols, final_values, reinterpret_cast<Fp const *>(final_values.v)
+        );
+        COL_WRITE_ARRAY(
+            row, PersistentBoundaryCols, final_hash, reinterpret_cast<Fp const *>(final_hash.v)
+        );
+        COL_WRITE_ARRAY(row, PersistentBoundaryCols, final_timestamps, record.timestamps);
     } else {
         row.fill_zero(0, width);
     }

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -363,7 +363,7 @@ impl MemoryCtx {
             + initial_default_poseidon_rows;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
-            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves * 2;
+            *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves;
             *trace_heights.get_unchecked_mut(poseidon2_idx) += poseidon2_rows;
             // Merkle AIR: 2 rows per internal node (init + final tree)
             *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes * 2;
@@ -489,7 +489,7 @@ mod tests {
         ctx.apply_height_updates(&mut trace_heights);
 
         let poseidon2_idx = trace_heights.len() - 2;
-        assert_eq!(trace_heights[BOUNDARY_AIR_ID], 4);
+        assert_eq!(trace_heights[BOUNDARY_AIR_ID], 2);
         assert_eq!(trace_heights[MERKLE_AIR_ID], 2 * height);
         assert_eq!(trace_heights[poseidon2_idx], 2 * height + 3);
     }
@@ -513,7 +513,7 @@ mod tests {
         ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1);
         ctx.apply_height_updates(&mut trace_heights);
 
-        assert_eq!(trace_heights[BOUNDARY_AIR_ID] - boundary_before, 2);
+        assert_eq!(trace_heights[BOUNDARY_AIR_ID] - boundary_before, 1);
         assert_eq!(
             trace_heights[MERKLE_AIR_ID] - merkle_before,
             2 * PAGE_MASK_LEAF_BITS_U32

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -303,7 +303,7 @@ impl MemoryCtx {
 
     /// Applies memory height deltas recorded since the last checkpoint.
     ///
-    /// - BOUNDARY_AIR: `2 * segment_leaves` rows
+    /// - BOUNDARY_AIR: `segment_leaves` rows
     /// - MERKLE_AIR:   `2 * segment_merkle_nodes` rows
     /// - Poseidon2:    hashes at the end of the segment plus hashes at its start
     ///

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -95,7 +95,7 @@ impl<RA> Chip<RA, GpuBackend> for BoundaryChipGPU {
             trace.buffer().fill_zero_on(&self.device_ctx).unwrap();
             return AirProvingContext::simple_no_pis(trace);
         }
-        let unpadded_height = 2 * num_records;
+        let unpadded_height = num_records;
         let trace_height = next_power_of_two_or_zero(unpadded_height);
         let trace =
             DeviceMatrix::<F>::with_capacity_on(trace_height, self.trace_width(), &self.device_ctx);

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -99,7 +99,7 @@ impl<RA> Chip<RA, GpuBackend> for BoundaryChipGPU {
         let trace_height = next_power_of_two_or_zero(unpadded_height);
         let trace =
             DeviceMatrix::<F>::with_capacity_on(trace_height, self.trace_width(), &self.device_ctx);
-        trace.buffer().fill_zero_on(&self.device_ctx).unwrap();
+        // The tracegen kernel initializes every active and padding row.
         let mem_ptrs = self.initial_leaves.to_device_on(&self.device_ctx).unwrap();
         let poseidon2_records = self.poseidon2_buffer.records();
         unsafe {

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -32,32 +32,39 @@ use crate::{
 /// Number of memory-bus blocks covered by one merkle leaf.
 pub const BLOCKS_PER_LEAF: usize = VM_DIGEST_WIDTH / BLOCK_FE_WIDTH;
 
-/// The values describe one merkle leaf (`DIGEST_WIDTH` cells)---the data together with the
-/// last accessed timestamp---in either the initial or final memory state.
+/// Each row describes one touched merkle leaf (`DIGEST_WIDTH` cells): its data and hash in both
+/// the initial and final memory state, together with the per-block final timestamps.
+/// Initial timestamps are always zero.
 #[repr(C)]
 #[derive(Debug, AlignedBorrow, StructReflection)]
 pub struct PersistentBoundaryCols<T, const DIGEST_WIDTH: usize> {
-    // `expand_direction` =  1 corresponds to initial memory state
-    // `expand_direction` = -1 corresponds to final memory state
-    // `expand_direction` =  0 corresponds to irrelevant row (all interactions multiplicity 0)
-    pub expand_direction: T,
+    pub is_valid: T,
+    pub is_dirty: T,
     pub address_space: T,
     pub leaf_label: T,
-    pub values: [T; DIGEST_WIDTH],
-    pub hash: [T; DIGEST_WIDTH],
+    pub initial_values: [T; DIGEST_WIDTH],
+    pub final_values: [T; DIGEST_WIDTH],
+    pub initial_hash: [T; DIGEST_WIDTH],
+    pub final_hash: [T; DIGEST_WIDTH],
     /// Per-block timestamps. Each BLOCK_FE_WIDTH block within the leaf has its own timestamp.
     /// For untouched blocks, timestamp stays at 0 (balances: boundary sends at t=0 init, receives
     /// at t=0 final).
-    pub timestamps: [T; BLOCKS_PER_LEAF],
+    pub final_timestamps: [T; BLOCKS_PER_LEAF],
 }
 
 /// Imposes the following constraints:
-/// - `expand_direction` should be -1, 0, 1
+/// - `is_valid` and `is_dirty` are boolean, and `is_dirty` implies `is_valid`
+/// - on clean rows (`is_valid = 1, is_dirty = 0`), final values and hash equal initial ones
 ///
-/// Sends the following interactions:
-/// - if `expand_direction` is 1, sends `[0, 0, address_space_label, leaf_label]` to `merkle_bus`.
-/// - if `expand_direction` is -1, receives `[1, 0, address_space_label, leaf_label]` from
-///   `merkle_bus`.
+/// Sends the following interactions (one row per touched leaf):
+/// - merkle bus: initial leaf `[1, 0, as_label, leaf_label, initial_hash]` with multiplicity
+///   `is_valid`; final leaf `[-1, 0, as_label, leaf_label, final_hash]` with multiplicity
+///   `-is_dirty`.
+/// - compression bus: `(initial_values, 0, initial_hash)` with multiplicity `is_valid`;
+///   `(final_values, 0, final_hash)` with multiplicity `is_dirty`.
+/// - memory bus: opens the block at timestamp 0 with
+///   `initial_values` (multiplicity `is_valid`) and closes it at `final_timestamps` with
+///   `final_values` (multiplicity `-is_valid`).
 #[derive(Clone, Debug, ColumnsAir)]
 #[columns_via(PersistentBoundaryCols<u8, DIGEST_WIDTH>)]
 pub struct PersistentBoundaryAir<const DIGEST_WIDTH: usize> {
@@ -86,54 +93,85 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder> Air<AB>
         let local = main.row_slice(0).expect("window should have two elements");
         let local: &PersistentBoundaryCols<AB::Var, DIGEST_WIDTH> = (*local).borrow();
 
-        // `direction` should be -1, 0, 1
-        builder.assert_eq(
-            local.expand_direction,
-            local.expand_direction * local.expand_direction * local.expand_direction,
-        );
+        builder.assert_bool(local.is_valid);
+        builder.assert_bool(local.is_dirty);
+        // `is_dirty` may only be set on valid rows
+        builder
+            .when(AB::Expr::ONE - local.is_valid)
+            .assert_zero(local.is_dirty);
 
-        // Constrain that an "initial" row has all timestamp zero.
-        // Since `direction` is constrained to be in {-1, 0, 1}, we can select `direction == 1`
-        // with the constraint below.
-        let mut when_initial =
-            builder.when(local.expand_direction * (local.expand_direction + AB::F::ONE));
-        for i in 0..BLOCKS_PER_LEAF {
-            when_initial.assert_zero(local.timestamps[i]);
+        // If the leaf is clean, its final values and hash must match the initial ones.
+        // Since both bits are boolean and `is_dirty` implies `is_valid`, the selector below
+        // is 1 exactly on clean valid rows.
+        let mut when_clean = builder.when(local.is_valid - local.is_dirty);
+        for i in 0..DIGEST_WIDTH {
+            when_clean.assert_eq(local.initial_values[i], local.final_values[i]);
+            when_clean.assert_eq(local.initial_hash[i], local.final_hash[i]);
         }
 
+        // merkle-bus interaction: initial leaf
         let mut expand_fields = vec![
-            // direction =  1 => is_final = 0
-            // direction = -1 => is_final = 1
-            local.expand_direction.into(),
+            AB::Expr::ONE,
             AB::Expr::ZERO,
             local.address_space - AB::F::from_u32(ADDR_SPACE_OFFSET),
             local.leaf_label.into(),
         ];
-        expand_fields.extend(local.hash.map(Into::into));
+        expand_fields.extend(local.initial_hash.map(Into::into));
         self.merkle_bus
-            .interact(builder, expand_fields, local.expand_direction.into());
+            .interact(builder, expand_fields, local.is_valid.into());
+        // merkle-bus interaction: final leaf
+        let mut expand_fields = vec![
+            AB::Expr::NEG_ONE,
+            AB::Expr::ZERO,
+            local.address_space - AB::F::from_u32(ADDR_SPACE_OFFSET),
+            local.leaf_label.into(),
+        ];
+        expand_fields.extend(local.final_hash.map(Into::into));
+        self.merkle_bus
+            .interact(builder, expand_fields, AB::Expr::ZERO - local.is_dirty);
 
+        // compression bus interaction: initial leaf
         self.compression_bus.interact(
             builder,
             iter::empty()
-                .chain(local.values.map(Into::into))
+                .chain(local.initial_values.map(Into::into))
                 .chain(iter::repeat_n(AB::Expr::ZERO, DIGEST_WIDTH))
-                .chain(local.hash.map(Into::into)),
-            local.expand_direction * local.expand_direction,
+                .chain(local.initial_hash.map(Into::into)),
+            local.is_valid,
+        );
+        // compression bus interaction: final leaf
+        self.compression_bus.interact(
+            builder,
+            iter::empty()
+                .chain(local.final_values.map(Into::into))
+                .chain(iter::repeat_n(AB::Expr::ZERO, DIGEST_WIDTH))
+                .chain(local.final_hash.map(Into::into)),
+            local.is_dirty,
         );
 
+        // memory bus interactions
         let leaf_ptr = local.leaf_label * AB::F::from_usize(DIGEST_WIDTH);
         for block_idx in 0..BLOCKS_PER_LEAF {
             let ptr = leaf_ptr.clone() + AB::F::from_usize(block_idx * BLOCK_FE_WIDTH);
             // Each block uses its own timestamp; untouched blocks stay at t=0.
+            // initial block
+            self.memory_bus
+                .send(
+                    MemoryAddress::new(local.address_space, ptr.clone()),
+                    local.initial_values[block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
+                        .to_vec(),
+                    AB::Expr::ZERO,
+                )
+                .eval(builder, local.is_valid);
+            // final block
             self.memory_bus
                 .send(
                     MemoryAddress::new(local.address_space, ptr),
-                    local.values[block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
+                    local.final_values[block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
                         .to_vec(),
-                    local.timestamps[block_idx],
+                    local.final_timestamps[block_idx],
                 )
-                .eval(builder, local.expand_direction);
+                .eval(builder, AB::Expr::ZERO - local.is_valid);
         }
     }
 }

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
 };
 use tracing::instrument;
 
-use super::{merkle::SerialReceiver, online::INITIAL_TIMESTAMP};
+use super::merkle::SerialReceiver;
 use crate::{
     arch::{hasher::Hasher, ADDR_SPACE_OFFSET, BLOCK_FE_WIDTH},
     primitives::Chip,
@@ -62,9 +62,8 @@ pub struct PersistentBoundaryCols<T, const DIGEST_WIDTH: usize> {
 ///   `-is_dirty`.
 /// - compression bus: `(initial_values, 0, initial_hash)` with multiplicity `is_valid`;
 ///   `(final_values, 0, final_hash)` with multiplicity `is_dirty`.
-/// - memory bus: opens the block at timestamp 0 with
-///   `initial_values` (multiplicity `is_valid`) and closes it at `final_timestamps` with
-///   `final_values` (multiplicity `-is_valid`).
+/// - memory bus: opens the block at timestamp 0 with `initial_values` (multiplicity `is_valid`) and
+///   closes it at `final_timestamps` with `final_values` (multiplicity `-is_valid`).
 #[derive(Clone, Debug, ColumnsAir)]
 #[columns_via(PersistentBoundaryCols<u8, DIGEST_WIDTH>)]
 pub struct PersistentBoundaryAir<const DIGEST_WIDTH: usize> {
@@ -158,7 +157,8 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder> Air<AB>
             self.memory_bus
                 .send(
                     MemoryAddress::new(local.address_space, ptr.clone()),
-                    local.initial_values[block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
+                    local.initial_values
+                        [block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
                         .to_vec(),
                     AB::Expr::ZERO,
                 )
@@ -167,7 +167,8 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder> Air<AB>
             self.memory_bus
                 .send(
                     MemoryAddress::new(local.address_space, ptr),
-                    local.final_values[block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
+                    local.final_values
+                        [block_idx * BLOCK_FE_WIDTH..(block_idx + 1) * BLOCK_FE_WIDTH]
                         .to_vec(),
                     local.final_timestamps[block_idx],
                 )
@@ -311,7 +312,7 @@ where
                 .expect("Cannot generate trace before finalization");
             let width = PersistentBoundaryCols::<Val<SC>, DIGEST_WIDTH>::width();
             // Boundary AIR should always present in order to fix the AIR ID of merkle AIR.
-            let mut height = (2 * touched_labels.len()).next_power_of_two();
+            let mut height = touched_labels.len().next_power_of_two();
             if let Some(mut oh) = self.overridden_height {
                 oh = oh.next_power_of_two();
                 assert!(
@@ -322,26 +323,20 @@ where
             }
             let mut rows = Val::<SC>::zero_vec(height * width);
 
-            rows.par_chunks_mut(2 * width)
+            rows.par_chunks_mut(width)
                 .zip(touched_labels.par_iter())
                 .for_each(|(row, touched_label)| {
-                    let (initial_row, final_row) = row.split_at_mut(width);
-                    *initial_row.borrow_mut() = PersistentBoundaryCols {
-                        expand_direction: Val::<SC>::ONE,
+                    *row.borrow_mut() = PersistentBoundaryCols {
+                        is_valid: Val::<SC>::ONE,
+                        // TODO: set is_dirty only when it is actually dirty
+                        is_dirty: Val::<SC>::ONE,
                         address_space: Val::<SC>::from_u32(touched_label.address_space),
                         leaf_label: Val::<SC>::from_u32(touched_label.label),
-                        values: touched_label.init_values,
-                        hash: touched_label.init_hash,
-                        timestamps: [Val::<SC>::from_u32(INITIAL_TIMESTAMP); BLOCKS_PER_LEAF],
-                    };
-
-                    *final_row.borrow_mut() = PersistentBoundaryCols {
-                        expand_direction: Val::<SC>::NEG_ONE,
-                        address_space: Val::<SC>::from_u32(touched_label.address_space),
-                        leaf_label: Val::<SC>::from_u32(touched_label.label),
-                        values: touched_label.final_values,
-                        hash: touched_label.final_hash,
-                        timestamps: touched_label.final_timestamps.map(Val::<SC>::from_u32),
+                        initial_values: touched_label.init_values,
+                        final_values: touched_label.final_values,
+                        initial_hash: touched_label.init_hash,
+                        final_hash: touched_label.final_hash,
+                        final_timestamps: touched_label.final_timestamps.map(Val::<SC>::from_u32),
                     };
                 });
             RowMajorMatrix::new(rows, width)

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -54,7 +54,7 @@ pub struct PersistentBoundaryCols<T, const DIGEST_WIDTH: usize> {
 
 /// Imposes the following constraints:
 /// - `is_valid` and `is_dirty` are boolean, and `is_dirty` implies `is_valid`
-/// - on clean rows (`is_valid = 1, is_dirty = 0`), final values and hash equal initial ones
+/// - on clean rows (`is_valid = 1, is_dirty = 0`), final values equal initial ones
 ///
 /// Sends the following interactions (one row per touched leaf):
 /// - merkle bus: initial leaf `[1, 0, as_label, leaf_label, initial_hash]` with multiplicity
@@ -97,14 +97,15 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder> Air<AB>
         // `is_dirty` may only be set on valid rows
         builder.when(local.is_dirty).assert_one(local.is_valid);
 
-        // If the leaf is clean, its final values and hash must match the initial ones.
+        // If the leaf is clean, its final values must match the initial ones.
         // Since both bits are boolean and `is_dirty` implies `is_valid`, the selector below
         // is 1 exactly on clean valid rows.
         let mut when_clean = builder.when(local.is_valid - local.is_dirty);
         for i in 0..DIGEST_WIDTH {
             when_clean.assert_eq(local.initial_values[i], local.final_values[i]);
-            when_clean.assert_eq(local.initial_hash[i], local.final_hash[i]);
         }
+        // `final_hash` needs no clean-row constraint: both interactions that contain it
+        // have multiplicity `is_dirty`, so it is unused here.
 
         // merkle-bus interaction: initial leaf
         let mut expand_fields = vec![

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -95,9 +95,7 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder> Air<AB>
         builder.assert_bool(local.is_valid);
         builder.assert_bool(local.is_dirty);
         // `is_dirty` may only be set on valid rows
-        builder
-            .when(AB::Expr::ONE - local.is_valid)
-            .assert_zero(local.is_dirty);
+        builder.when(local.is_dirty).assert_one(local.is_valid);
 
         // If the leaf is clean, its final values and hash must match the initial ones.
         // Since both bits are boolean and `is_dirty` implies `is_valid`, the selector below


### PR DESCRIPTION
This PR updated `PersistentBoundaryAir` to combine both initial and final states. This is done by storing initial and final values. On top of it, there is new addition of is_valid and is_dirty flags. This PR focuses on updating PersistentBoundaryAir columns.

The second PR properly adds is_dirty flag (https://github.com/openvm-org/openvm/pull/3055). In this PR, for development purposes, it is set to one.

towards INT-8828