### PR TITLE
perf(v2.1): use halo2curves asm for bn254 witnesses

### DIFF
--- a/crates/rvr/rvr-openvm-build/src/lib.rs
+++ b/crates/rvr/rvr-openvm-build/src/lib.rs
@@ -147,8 +147,21 @@ pub fn build_rust_staticlib(
     lib_name: &str,
     crate_name: &str,
 ) -> PathBuf {
+    build_rust_staticlib_with_features(manifest_path, target_dir, lib_name, crate_name, &[])
+}
+
+/// Build a Rust staticlib crate with the requested Cargo features in a private
+/// target directory and return the expected archive path.
+pub fn build_rust_staticlib_with_features(
+    manifest_path: &Path,
+    target_dir: &Path,
+    lib_name: &str,
+    crate_name: &str,
+    features: &[&str],
+) -> PathBuf {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let output = Command::new(&cargo)
+    let mut command = Command::new(&cargo);
+    command
         .args([
             "build",
             "--release",
@@ -158,7 +171,11 @@ pub fn build_rust_staticlib(
         ])
         .arg(manifest_path)
         .arg("--target-dir")
-        .arg(target_dir)
+        .arg(target_dir);
+    if !features.is_empty() {
+        command.args(["--features", &features.join(",")]);
+    }
+    let output = command
         .output()
         .unwrap_or_else(|e| panic!("failed to spawn cargo for {crate_name}: {e}"));
 

--- a/extensions/pairing/rvr/build.rs
+++ b/extensions/pairing/rvr/build.rs
@@ -4,7 +4,7 @@
 
 use std::{env, path::PathBuf};
 
-use rvr_openvm_build::build_rust_staticlib;
+use rvr_openvm_build::build_rust_staticlib_with_features;
 
 fn main() {
     let manifest_dir =
@@ -14,11 +14,17 @@ fn main() {
     let ffi_manifest = manifest_dir.join("ffi/Cargo.toml");
     let ffi_target_dir = out_dir.join("ffi-target");
 
-    let lib_path = build_rust_staticlib(
+    let features = if supports_halo2curves_asm() {
+        &["halo2curves-asm"][..]
+    } else {
+        &[]
+    };
+    let lib_path = build_rust_staticlib_with_features(
         &ffi_manifest,
         &ffi_target_dir,
         "librvr_openvm_ext_pairing_ffi.a",
         "rvr-openvm-ext-pairing-ffi",
+        features,
     );
 
     println!(
@@ -27,4 +33,20 @@ fn main() {
     );
     println!("cargo:rerun-if-changed=ffi/Cargo.toml");
     println!("cargo:rerun-if-changed=ffi/src");
+}
+
+fn supports_halo2curves_asm() -> bool {
+    if env::var("CARGO_CFG_TARGET_ARCH").as_deref() != Ok("x86_64") {
+        return false;
+    }
+
+    // Cargo expands `target-cpu` and `target-feature` settings into this list.
+    let target_features = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    let has_feature = |required| {
+        target_features
+            .split(',')
+            .any(|feature| feature == required)
+    };
+    // Halo2curves' x86-64 field implementation uses both instruction sets.
+    has_feature("adx") && has_feature("bmi2")
 }

--- a/extensions/pairing/rvr/ffi/Cargo.toml
+++ b/extensions/pairing/rvr/ffi/Cargo.toml
@@ -19,3 +19,6 @@ openvm-ecc-guest.workspace = true
 openvm-pairing-guest = { workspace = true, features = ["halo2curves", "bn254", "bls12_381"] }
 
 halo2curves-axiom.workspace = true
+
+[features]
+halo2curves-asm = ["halo2curves-axiom/asm"]


### PR DESCRIPTION
- BN254 pairing witnesses previously used Halo2curves' portable field arithmetic even when the RVR artifact targeted an x86-64 CPU with ADX and BMI2.
- The pairing FFI library now enables Halo2curves' assembly implementation when both target features are available, and keeps the portable implementation on other targets.
- The shared Rust static-library build helper now accepts Cargo features so native extensions can select target-specific implementations without changing their default build.

[Benchmark comparison](https://github.com/openvm-org/rvr-openvm/actions/runs/29851345996)