### PR TITLE
perf(v2.1): use `blst` for bls pairing witnesses

### DIFF
--- a/.github/workflows/extension-tests.group.yml
+++ b/.github/workflows/extension-tests.group.yml
@@ -147,7 +147,7 @@ jobs:
               echo "::group::Running guest tests for $extension"
               guest_feature_args=()
               if [[ "$extension" == "pairing" ]]; then
-                guest_feature_args=(--features=bn254,bls12_381,halo2curves)
+                guest_feature_args=(--features=bn254,bls12_381,halo2curves,blst)
               fi
               pushd "extensions/$extension/guest"
               cargo nextest run --cargo-profile=fast "${guest_feature_args[@]}" --no-tests=pass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,7 +5182,7 @@ dependencies = [
 name = "openvm-pairing-guest"
 version = "2.0.0"
 dependencies = [
- "blstrs",
+ "blst",
  "halo2curves-axiom 0.7.3",
  "hex-literal",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,7 @@ num-traits = { version = "0.2.19", default-features = false }
 ff = { version = "0.13.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 blstrs = { version = "0.7.1", default-features = true }
+blst = { version = "0.3.15" }
 
 [workspace.metadata.cargo-shear]
 ignored = [

--- a/extensions/pairing/circuit/Cargo.toml
+++ b/extensions/pairing/circuit/Cargo.toml
@@ -18,7 +18,7 @@ openvm-pairing-guest = { workspace = true, features = [
     "halo2curves",
     "bls12_381",
     "bn254",
-    "blstrs"
+    "blst"
 ] }
 openvm-instructions = { workspace = true }
 openvm-mod-circuit-builder = { workspace = true }

--- a/extensions/pairing/guest/Cargo.toml
+++ b/extensions/pairing/guest/Cargo.toml
@@ -22,7 +22,6 @@ openvm-custom-insn = { workspace = true }
 
 # Used for `halo2curves` feature
 halo2curves-axiom = { workspace = true, optional = true }
-blst = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand08 = { package = "rand", version = "0.8.5", features = ["std_rng"] }
@@ -33,6 +32,7 @@ num-bigint.workspace = true
 num-traits.workspace = true
 lazy_static.workspace = true
 openvm-ecc-guest = { workspace = true, features = ["halo2curves"] }
+blst = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_os = "none", target_os = "openvm")))'.dev-dependencies]
 subtle = "2.6.1"

--- a/extensions/pairing/guest/Cargo.toml
+++ b/extensions/pairing/guest/Cargo.toml
@@ -22,7 +22,7 @@ openvm-custom-insn = { workspace = true }
 
 # Used for `halo2curves` feature
 halo2curves-axiom = { workspace = true, optional = true }
-blstrs = { workspace = true, optional = true }
+blst = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand08 = { package = "rand", version = "0.8.5", features = ["std_rng"] }
@@ -40,7 +40,7 @@ subtle = "2.6.1"
 [features]
 default = []
 halo2curves = ["bls12_381", "bn254", "dep:halo2curves-axiom"]
-blstrs = ["bls12_381", "dep:blstrs"]
+blst = ["bls12_381", "dep:blst"]
 # features to enable specific curves in guest programs
 # only enable for the curves you use as it affects the init! macro
 bn254 = []

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/blst.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/blst.rs
@@ -1,0 +1,182 @@
+use core::mem::MaybeUninit;
+
+use blst::{
+    blst_bendian_from_fp, blst_fp, blst_fp12, blst_fp12_inverse, blst_fp12_is_equal, blst_fp12_mul,
+    blst_fp12_one, blst_fp12_sqr, blst_fp2, blst_fp6, blst_fp_from_bendian,
+};
+use halo2curves_axiom::bls12_381::{Fq, Fq12, Fq2, Fq6};
+
+use super::final_exp::{
+    FINAL_EXP_FACTOR_NAF, FINAL_EXP_TIMES_27_MOD_POLY_NAF, LAMBDA_INV_FINAL_EXP_NAF,
+    POLY_FACTOR_NAF, TEN_NAF, TWENTY_SEVEN_NAF,
+};
+
+const FQ_BYTES: usize = 48;
+const FP12_ZERO: blst_fp12 = blst_fp12 {
+    fp6: [blst_fp6 {
+        fp2: [blst_fp2 {
+            fp: [blst_fp { l: [0; 6] }; 2],
+        }; 3],
+    }; 2],
+};
+
+#[derive(Clone, Copy)]
+struct BlstFp12(blst_fp12);
+
+impl BlstFp12 {
+    fn one() -> Self {
+        // BLST owns this immutable process-wide constant.
+        Self(unsafe { *blst_fp12_one() })
+    }
+
+    fn square(self) -> Self {
+        let mut output = MaybeUninit::uninit();
+        unsafe {
+            blst_fp12_sqr(output.as_mut_ptr(), &self.0);
+            Self(output.assume_init())
+        }
+    }
+
+    fn mul(self, rhs: Self) -> Self {
+        let mut output = MaybeUninit::uninit();
+        unsafe {
+            blst_fp12_mul(output.as_mut_ptr(), &self.0, &rhs.0);
+            Self(output.assume_init())
+        }
+    }
+
+    fn invert_or_one(self) -> Self {
+        if self.is_zero() {
+            return Self::one();
+        }
+
+        let mut output = MaybeUninit::uninit();
+        unsafe {
+            blst_fp12_inverse(output.as_mut_ptr(), &self.0);
+            Self(output.assume_init())
+        }
+    }
+
+    fn is_one(self) -> bool {
+        unsafe { blst_fp12_is_equal(&self.0, blst_fp12_one()) }
+    }
+
+    fn is_zero(self) -> bool {
+        unsafe { blst_fp12_is_equal(&self.0, &FP12_ZERO) }
+    }
+
+    fn exp_naf(self, is_positive: bool, digits: &[i8]) -> Self {
+        if digits.is_empty() {
+            return Self::one();
+        }
+
+        let base = if is_positive {
+            self
+        } else {
+            self.invert_or_one()
+        };
+        let base_inv = digits.contains(&-1).then(|| base.invert_or_one());
+
+        let mut result = Self::one();
+        for &digit in digits.iter().rev() {
+            result = result.square();
+            if digit == 1 {
+                result = result.mul(base);
+            } else if digit == -1 {
+                result = result.mul(
+                    base_inv.expect("negative digit requires an inverse of the exponent base"),
+                );
+            }
+        }
+        result
+    }
+}
+
+impl From<&Fq12> for BlstFp12 {
+    fn from(value: &Fq12) -> Self {
+        Self(blst_fp12 {
+            fp6: [fq6_to_blst(&value.c0), fq6_to_blst(&value.c1)],
+        })
+    }
+}
+
+impl From<BlstFp12> for Fq12 {
+    fn from(value: BlstFp12) -> Self {
+        Self {
+            c0: fq6_from_blst(&value.0.fp6[0]),
+            c1: fq6_from_blst(&value.0.fp6[1]),
+        }
+    }
+}
+
+fn fq6_to_blst(value: &Fq6) -> blst_fp6 {
+    blst_fp6 {
+        fp2: [
+            fq2_to_blst(&value.c0),
+            fq2_to_blst(&value.c1),
+            fq2_to_blst(&value.c2),
+        ],
+    }
+}
+
+fn fq6_from_blst(value: &blst_fp6) -> Fq6 {
+    Fq6 {
+        c0: fq2_from_blst(&value.fp2[0]),
+        c1: fq2_from_blst(&value.fp2[1]),
+        c2: fq2_from_blst(&value.fp2[2]),
+    }
+}
+
+fn fq2_to_blst(value: &Fq2) -> blst_fp2 {
+    blst_fp2 {
+        fp: [fq_to_blst(&value.c0), fq_to_blst(&value.c1)],
+    }
+}
+
+fn fq2_from_blst(value: &blst_fp2) -> Fq2 {
+    Fq2 {
+        c0: fq_from_blst(&value.fp[0]),
+        c1: fq_from_blst(&value.fp[1]),
+    }
+}
+
+fn fq_to_blst(value: &Fq) -> blst_fp {
+    // Canonical encoding keeps the conversion independent of each field's
+    // in-memory representation.
+    let bytes = value.to_bytes_be();
+    let mut output = MaybeUninit::uninit();
+    unsafe {
+        blst_fp_from_bendian(output.as_mut_ptr(), bytes.as_ptr());
+        output.assume_init()
+    }
+}
+
+fn fq_from_blst(value: &blst_fp) -> Fq {
+    let mut bytes = [0; FQ_BYTES];
+    unsafe { blst_bendian_from_fp(bytes.as_mut_ptr(), value) };
+    Option::from(Fq::from_bytes_be(&bytes)).expect("BLST produced a non-canonical field element")
+}
+
+pub(super) fn final_exp_hint(f: &Fq12) -> (Fq12, Fq12) {
+    let f = BlstFp12::from(f);
+    let f_final_exp = f.exp_naf(true, &FINAL_EXP_FACTOR_NAF);
+    let root = f_final_exp.exp_naf(true, &TWENTY_SEVEN_NAF);
+
+    let root_pth_inv = if root.is_one() {
+        BlstFp12::one()
+    } else {
+        root.exp_naf(false, &FINAL_EXP_TIMES_27_MOD_POLY_NAF)
+    };
+
+    let root = f_final_exp.exp_naf(true, &POLY_FACTOR_NAF);
+    let root_27th_inv = if root.exp_naf(true, &TWENTY_SEVEN_NAF).is_one() {
+        root.exp_naf(false, &TEN_NAF)
+    } else {
+        BlstFp12::one()
+    };
+
+    let s = root_pth_inv.mul(root_27th_inv);
+    let c = f.mul(s).exp_naf(true, &LAMBDA_INV_FINAL_EXP_NAF);
+
+    (c.into(), s.into())
+}

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/final_exp.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/final_exp.rs
@@ -5,6 +5,8 @@ use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use openvm_ecc_guest::{algebra::Field, AffinePoint};
 
+#[cfg(feature = "blst")]
+use super::blst;
 use super::{Bls12_381, FINAL_EXP_FACTOR, LAMBDA, POLY_FACTOR};
 use crate::{
     halo2curves_shims::naf::biguint_to_naf,
@@ -12,20 +14,20 @@ use crate::{
 };
 
 lazy_static! {
-    static ref FINAL_EXP_FACTOR_NAF: Vec<i8> = biguint_to_naf(&FINAL_EXP_FACTOR);
-    static ref POLY_FACTOR_NAF: Vec<i8> = biguint_to_naf(&POLY_FACTOR);
-    static ref TWENTY_SEVEN_NAF: Vec<i8> = biguint_to_naf(&BigUint::from(27u32));
-    static ref TEN_NAF: Vec<i8> = biguint_to_naf(&BigUint::from(10u32));
+    pub(super) static ref FINAL_EXP_FACTOR_NAF: Vec<i8> = biguint_to_naf(&FINAL_EXP_FACTOR);
+    pub(super) static ref POLY_FACTOR_NAF: Vec<i8> = biguint_to_naf(&POLY_FACTOR);
+    pub(super) static ref TWENTY_SEVEN_NAF: Vec<i8> = biguint_to_naf(&BigUint::from(27u32));
+    pub(super) static ref TEN_NAF: Vec<i8> = biguint_to_naf(&BigUint::from(10u32));
     static ref FINAL_EXP_TIMES_27: BigUint = FINAL_EXP_FACTOR.clone() * BigUint::from(27u32);
     static ref FINAL_EXP_TIMES_27_MOD_POLY: BigUint = {
         let exp_inv = FINAL_EXP_TIMES_27.modinv(&POLY_FACTOR.clone()).unwrap();
         exp_inv % POLY_FACTOR.clone()
     };
-    static ref FINAL_EXP_TIMES_27_MOD_POLY_NAF: Vec<i8> =
+    pub(super) static ref FINAL_EXP_TIMES_27_MOD_POLY_NAF: Vec<i8> =
         biguint_to_naf(&FINAL_EXP_TIMES_27_MOD_POLY);
     static ref LAMBDA_INV_FINAL_EXP: BigUint =
         LAMBDA.clone().modinv(&FINAL_EXP_FACTOR.clone()).unwrap();
-    static ref LAMBDA_INV_FINAL_EXP_NAF: Vec<i8> = biguint_to_naf(&LAMBDA_INV_FINAL_EXP);
+    pub(super) static ref LAMBDA_INV_FINAL_EXP_NAF: Vec<i8> = biguint_to_naf(&LAMBDA_INV_FINAL_EXP);
 }
 
 // The paper only describes the implementation for Bn254, so we use the gnark implementation for
@@ -69,52 +71,50 @@ impl FinalExp for Bls12_381 {
     // returns c (residueWitness) and s (scalingFactor)
     // The Gnark implementation is based on https://eprint.iacr.org/2024/640.pdf
     fn final_exp_hint(f: &Self::Fp12) -> (Self::Fp12, Self::Fp12) {
-        let f_final_exp = exp_naf(f, true, &FINAL_EXP_FACTOR_NAF);
-        let root = exp_naf(&f_final_exp, true, &TWENTY_SEVEN_NAF);
+        #[cfg(feature = "blst")]
+        return blst::final_exp_hint(f);
 
-        // 1. get p-th root inverse
-        let root_pth_inv = if root == Fq12::ONE {
-            Fq12::ONE
-        } else {
-            exp_naf(&root, false, &FINAL_EXP_TIMES_27_MOD_POLY_NAF)
-        };
-
-        let root = exp_naf(&f_final_exp, true, &POLY_FACTOR_NAF);
-        // 2. get 27th root inverse
-        let root_27th_inv = if exp_naf(&root, true, &TWENTY_SEVEN_NAF) == Fq12::ONE {
-            exp_naf(&root, false, &TEN_NAF)
-        } else {
-            Fq12::ONE
-        };
-
-        // 2.3. shift the Miller loop result so that millerLoop * scalingFactor
-        // is of order finalExpFactor
-        let s = root_pth_inv * root_27th_inv;
-        let f = f * s;
-
-        // 3. get the witness residue
-        // lambda = q - u, the optimal exponent
-        let c = exp_naf(&f, true, &LAMBDA_INV_FINAL_EXP_NAF);
-
-        (c, s)
+        #[cfg(not(feature = "blst"))]
+        final_exp_hint_basic(f)
     }
+}
+
+#[cfg(any(test, not(feature = "blst")))]
+pub(super) fn final_exp_hint_basic(f: &Fq12) -> (Fq12, Fq12) {
+    let f_final_exp = exp_naf(f, true, &FINAL_EXP_FACTOR_NAF);
+    let root = exp_naf(&f_final_exp, true, &TWENTY_SEVEN_NAF);
+
+    // 1. get p-th root inverse
+    let root_pth_inv = if root == Fq12::ONE {
+        Fq12::ONE
+    } else {
+        exp_naf(&root, false, &FINAL_EXP_TIMES_27_MOD_POLY_NAF)
+    };
+
+    let root = exp_naf(&f_final_exp, true, &POLY_FACTOR_NAF);
+    // 2. get 27th root inverse
+    let root_27th_inv = if exp_naf(&root, true, &TWENTY_SEVEN_NAF) == Fq12::ONE {
+        exp_naf(&root, false, &TEN_NAF)
+    } else {
+        Fq12::ONE
+    };
+
+    // 2.3. shift the Miller loop result so that millerLoop * scalingFactor
+    // is of order finalExpFactor
+    let s = root_pth_inv * root_27th_inv;
+    let f = f * s;
+
+    // 3. get the witness residue
+    // lambda = q - u, the optimal exponent
+    let c = exp_naf(&f, true, &LAMBDA_INV_FINAL_EXP_NAF);
+
+    (c, s)
 }
 
 /// Exponentiates a field element using a signed digit representation (e.g. NAF).
 /// `digits_naf` is expected to be in LSB-first order with entries in {-1, 0, 1}.
+#[cfg(any(test, not(feature = "blst")))]
 fn exp_naf(base: &Fq12, is_positive: bool, digits_naf: &[i8]) -> Fq12 {
-    #[cfg(feature = "blstrs")]
-    {
-        exp_naf_blstrs(base, is_positive, digits_naf)
-    }
-    #[cfg(not(feature = "blstrs"))]
-    {
-        exp_naf_basic(base, is_positive, digits_naf)
-    }
-}
-
-#[cfg(not(feature = "blstrs"))]
-fn exp_naf_basic(base: &Fq12, is_positive: bool, digits_naf: &[i8]) -> Fq12 {
     if digits_naf.is_empty() {
         return Fq12::ONE;
     }
@@ -144,58 +144,4 @@ fn exp_naf_basic(base: &Fq12, is_positive: bool, digits_naf: &[i8]) -> Fq12 {
     }
 
     res
-}
-
-#[cfg(feature = "blstrs")]
-fn exp_naf_blstrs(base: &Fq12, is_positive: bool, digits_naf: &[i8]) -> Fq12 {
-    use halo2curves_axiom::ff::Field;
-
-    if digits_naf.is_empty() {
-        return <Fq12 as halo2curves_axiom::ff::Field>::ONE;
-    }
-
-    // Transmute to blstrs for computation.
-    // Safety: requires identical memory layout between halo2curves Fq12 and blstrs Fp12.
-    debug_assert_eq!(
-        core::mem::size_of::<Fq12>(),
-        core::mem::size_of::<blstrs::Fp12>(),
-        "Fq12 and blstrs::Fp12 must have the same size"
-    );
-    debug_assert_eq!(
-        core::mem::align_of::<Fq12>(),
-        core::mem::align_of::<blstrs::Fp12>(),
-        "Fq12 and blstrs::Fp12 must have the same alignment"
-    );
-    let base_blstrs = unsafe { core::mem::transmute::<Fq12, blstrs::Fp12>(*base) };
-
-    let base_blstrs = if !is_positive {
-        base_blstrs.invert().unwrap_or(blstrs::Fp12::ONE)
-    } else {
-        base_blstrs
-    };
-
-    let base_inv_blstrs = if digits_naf.contains(&-1) {
-        Some(base_blstrs.invert().unwrap_or(blstrs::Fp12::ONE))
-    } else {
-        None
-    };
-
-    let mut res_blstrs = blstrs::Fp12::ONE;
-    for &digit in digits_naf.iter().rev() {
-        res_blstrs = res_blstrs.square();
-        if digit == 1 {
-            res_blstrs *= base_blstrs;
-        } else if digit == -1 {
-            res_blstrs *= base_inv_blstrs
-                .as_ref()
-                .expect("negative digit requires available inverse");
-        }
-    }
-
-    // Transmute back to Fq12 (same size/alignment invariant as above)
-    debug_assert_eq!(
-        core::mem::size_of::<blstrs::Fp12>(),
-        core::mem::size_of::<Fq12>(),
-    );
-    unsafe { core::mem::transmute::<blstrs::Fp12, Fq12>(res_blstrs) }
 }

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/mod.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "blst")]
+mod blst;
 mod curve;
 mod final_exp;
 mod line;

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/test_final_exp.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/test_final_exp.rs
@@ -1,13 +1,17 @@
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
-use halo2curves_axiom::bls12_381::{Fq, Fq2, Fr, G1Affine, G2Affine};
+use halo2curves_axiom::{
+    bls12_381::{Fq, Fq12, Fq2, Fr, G1Affine, G2Affine},
+    ff::Field,
+};
 use itertools::izip;
 use num_bigint::BigUint;
 use num_traits::Num;
 use openvm_ecc_guest::{algebra::ExpBytes, AffinePoint};
+use rand08::{rngs::StdRng, SeedableRng};
 
 use crate::{
-    halo2curves_shims::bls12_381::{Bls12_381, SEED_NEG},
+    halo2curves_shims::bls12_381::{final_exp::final_exp_hint_basic, Bls12_381, SEED_NEG},
     pairing::{FinalExp, MultiMillerLoop},
 };
 
@@ -27,6 +31,20 @@ fn test_bls12_381_final_exp_hint() {
     let c_qt = c.exp_bytes(true, &q.to_bytes_be()) * c.exp_bytes(true, &SEED_NEG.to_bytes_be());
 
     assert_eq!(f * s, c_qt);
+}
+
+#[cfg(feature = "blst")]
+#[test]
+fn test_blst_final_exp_hint_matches_basic() {
+    let mut inputs = vec![Fq12::ZERO, Fq12::ONE];
+    let mut rng = StdRng::seed_from_u64(0x41b5_1238);
+    inputs.extend((0..4).map(|_| Fq12::random(&mut rng)));
+
+    for f in inputs {
+        let expected = final_exp_hint_basic(&f);
+        let actual = Bls12_381::final_exp_hint(&f);
+        assert_eq!(actual, expected);
+    }
 }
 
 #[test]

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/test_final_exp.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/test_final_exp.rs
@@ -42,7 +42,7 @@ fn test_bls12_381_final_exp_hint() {
 fn test_blst_final_exp_hint_matches_basic() {
     let mut inputs = vec![Fq12::ZERO, Fq12::ONE];
     let mut rng = StdRng::seed_from_u64(0x41b5_1238);
-    inputs.extend((0..4).map(|_| Fq12::random(&mut rng)));
+    inputs.extend((0..16).map(|_| Fq12::random(&mut rng)));
 
     for f in inputs {
         let expected = final_exp_hint_basic(&f);

--- a/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/test_final_exp.rs
+++ b/extensions/pairing/guest/src/halo2curves_shims/bls12_381/tests/test_final_exp.rs
@@ -1,17 +1,21 @@
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
-use halo2curves_axiom::{
-    bls12_381::{Fq, Fq12, Fq2, Fr, G1Affine, G2Affine},
-    ff::Field,
-};
+use halo2curves_axiom::bls12_381::{Fq, Fq2, Fr, G1Affine, G2Affine};
 use itertools::izip;
 use num_bigint::BigUint;
 use num_traits::Num;
 use openvm_ecc_guest::{algebra::ExpBytes, AffinePoint};
-use rand08::{rngs::StdRng, SeedableRng};
+#[cfg(feature = "blst")]
+use {
+    alloc::vec,
+    halo2curves_axiom::{bls12_381::Fq12, ff::Field},
+    rand08::{rngs::StdRng, SeedableRng},
+};
 
+#[cfg(feature = "blst")]
+use crate::halo2curves_shims::bls12_381::final_exp::final_exp_hint_basic;
 use crate::{
-    halo2curves_shims::bls12_381::{final_exp::final_exp_hint_basic, Bls12_381, SEED_NEG},
+    halo2curves_shims::bls12_381::{Bls12_381, SEED_NEG},
     pairing::{FinalExp, MultiMillerLoop},
 };
 

--- a/extensions/pairing/rvr/ffi/Cargo.toml
+++ b/extensions/pairing/rvr/ffi/Cargo.toml
@@ -16,6 +16,6 @@ rvr-openvm-ext-algebra-ffi-common.workspace = true
 rvr-openvm-ext-ffi-common.workspace = true
 
 openvm-ecc-guest.workspace = true
-openvm-pairing-guest = { workspace = true, features = ["halo2curves", "bn254", "bls12_381"] }
+openvm-pairing-guest = { workspace = true, features = ["halo2curves", "blst", "bn254", "bls12_381"] }
 
 halo2curves-axiom.workspace = true


### PR DESCRIPTION
- BLS12-381 pairing witnesses previously used `blstrs` through an unsafe assumption that its Fp12 memory layout matched Halo2curves.
- Witness exponentiation now uses public `blst` Fp12 operations and converts field elements through canonical encodings, so it does not depend on either library's private memory layout.
- Tests compare the `blst` path with the existing implementation for zero, one, and random Fp12 inputs.

[Benchmark comparison](https://github.com/openvm-org/rvr-openvm/actions/runs/29871734886)
