### PR TITLE
refactor: leaf level dirty bit

### DIFF
--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -10,7 +10,8 @@ template <size_t CHUNK, size_t BLOCKS> struct BoundaryRecord {
     // AS-native pointer to the first cell of this Merkle leaf.
     uint32_t ptr;
     // Whether some block of the leaf was *written* during execution (0/1), tracked by
-    // preflight and merged by inventory.cu. Not consumed yet.
+    // preflight and merged by inventory.cu. Gates the row's final-state interactions
+    // and the final compression.
     uint32_t is_dirty;
     uint32_t timestamps[BLOCKS];
     uint32_t values[CHUNK]; // Montgomery-encoded Fp values stored as raw u32
@@ -46,10 +47,9 @@ __global__ void cukernel_persistent_boundary_tracegen(
         BoundaryRecord<DIGEST_WIDTH, BLOCKS_PER_LEAF> record = records[row_idx];
         Poseidon2Buffer poseidon2(poseidon2_buffer, poseidon2_buffer_idx, poseidon2_capacity);
         COL_WRITE_VALUE(row, PersistentBoundaryCols, is_valid, Fp::one());
-        // TODO(follow-up): set real dirtiness (`final_values != init_values`) once
-        // MemoryMerkleAir supports skipping clean leaves in the final expansion. Until
-        // then every touched leaf is treated as dirty, matching the CPU tracegen.
-        COL_WRITE_VALUE(row, PersistentBoundaryCols, is_dirty, Fp::one());
+        // Dirtiness is per *write*, tracked during execution and carried in the record.
+        bool is_dirty = record.is_dirty != 0;
+        COL_WRITE_VALUE(row, PersistentBoundaryCols, is_dirty, is_dirty);
         COL_WRITE_VALUE(row, PersistentBoundaryCols, address_space, record.address_space);
         COL_WRITE_VALUE(
             row,
@@ -96,7 +96,10 @@ __global__ void cukernel_persistent_boundary_tracegen(
 
         // record.values are already Montgomery-encoded (see read_initial_chunk in inventory.cu)
         FpArray<DIGEST_WIDTH> final_values = FpArray<DIGEST_WIDTH>::from_raw_array(record.values);
-        FpArray<DIGEST_WIDTH> final_hash = poseidon2.hash_and_record(final_values);
+        // A clean leaf's final compression has multiplicity `is_dirty = 0`, so it must
+        // not be recorded with the hasher; its final hash equals the initial one.
+        FpArray<DIGEST_WIDTH> final_hash =
+            is_dirty ? poseidon2.hash_and_record(final_values) : init_hash;
         COL_WRITE_ARRAY(
             row, PersistentBoundaryCols, final_values, reinterpret_cast<Fp const *>(final_values.v)
         );

--- a/crates/vm/cuda/src/system/boundary.cu
+++ b/crates/vm/cuda/src/system/boundary.cu
@@ -9,6 +9,9 @@ template <size_t CHUNK, size_t BLOCKS> struct BoundaryRecord {
     uint32_t address_space;
     // AS-native pointer to the first cell of this Merkle leaf.
     uint32_t ptr;
+    // Whether some block of the leaf was *written* during execution (0/1), tracked by
+    // preflight and merged by inventory.cu. Not consumed yet.
+    uint32_t is_dirty;
     uint32_t timestamps[BLOCKS];
     uint32_t values[CHUNK]; // Montgomery-encoded Fp values stored as raw u32
 };

--- a/crates/vm/cuda/src/system/inventory.cu
+++ b/crates/vm/cuda/src/system/inventory.cu
@@ -17,7 +17,8 @@ template <size_t CHUNK, size_t BLOCKS> struct MemoryInventoryRecord {
     uint32_t ptr;           // plain integer (address-space pointer)
     /// Whether some covered block was *written* during execution (0/1), tracked by
     /// preflight and carried in the input records; the merge kernel ORs the merged
-    /// blocks' bits. Not consumed on device yet.
+    /// blocks' bits. Consumed by boundary.cu (conditional final hash) and, via the
+    /// merkle record's third word, by merkle_tree.cu.
     uint32_t is_dirty;
     uint32_t timestamps[BLOCKS]; // plain integers
     uint32_t values[CHUNK];      // Montgomery-encoded Fp values (Fp::asRaw())
@@ -225,13 +226,14 @@ extern "C" int _inventory_merge_records_get_temp_bytes(
 }
 
 /// Width in u32 words of one Merkle touched-block record:
-/// (address_space, ptr, timestamp, values[DIGEST_WIDTH]).
+/// (address_space, ptr, is_dirty, values[DIGEST_WIDTH]).
 /// Must match MERKLE_TOUCHED_BLOCK_WIDTH on the Rust side.
 inline constexpr uint32_t MERKLE_REC_WIDTH = 3 + DIGEST_WIDTH;
 
 /// Converts merged inventory records (boundary layout) into Merkle
-/// touched-block records: drops the second timestamp, taking the max.
-/// Values stay Montgomery-encoded in both layouts.
+/// touched-block records, carrying the leaf's execution-tracked dirty bit in
+/// the third word (read by merkle_tree.cu, which emits final-direction rows
+/// only for dirty nodes). Values stay Montgomery-encoded in both layouts.
 __global__ void inventory_to_merkle_records_kernel(
     uint32_t const *out_records,
     size_t num_records,
@@ -244,7 +246,7 @@ __global__ void inventory_to_merkle_records_kernel(
         uint32_t *dst = merkle_records + i * MERKLE_REC_WIDTH;
         dst[0] = r.address_space;
         dst[1] = r.ptr;
-        dst[2] = max(r.timestamps[0], r.timestamps[1]);
+        dst[2] = r.is_dirty;
 #pragma unroll
         for (int j = 0; j < DIGEST_WIDTH; ++j) {
             dst[3 + j] = r.values[j];

--- a/crates/vm/cuda/src/system/inventory.cu
+++ b/crates/vm/cuda/src/system/inventory.cu
@@ -11,10 +11,14 @@
 ///
 /// Note on uint32_t encoding: only `values` stores Montgomery-encoded BabyBear
 /// field elements (Fp::asRaw()). All other fields (`address_space`,
-/// `ptr`, `timestamps`) are plain integers.
+/// `ptr`, `is_dirty`, `timestamps`) are plain integers.
 template <size_t CHUNK, size_t BLOCKS> struct MemoryInventoryRecord {
-    uint32_t address_space;      // plain integer
-    uint32_t ptr;                // plain integer (address-space pointer)
+    uint32_t address_space; // plain integer
+    uint32_t ptr;           // plain integer (address-space pointer)
+    /// Whether some covered block was *written* during execution (0/1), tracked by
+    /// preflight and carried in the input records; the merge kernel ORs the merged
+    /// blocks' bits. Not consumed on device yet.
+    uint32_t is_dirty;
     uint32_t timestamps[BLOCKS]; // plain integers
     uint32_t values[CHUNK];      // Montgomery-encoded Fp values (Fp::asRaw())
 };
@@ -99,6 +103,7 @@ __global__ void cukernel_build_candidates(
     OutRec rec{};
     rec.address_space = in[row_idx].address_space;
     rec.ptr = (in[row_idx].ptr / DIGEST_WIDTH) * DIGEST_WIDTH;
+    rec.is_dirty = in[row_idx].is_dirty;
     #pragma unroll
     for (size_t i = 0; i < BLOCKS_PER_LEAF; ++i) {
         rec.timestamps[i] = 0;
@@ -123,6 +128,7 @@ __global__ void cukernel_build_candidates(
             rec.values[block_idx2 * BLOCK_FE_WIDTH + i] = in[row_idx + 1].values[i];
         }
         rec.timestamps[block_idx2] = in[row_idx + 1].timestamps[0];
+        rec.is_dirty |= in[row_idx + 1].is_dirty;
     }
 
     tmp_out[row_idx] = rec;

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -195,9 +195,8 @@ template <typename T> struct MerkleCols {
     T right_child_hash[CELLS_OUT];
     T left_direction_different;
     T right_direction_different;
-    // Reference-count adjustments for initial-row child interactions; always 0 while
-    // tracegen emits full (initial, final) pairs. The trace buffer is pre-zeroed, so
-    // these columns are never written by the kernels.
+    // Reference-count adjustments for initial-row child interactions; see
+    // `MemoryMerkleCols` (columns.rs) and `fill_merkle_trace_row`.
     T left_extra_ref;
     T right_extra_ref;
     T left_absent_ref;
@@ -207,7 +206,12 @@ template <typename T> struct MerkleCols {
 struct LabeledDigest {
     uint32_t address_space_idx;
     uint32_t label;
-    uint32_t timestamp; // unused
+    /// "This node's value changed": arrives precomputed for leaves in the record's third
+    /// word (the inventory record-conversion kernel compares final against initial
+    /// values; see `MemoryMerkleRecord`) and is OR-propagated upward by
+    /// `update_merkle_layer`. Dirtiness decides whether a node emits a final-direction
+    /// trace row.
+    uint32_t is_dirty;
     uint32_t digest_raw[CELLS_OUT];
 };
 
@@ -279,6 +283,15 @@ __global__ void group_by_parent(
     }
 }
 
+/// Fills one merkle trace row and records its compression (leaving the parent digest in
+/// `digests[0..CELLS_OUT]`).
+///
+/// For final rows (`new_values`), `direction_different` marks children *not expanded
+/// finally* (untouched or touched-but-clean), whose hashes are borrowed from the initial
+/// tree. For initial rows, the reference-count flags adjust how many copies of a child's
+/// initial claim this node consumes: an extra one when this node's final row dd-borrows a
+/// touched-clean child, none when the child is untouched and this node has no final row
+/// to prop the reference (see `MemoryMerkleCols`).
 __device__ void fill_merkle_trace_row(
     RowSlice row,
     bool new_values,
@@ -286,8 +299,11 @@ __device__ void fill_merkle_trace_row(
     uint32_t parent_label,
     uint32_t parent_height,
     Fp *digests,
-    bool left_new,
-    bool right_new,
+    bool left_present,
+    bool right_present,
+    bool left_dirty,
+    bool right_dirty,
+    bool emits_final,
     Poseidon2Buffer &poseidon2
 ) {
     COL_WRITE_VALUE(row, MerkleCols, expand_direction, new_values ? Fp::neg_one() : Fp::one());
@@ -301,8 +317,32 @@ __device__ void fill_merkle_trace_row(
     COL_WRITE_ARRAY(row, MerkleCols, right_child_hash, digests + CELLS_OUT);
     poseidon2.compress_and_record_inplace(digests);
     COL_WRITE_ARRAY(row, MerkleCols, parent_hash, digests);
-    COL_WRITE_VALUE(row, MerkleCols, left_direction_different, left_new != new_values);
-    COL_WRITE_VALUE(row, MerkleCols, right_direction_different, right_new != new_values);
+    COL_WRITE_VALUE(row, MerkleCols, left_direction_different, new_values && !left_dirty);
+    COL_WRITE_VALUE(row, MerkleCols, right_direction_different, new_values && !right_dirty);
+    COL_WRITE_VALUE(
+        row,
+        MerkleCols,
+        left_extra_ref,
+        !new_values && emits_final && left_present && !left_dirty
+    );
+    COL_WRITE_VALUE(
+        row,
+        MerkleCols,
+        right_extra_ref,
+        !new_values && emits_final && right_present && !right_dirty
+    );
+    COL_WRITE_VALUE(
+        row,
+        MerkleCols,
+        left_absent_ref,
+        !new_values && !emits_final && !left_present
+    );
+    COL_WRITE_VALUE(
+        row,
+        MerkleCols,
+        right_absent_ref,
+        !new_values && !emits_final && !right_present
+    );
 }
 
 // A "virtual node" is a node of the conceptual full subtree, addressed by
@@ -387,6 +427,36 @@ __device__ void store_virtual_node(
     COPY_DIGEST(&subtree[idx], value);
 }
 
+/// For each parent group of the current layer, computes whether the parent is dirty
+/// (some present child is dirty; leaf dirtiness arrives precomputed in the records).
+/// Launched over `num_children` threads so the count can stay on device: entries beyond
+/// the parent count (read from the tail of the inclusive scan) are zeroed, letting the
+/// subsequent prefix sum run over the host-known `num_children` length. The prefix
+/// places each dirty parent's final row and its total gives the layer's final-row count.
+__global__ void mark_parent_dirty(
+    uint32_t const *child_ptrs,
+    LabeledDigest const *layer,
+    uint32_t *parent_dirty,
+    size_t const num_children,
+    uint32_t const *num_parents_minus_one
+) {
+    auto gid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (gid >= num_children) {
+        return;
+    }
+    uint32_t dirty = 0;
+    if (gid <= *num_parents_minus_one) {
+        #pragma unroll
+        for (int i = 0; i < 2; ++i) {
+            uint32_t const child_ptr = child_ptrs[2 * gid + i];
+            if (child_ptr != MISSING_CHILD) {
+                dirty |= layer[child_ptr].is_dirty;
+            }
+        }
+    }
+    parent_dirty[gid] = dirty;
+}
+
 __global__ void update_merkle_layer(
     uint32_t layer_height,
     digest_t const *zero_hash,
@@ -401,6 +471,13 @@ __global__ void update_merkle_layer(
     uintptr_t *d_subtrees,
     Fp *const merkle_trace,
     size_t const trace_height,
+    // Inclusive prefix sum of per-parent dirtiness for this layer; a dirty parent's
+    // final row goes at `num_parents + prefix[idx] - 1` within the layer's region.
+    uint32_t const *parent_dirty_prefix,
+    // Set only for the topmost layer when it holds the true root (single-subtree
+    // configs): the root's final row must exist even if it is clean, since the AIR pins
+    // the first two rows to the root public values.
+    bool const force_final,
     Fp *poseidon2_buffer,
     uint32_t *poseidon2_buffer_idx,
     size_t poseidon2_capacity
@@ -449,10 +526,19 @@ __global__ void update_merkle_layer(
         2 * parent_label + 1,
         &old_right_digest
     );
-    { // old values trace row
+    // TODO: If we update MerkleMemoryAir, then we need to modify this part
+    bool const left_present = child_ptrs[2 * idx] != MISSING_CHILD;
+    bool const right_present = child_ptrs[2 * idx + 1] != MISSING_CHILD;
+    bool const left_dirty = left_present && layer[child_ptrs[2 * idx]].is_dirty;
+    bool const right_dirty = right_present && layer[child_ptrs[2 * idx + 1]].is_dirty;
+    bool const node_dirty = left_dirty || right_dirty;
+    bool const emits_final = node_dirty || force_final;
+
+    digest_t old_parent;
+    { // initial (old values) trace row -- one per touched node
         COPY_DIGEST(cells, &old_left_digest);
         COPY_DIGEST(cells + CELLS_OUT, &old_right_digest);
-        RowSlice row(merkle_trace + 2 * idx, trace_height);
+        RowSlice row(merkle_trace + idx, trace_height);
         fill_merkle_trace_row(
             row,
             false,
@@ -460,16 +546,20 @@ __global__ void update_merkle_layer(
             parent_label,
             layer_height,
             cells,
-            false,
-            false,
+            left_present,
+            right_present,
+            left_dirty,
+            right_dirty,
+            emits_final,
             poseidon2
         );
+        // fill_merkle_trace_row leaves the compressed parent digest in `cells`.
+        COPY_DIGEST(&old_parent, cells);
     }
 
-    { // new values trace row + actual update
-        bool left_new = false;
-        if (auto const child_ptr = child_ptrs[2 * idx]; child_ptr != MISSING_CHILD) {
-            COPY_DIGEST(cells, layer[child_ptr].digest_raw);
+    { // subtree update + optional final (new values) trace row
+        if (left_present) {
+            COPY_DIGEST(cells, layer[child_ptrs[2 * idx]].digest_raw);
             store_virtual_node(
                 subtree,
                 layout,
@@ -477,15 +567,13 @@ __global__ void update_merkle_layer(
                 actual_height,
                 layer_height - 1,
                 2 * parent_label,
-                reinterpret_cast<digest_t const *>(layer[child_ptr].digest_raw)
+                reinterpret_cast<digest_t const *>(layer[child_ptrs[2 * idx]].digest_raw)
             );
-            left_new = true;
         } else {
             COPY_DIGEST(cells, &old_left_digest);
         }
-        bool right_new = false;
-        if (auto const child_ptr = child_ptrs[2 * idx + 1]; child_ptr != MISSING_CHILD) {
-            COPY_DIGEST(cells + CELLS_OUT, layer[child_ptr].digest_raw);
+        if (right_present) {
+            COPY_DIGEST(cells + CELLS_OUT, layer[child_ptrs[2 * idx + 1]].digest_raw);
             store_virtual_node(
                 subtree,
                 layout,
@@ -493,25 +581,37 @@ __global__ void update_merkle_layer(
                 actual_height,
                 layer_height - 1,
                 2 * parent_label + 1,
-                reinterpret_cast<digest_t const *>(layer[child_ptr].digest_raw)
+                reinterpret_cast<digest_t const *>(layer[child_ptrs[2 * idx + 1]].digest_raw)
             );
-            right_new = true;
         } else {
             COPY_DIGEST(cells + CELLS_OUT, &old_right_digest);
         }
-        RowSlice row(merkle_trace + 2 * idx + 1, trace_height);
-        fill_merkle_trace_row(
-            row,
-            true,
-            address_space_idx,
-            parent_label,
-            layer_height,
-            cells,
-            left_new,
-            right_new,
-            poseidon2
-        );
-        COPY_DIGEST(layer[parent_ptr].digest_raw, cells);
+        if (emits_final) {
+            // Dirty finals are packed after the layer's initial rows in prefix order; a
+            // clean forced root (rank 0 in a single-node layer) lands there trivially.
+            uint32_t const rank = parent_dirty_prefix[idx] - (node_dirty ? 1 : 0);
+            RowSlice row(merkle_trace + num_parents + rank, trace_height);
+            fill_merkle_trace_row(
+                row,
+                true,
+                address_space_idx,
+                parent_label,
+                layer_height,
+                cells,
+                left_present,
+                right_present,
+                left_dirty,
+                right_dirty,
+                true,
+                poseidon2
+            );
+            COPY_DIGEST(layer[parent_ptr].digest_raw, cells);
+        } else {
+            // Clean node: the new digest equals the stored one; no final row, no final
+            // compression.
+            COPY_DIGEST(layer[parent_ptr].digest_raw, &old_parent);
+        }
+        layer[parent_ptr].is_dirty = node_dirty;
     }
 }
 
@@ -562,15 +662,39 @@ __global__ void update_to_root(
         if (children_ids[0] == MISSING_CHILD && children_ids[1] == MISSING_CHILD) {
             continue;
         }
-        merkle_trace_offset -= 2;
+        bool const left_present = children_ids[0] != MISSING_CHILD;
+        bool const right_present = children_ids[1] != MISSING_CHILD;
+        bool const left_dirty =
+            left_present && layer[layer_ids[children_ids[0]]].is_dirty;
+        bool const right_dirty =
+            right_present && layer[layer_ids[children_ids[1]]].is_dirty;
+        bool const node_dirty = left_dirty || right_dirty;
+        // The true root's final row always exists: the AIR pins the first two rows to
+        // the initial/final root public values.
+        bool const emits_final = node_dirty || out_idx == 0;
+
+        merkle_trace_offset -= emits_final ? 2 : 1;
+        digest_t old_parent;
         {
             RowSlice row(merkle_trace + merkle_trace_offset, trace_height);
             COPY_DIGEST(cells, &out[2 * out_idx + 1]);
             COPY_DIGEST(cells + CELLS_OUT, &out[2 * out_idx + 2]);
             fill_merkle_trace_row(
-                row, false, drop_highest_bit(out_idx + 1), 0, h, cells, false, false, poseidon2
+                row,
+                false,
+                drop_highest_bit(out_idx + 1),
+                0,
+                h,
+                cells,
+                left_present,
+                right_present,
+                left_dirty,
+                right_dirty,
+                emits_final,
+                poseidon2
             );
             COL_WRITE_VALUE(row, MerkleCols, height_section, true);
+            COPY_DIGEST(&old_parent, cells);
         }
         for (auto i : {0, 1}) {
             if (children_ids[i] != MISSING_CHILD) {
@@ -587,7 +711,7 @@ __global__ void update_to_root(
             layer_ids[max_idx] = layer_ids[--layer_size];
         }
         layer[layer_ids[surely_surviving_child]].label = out_idx;
-        {
+        if (emits_final) {
             RowSlice row(merkle_trace + merkle_trace_offset + 1, trace_height);
             fill_merkle_trace_row(
                 row,
@@ -596,15 +720,25 @@ __global__ void update_to_root(
                 0,
                 h,
                 cells,
-                children_ids[0] != MISSING_CHILD,
-                children_ids[1] != MISSING_CHILD,
+                left_present,
+                right_present,
+                left_dirty,
+                right_dirty,
+                true,
                 poseidon2
             );
             COPY_DIGEST(layer[layer_ids[surely_surviving_child]].digest_raw, cells);
             COL_WRITE_VALUE(row, MerkleCols, height_section, true);
+        } else {
+            // Clean node: new digest equals the stored one; no final row or compression.
+            COPY_DIGEST(layer[layer_ids[surely_surviving_child]].digest_raw, &old_parent);
         }
+        layer[layer_ids[surely_surviving_child]].is_dirty = node_dirty;
     }
     COPY_DIGEST(out, layer[layer_ids[0]].digest_raw);
+    // The host computed the trace height exactly, so the downward walk must land the
+    // root pair precisely at rows 0..1.
+    assert(merkle_trace_offset == 0);
     for (auto i : {0, 1}) {
         RowSlice row(merkle_trace + i, trace_height);
         COL_WRITE_VALUE(row, MerkleCols, is_root, true);
@@ -723,6 +857,7 @@ extern "C" int _update_merkle_tree(
     size_t subtree_height,
     uint32_t *child_buf,
     uint32_t *tmp_buf,
+    uint32_t *dirty_buf,
     uint8_t *d_temp_storage,
     size_t need_tmp_storage_bytes,
     Fp *const merkle_trace,
@@ -751,6 +886,9 @@ extern "C" int _update_merkle_tree(
     {
         auto [grid, block] = kernel_launch_params(num_leaves, 256);
         prepare_for_updating<<<grid, block, 0, stream>>>(child_buf, layer, num_children);
+        if (int err = CHECK_KERNEL(); err) {
+            return err;
+        }
     }
 
     uint32_t merkle_trace_offset = unpadded_trace_height;
@@ -791,10 +929,38 @@ extern "C" int _update_merkle_tree(
                 return err;
             }
         }
-        uint32_t num_parents;
+        bool const force_final = (num_subtrees == 1) && (h == subtree_height);
+        // TODO: might need to think of better layout, or maybe different way of storing
+        // Count this layer's dirty parents (each contributes a final row) and prefix-sum
+        // so every dirty parent knows its final-row slot. Launched over `num_children`
+        // with the parent count read on device, so a single sync fetches both counts.
+        {
+            auto [grid, block] = kernel_launch_params(num_children);
+            mark_parent_dirty<<<grid, block, 0, stream>>>(
+                tmp_buf, layer, dirty_buf, num_children, parent_ids + (num_children - 1)
+            );
+            if (int err = CHECK_KERNEL(); err) {
+                return err;
+            }
+        }
+        cub::DeviceScan::InclusiveSum(
+            d_temp_storage, need_tmp_storage_bytes, dirty_buf, dirty_buf, num_children, stream
+        );
+        if (int err = CHECK_KERNEL(); err) {
+            return err;
+        }
+        uint32_t num_parents = 0;
+        uint32_t num_dirty = 0;
         cudaMemcpyAsync(
             &num_parents,
             parent_ids + (num_children - 1),
+            sizeof(uint32_t),
+            cudaMemcpyDeviceToHost,
+            stream
+        );
+        cudaMemcpyAsync(
+            &num_dirty,
+            dirty_buf + (num_children - 1),
             sizeof(uint32_t),
             cudaMemcpyDeviceToHost,
             stream
@@ -804,7 +970,15 @@ extern "C" int _update_merkle_tree(
         }
         cudaStreamSynchronize(stream);
         ++num_parents;
-        merkle_trace_offset -= 2 * num_parents;
+        // A forced-final layer holds the single true root, which emits a final row even
+        // when clean.
+        uint32_t const layer_rows = num_parents + (force_final ? 1 : num_dirty);
+        // The trace height is computed exactly on the host from the leaf records; a
+        // mismatch here means that invariant broke, and writing would corrupt memory.
+        if (layer_rows > merkle_trace_offset) {
+            return -1;
+        }
+        merkle_trace_offset -= layer_rows;
         auto [grid, block] = kernel_launch_params(num_parents, 256);
         update_merkle_layer<<<grid, block, 0, stream>>>(
             h,
@@ -820,6 +994,8 @@ extern "C" int _update_merkle_tree(
             subtrees,
             merkle_trace + merkle_trace_offset,
             trace_height,
+            dirty_buf,
+            force_final,
             d_poseidon2_raw_buffer,
             d_poseidon2_buffer_idx,
             poseidon2_record_capacity

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -195,12 +195,8 @@ template <typename T> struct MerkleCols {
     T right_child_hash[CELLS_OUT];
     T left_direction_different;
     T right_direction_different;
-    // Reference-count adjustments for initial-row child interactions; see
-    // `MemoryMerkleCols` (columns.rs) and `fill_merkle_trace_row`.
-    T left_extra_ref;
-    T right_extra_ref;
-    T left_absent_ref;
-    T right_absent_ref;
+    T left_adj_ref;
+    T right_adj_ref;
 };
 
 struct LabeledDigest {
@@ -283,15 +279,23 @@ __global__ void group_by_parent(
     }
 }
 
+/// Reference-count adjustment for a child of an initial row
+__device__ inline Fp child_adj_ref(bool emits_final, bool present, bool dirty) {
+    if (emits_final && present && !dirty) {
+        return Fp::one();
+    }
+    if (!emits_final && !present) {
+        return Fp::neg_one();
+    }
+    return Fp::zero();
+}
+
 /// Fills one merkle trace row and records its compression (leaving the parent digest in
 /// `digests[0..CELLS_OUT]`).
 ///
 /// For final rows (`new_values`), `direction_different` marks children *not expanded
 /// finally* (untouched or touched-but-clean), whose hashes are borrowed from the initial
-/// tree. For initial rows, the reference-count flags adjust how many copies of a child's
-/// initial claim this node consumes: an extra one when this node's final row dd-borrows a
-/// touched-clean child, none when the child is untouched and this node has no final row
-/// to prop the reference (see `MemoryMerkleCols`).
+/// tree.
 __device__ void fill_merkle_trace_row(
     RowSlice row,
     bool new_values,
@@ -322,26 +326,14 @@ __device__ void fill_merkle_trace_row(
     COL_WRITE_VALUE(
         row,
         MerkleCols,
-        left_extra_ref,
-        !new_values && emits_final && left_present && !left_dirty
+        left_adj_ref,
+        new_values ? Fp::zero() : child_adj_ref(emits_final, left_present, left_dirty)
     );
     COL_WRITE_VALUE(
         row,
         MerkleCols,
-        right_extra_ref,
-        !new_values && emits_final && right_present && !right_dirty
-    );
-    COL_WRITE_VALUE(
-        row,
-        MerkleCols,
-        left_absent_ref,
-        !new_values && !emits_final && !left_present
-    );
-    COL_WRITE_VALUE(
-        row,
-        MerkleCols,
-        right_absent_ref,
-        !new_values && !emits_final && !right_present
+        right_adj_ref,
+        new_values ? Fp::zero() : child_adj_ref(emits_final, right_present, right_dirty)
     );
 }
 
@@ -526,7 +518,6 @@ __global__ void update_merkle_layer(
         2 * parent_label + 1,
         &old_right_digest
     );
-    // TODO: If we update MerkleMemoryAir, then we need to modify this part
     bool const left_present = child_ptrs[2 * idx] != MISSING_CHILD;
     bool const right_present = child_ptrs[2 * idx + 1] != MISSING_CHILD;
     bool const left_dirty = left_present && layer[child_ptrs[2 * idx]].is_dirty;
@@ -602,7 +593,7 @@ __global__ void update_merkle_layer(
                 right_present,
                 left_dirty,
                 right_dirty,
-                true,
+                emits_final,
                 poseidon2
             );
             COPY_DIGEST(layer[parent_ptr].digest_raw, cells);
@@ -724,7 +715,7 @@ __global__ void update_to_root(
                 right_present,
                 left_dirty,
                 right_dirty,
-                true,
+                emits_final,
                 poseidon2
             );
             COPY_DIGEST(layer[layer_ids[surely_surviving_child]].digest_raw, cells);

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -195,6 +195,13 @@ template <typename T> struct MerkleCols {
     T right_child_hash[CELLS_OUT];
     T left_direction_different;
     T right_direction_different;
+    // Reference-count adjustments for initial-row child interactions; always 0 while
+    // tracegen emits full (initial, final) pairs. The trace buffer is pre-zeroed, so
+    // these columns are never written by the kernels.
+    T left_extra_ref;
+    T right_extra_ref;
+    T left_absent_ref;
+    T right_absent_ref;
 };
 
 struct LabeledDigest {

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -193,10 +193,8 @@ template <typename T> struct MerkleCols {
     T parent_hash[CELLS_OUT];
     T left_child_hash[CELLS_OUT];
     T right_child_hash[CELLS_OUT];
-    T left_direction_different;
-    T right_direction_different;
-    T left_adj_ref;
-    T right_adj_ref;
+    T left_child_mode;
+    T right_child_mode;
 };
 
 struct LabeledDigest {
@@ -279,23 +277,21 @@ __global__ void group_by_parent(
     }
 }
 
-/// Reference-count adjustment for a child of an initial row
-__device__ inline Fp child_adj_ref(bool emits_final, bool present, bool dirty) {
-    if (emits_final && present && !dirty) {
-        return Fp::one();
+/// The `*_child_mode` value for a merkle row (see `MemoryMerkleCols` in columns.rs).
+/// Initial rows (`!new_values`) carry the reference count in {0, 1, 2}: one if the child
+/// is on the touched path, plus one if this node's final row dd-borrows it. Final rows
+/// carry the dd bit: 1 iff the child is borrowed from the initial tree (not dirty).
+__device__ inline Fp child_mode(bool new_values, bool present, bool dirty, bool emits_final) {
+    if (new_values) {
+        return Fp((uint32_t)(!dirty));
     }
-    if (!emits_final && !present) {
-        return Fp::neg_one();
-    }
-    return Fp::zero();
+    return Fp((uint32_t)present + (uint32_t)(emits_final && !dirty));
 }
 
 /// Fills one merkle trace row and records its compression (leaving the parent digest in
 /// `digests[0..CELLS_OUT]`).
 ///
-/// For final rows (`new_values`), `direction_different` marks children *not expanded
-/// finally* (untouched or touched-but-clean), whose hashes are borrowed from the initial
-/// tree.
+/// The `*_child_mode` columns are derived from the node state via `child_mode`.
 __device__ void fill_merkle_trace_row(
     RowSlice row,
     bool new_values,
@@ -321,19 +317,17 @@ __device__ void fill_merkle_trace_row(
     COL_WRITE_ARRAY(row, MerkleCols, right_child_hash, digests + CELLS_OUT);
     poseidon2.compress_and_record_inplace(digests);
     COL_WRITE_ARRAY(row, MerkleCols, parent_hash, digests);
-    COL_WRITE_VALUE(row, MerkleCols, left_direction_different, new_values && !left_dirty);
-    COL_WRITE_VALUE(row, MerkleCols, right_direction_different, new_values && !right_dirty);
     COL_WRITE_VALUE(
         row,
         MerkleCols,
-        left_adj_ref,
-        new_values ? Fp::zero() : child_adj_ref(emits_final, left_present, left_dirty)
+        left_child_mode,
+        child_mode(new_values, left_present, left_dirty, emits_final)
     );
     COL_WRITE_VALUE(
         row,
         MerkleCols,
-        right_adj_ref,
-        new_values ? Fp::zero() : child_adj_ref(emits_final, right_present, right_dirty)
+        right_child_mode,
+        child_mode(new_values, right_present, right_dirty, emits_final)
     );
 }
 

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -457,13 +457,16 @@ __global__ void update_merkle_layer(
     uintptr_t *d_subtrees,
     Fp *const merkle_trace,
     size_t const trace_height,
-    // Inclusive prefix sum of per-parent dirtiness for this layer; a dirty parent's
-    // final row goes at `num_parents + prefix[idx] - 1` within the layer's region.
+    // Inclusive prefix sum of per-parent dirtiness for this layer, used to place each
+    // node's rows in the CPU-matching order (see the slot computation below).
     uint32_t const *parent_dirty_prefix,
     // Set only for the topmost layer when it holds the true root (single-subtree
     // configs): the root's final row must exist even if it is clean, since the AIR pins
     // the first two rows to the root public values.
     bool const force_final,
+    // Total rows this layer occupies (`num_parents + num_dirty`, or `num_parents + 1`
+    // when `force_final`). Needed to mirror row placement into the CPU order.
+    uint32_t const layer_rows,
     Fp *poseidon2_buffer,
     uint32_t *poseidon2_buffer_idx,
     size_t poseidon2_capacity
@@ -519,11 +522,17 @@ __global__ void update_merkle_layer(
     bool const node_dirty = left_dirty || right_dirty;
     bool const emits_final = node_dirty || force_final;
 
+    // Match the CPU tracegen row order. force_final is for roots, so it is hardcoded
+    uint32_t const rank = parent_dirty_prefix[idx] - (node_dirty ? 1 : 0);
+    uint32_t const s = idx + rank;
+    uint32_t const init_slot = force_final ? 0 : (layer_rows - 1 - s);
+    uint32_t const final_slot = force_final ? 1 : (layer_rows - 2 - s);
+
     digest_t old_parent;
     { // initial (old values) trace row -- one per touched node
         COPY_DIGEST(cells, &old_left_digest);
         COPY_DIGEST(cells + CELLS_OUT, &old_right_digest);
-        RowSlice row(merkle_trace + idx, trace_height);
+        RowSlice row(merkle_trace + init_slot, trace_height);
         fill_merkle_trace_row(
             row,
             false,
@@ -572,10 +581,7 @@ __global__ void update_merkle_layer(
             COPY_DIGEST(cells + CELLS_OUT, &old_right_digest);
         }
         if (emits_final) {
-            // Dirty finals are packed after the layer's initial rows in prefix order; a
-            // clean forced root (rank 0 in a single-node layer) lands there trivially.
-            uint32_t const rank = parent_dirty_prefix[idx] - (node_dirty ? 1 : 0);
-            RowSlice row(merkle_trace + num_parents + rank, trace_height);
+            RowSlice row(merkle_trace + final_slot, trace_height);
             fill_merkle_trace_row(
                 row,
                 true,
@@ -659,9 +665,13 @@ __global__ void update_to_root(
         bool const emits_final = node_dirty || out_idx == 0;
 
         merkle_trace_offset -= emits_final ? 2 : 1;
+        uint32_t const init_off =
+            (out_idx == 0 || !emits_final) ? merkle_trace_offset : merkle_trace_offset + 1;
+        uint32_t const final_off =
+            (out_idx == 0) ? merkle_trace_offset + 1 : merkle_trace_offset;
         digest_t old_parent;
         {
-            RowSlice row(merkle_trace + merkle_trace_offset, trace_height);
+            RowSlice row(merkle_trace + init_off, trace_height);
             COPY_DIGEST(cells, &out[2 * out_idx + 1]);
             COPY_DIGEST(cells + CELLS_OUT, &out[2 * out_idx + 2]);
             fill_merkle_trace_row(
@@ -697,7 +707,7 @@ __global__ void update_to_root(
         }
         layer[layer_ids[surely_surviving_child]].label = out_idx;
         if (emits_final) {
-            RowSlice row(merkle_trace + merkle_trace_offset + 1, trace_height);
+            RowSlice row(merkle_trace + final_off, trace_height);
             fill_merkle_trace_row(
                 row,
                 true,
@@ -981,6 +991,7 @@ extern "C" int _update_merkle_tree(
             trace_height,
             dirty_buf,
             force_final,
+            layer_rows,
             d_poseidon2_raw_buffer,
             d_poseidon2_buffer_idx,
             poseidon2_record_capacity

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -200,11 +200,9 @@ template <typename T> struct MerkleCols {
 struct LabeledDigest {
     uint32_t address_space_idx;
     uint32_t label;
-    /// "This node's value changed": arrives precomputed for leaves in the record's third
-    /// word (the inventory record-conversion kernel compares final against initial
-    /// values; see `MemoryMerkleRecord`) and is OR-propagated upward by
-    /// `update_merkle_layer`. Dirtiness decides whether a node emits a final-direction
-    /// trace row.
+    /// Whether this subtree contains a leaf written during execution. Leaves receive
+    /// this bit in the record's third word from the inventory record-conversion kernel;
+    /// `update_merkle_layer` ORs it upward. Dirty nodes emit final-direction rows.
     uint32_t is_dirty;
     uint32_t digest_raw[CELLS_OUT];
 };
@@ -279,8 +277,9 @@ __global__ void group_by_parent(
 
 /// The `*_child_mode` value for a merkle row (see `MemoryMerkleCols` in columns.rs).
 /// Initial rows (`!new_values`) carry the reference count in {0, 1, 2}: one if the child
-/// is on the touched path, plus one if this node's final row dd-borrows it. Final rows
-/// carry the dd bit: 1 iff the child is borrowed from the initial tree (not dirty).
+/// is present on the touched path, plus one if this node's final row uses the clean
+/// child's initial state. On final rows, mode 0 uses the final state and mode 1 uses the
+/// initial state.
 __device__ inline Fp child_mode(bool new_values, bool present, bool dirty, bool emits_final) {
     if (new_values) {
         return Fp((uint32_t)(!dirty));
@@ -925,7 +924,6 @@ extern "C" int _update_merkle_tree(
             }
         }
         bool const force_final = (num_subtrees == 1) && (h == subtree_height);
-        // TODO: might need to think of better layout, or maybe different way of storing
         // Count this layer's dirty parents (each contributes a final row) and prefix-sum
         // so every dirty parent knows its final-row slot. Launched over `num_children`
         // with the parent count read on device, so a single sync fetches both counts.

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -31,8 +31,6 @@ pub struct PersistentBoundaryRecord {
     pub address_space: u32,
     /// AS-native pointer to the first cell of this Merkle leaf.
     pub ptr: u32,
-    /// Whether some block of the leaf was *written* during execution (0/1); see
-    /// `TouchedBlock`. Not consumed yet.
     pub is_dirty: u32,
     pub timestamps: [u32; BLOCKS_PER_LEAF],
     pub values: [F; VM_DIGEST_WIDTH],

--- a/crates/vm/src/system/cuda/boundary.rs
+++ b/crates/vm/src/system/cuda/boundary.rs
@@ -31,6 +31,9 @@ pub struct PersistentBoundaryRecord {
     pub address_space: u32,
     /// AS-native pointer to the first cell of this Merkle leaf.
     pub ptr: u32,
+    /// Whether some block of the leaf was *written* during execution (0/1); see
+    /// `TouchedBlock`. Not consumed yet.
+    pub is_dirty: u32,
     pub timestamps: [u32; BLOCKS_PER_LEAF],
     pub values: [F; VM_DIGEST_WIDTH],
 }

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -45,11 +45,11 @@ const _: () = assert!(
     "CUDA memory inventory only supports (BLOCK_FE_WIDTH, VM_DIGEST_WIDTH) == (4, 8)"
 );
 
-// `TouchedBlock<F>` must be exactly the 7-word `InRec` layout in `inventory.cu`
+// `TouchedBlock<F>` must be exactly the 8-word `InRec` layout in `inventory.cu`
 // so the merge path can upload the vector's bytes without repacking.
 const _: () = assert!(
-    std::mem::size_of::<TouchedBlock<F>>() == (3 + BLOCK_FE_WIDTH) * std::mem::size_of::<u32>(),
-    "TouchedBlock<F> must match the 7-u32-word InRec layout in inventory.cu"
+    std::mem::size_of::<TouchedBlock<F>>() == (4 + BLOCK_FE_WIDTH) * std::mem::size_of::<u32>(),
+    "TouchedBlock<F> must match the 8-u32-word InRec layout in inventory.cu"
 );
 
 pub struct MemoryInventoryGPU {
@@ -112,6 +112,9 @@ impl Drop for PinnedStaging {
 struct MemoryInventoryRecord<const CHUNK: usize, const BLOCKS: usize> {
     address_space: u32,
     ptr: u32,
+    /// Whether some covered block was *written* during execution (0/1); see
+    /// [`TouchedBlock`]. The merge kernel ORs the input blocks' bits. Not consumed yet.
+    is_dirty: u32,
     timestamps: [u32; BLOCKS],
     values: [u32; CHUNK],
 }
@@ -593,12 +596,14 @@ mod tests {
             TouchedBlock {
                 address_space: RV64_MEMORY_AS,
                 ptr: 0,
+                is_dirty: 1,
                 timestamp: 1,
                 values: pack_u8_block_value(&touched_bytes.map(F::from_u8)),
             },
             TouchedBlock {
                 address_space: RV64_MEMORY_AS,
                 ptr: BLOCK_FE_WIDTH as u32,
+                is_dirty: 1,
                 timestamp: 3,
                 values: pack_u8_block_value(&touched_bytes_late.map(F::from_u8)),
             },

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -32,7 +32,7 @@ use tracing::instrument;
 
 use super::{
     boundary::BoundaryChipGPU,
-    merkle_tree::{MemoryMerkleTree, MERKLE_TOUCHED_BLOCK_WIDTH},
+    merkle_tree::{MemoryMerkleTree, SpanningNodeCounter, MERKLE_TOUCHED_BLOCK_WIDTH},
     Poseidon2PeripheryChipGPU,
 };
 use crate::{cuda_abi::inventory, system::memory::online::LinearMemory};
@@ -112,8 +112,6 @@ impl Drop for PinnedStaging {
 struct MemoryInventoryRecord<const CHUNK: usize, const BLOCKS: usize> {
     address_space: u32,
     ptr: u32,
-    /// Whether some covered block was *written* during execution (0/1); see
-    /// [`TouchedBlock`]. The merge kernel ORs the input blocks' bits. Not consumed yet.
     is_dirty: u32,
     timestamps: [u32; BLOCKS],
     values: [u32; CHUNK],
@@ -124,7 +122,7 @@ struct MemoryInventoryRecord<const CHUNK: usize, const BLOCKS: usize> {
 struct MemoryMerkleRecord {
     address_space: u32,
     ptr: u32,
-    timestamp: u32,
+    is_dirty: u32,
     values: [u32; VM_DIGEST_WIDTH],
 }
 
@@ -226,7 +224,10 @@ impl MemoryInventoryGPU {
     ) -> Vec<AirProvingContext<GpuBackend>> {
         let mem = MemTracker::start("generate mem proving ctxs");
         let partition = touched_memory;
-        let unpadded_merkle_height = if partition.is_empty() {
+        // Exact merkle trace rows: one initial row per touched-spanning node, one final
+        // row per dirty-spanning node (or just the forced root final row when nothing
+        // is dirty).
+        let merkle_rows = if partition.is_empty() {
             let leftmost_values = 'left: {
                 let mut res = [F::ZERO; VM_DIGEST_WIDTH];
                 if self.initial_memory[ADDR_SPACE_OFFSET as usize].is_empty() {
@@ -256,7 +257,7 @@ impl MemoryInventoryGPU {
             let merkle_record = MemoryMerkleRecord {
                 address_space: ADDR_SPACE_OFFSET,
                 ptr: 0,
-                timestamp: 0,
+                is_dirty: 0,
                 values: values_u32,
             };
             let merkle_records = [merkle_record];
@@ -268,17 +269,22 @@ impl MemoryInventoryGPU {
             };
             self.merkle_records = Some(merkle_words.to_device_on(&self.device_ctx).unwrap());
 
-            let unpadded_merkle_height = self
+            // The artificial clean touch spans one root-to-leaf path of initial rows,
+            // plus the always-present final root row.
+            let merkle_rows = self
                 .merkle_tree
-                .calculate_unpadded_height(&partition, |b| (b.address_space, b.ptr));
+                .mem_config()
+                .memory_dimensions()
+                .overall_height()
+                + 1;
             #[cfg(feature = "metrics")]
             {
-                self.unpadded_merkle_height = unpadded_merkle_height;
+                self.unpadded_merkle_height = merkle_rows;
             }
             self.boundary
                 .finalize_records::<VM_DIGEST_WIDTH>(Vec::new());
-            self.prepare_poseidon2_records(0, unpadded_merkle_height);
-            unpadded_merkle_height
+            self.prepare_poseidon2_records(0, 0, merkle_rows);
+            merkle_rows
         } else {
             let _span = tracing::info_span!("mem_merge_records").entered();
             let in_num_records = partition.len();
@@ -362,19 +368,47 @@ impl MemoryInventoryGPU {
                     })
                     .count();
 
-            // Host work overlapping the merge kernels: neither the unpadded
-            // height scan nor the Poseidon2 records buffer depends on the
-            // merge kernels.
-            let unpadded_merkle_height = self
-                .merkle_tree
-                .calculate_unpadded_height(&partition, |b| (b.address_space, b.ptr));
+            // Host work overlapping the merge kernels: the compacted leaf keys and
+            // their dirty bits are pure functions of the sorted partition (the same
+            // dedup rule the device merge uses; a leaf is dirty iff some of its blocks
+            // was written), so the exact merkle trace shape and Poseidon2 record count
+            // are computed here with no device synchronization.
+            let memory_dimensions = self.merkle_tree.mem_config().memory_dimensions();
+            let tree_height = memory_dimensions.overall_height();
+            let mut touched_nodes = SpanningNodeCounter::default();
+            let mut dirty_nodes = SpanningNodeCounter::default();
+            let mut num_touched_leaves = 0usize;
+            let mut num_dirty_leaves = 0usize;
+            for leaf_blocks in partition.chunk_by(|a, b| {
+                (a.address_space, a.ptr / VM_DIGEST_WIDTH as u32)
+                    == (b.address_space, b.ptr / VM_DIGEST_WIDTH as u32)
+            }) {
+                let block = &leaf_blocks[0];
+                let key = (block.address_space, block.ptr / VM_DIGEST_WIDTH as u32);
+                let leaf_index = memory_dimensions.label_to_index(key);
+                touched_nodes.push(leaf_index, tree_height);
+                num_touched_leaves += 1;
+                if leaf_blocks.iter().any(|b| b.is_dirty != 0) {
+                    dirty_nodes.push(leaf_index, tree_height);
+                    num_dirty_leaves += 1;
+                }
+            }
+            debug_assert_eq!(num_touched_leaves, out_num_records);
+            // One initial row per touched node, one final row per dirty node; the
+            // final root row exists even when nothing is dirty.
+            let merkle_rows = touched_nodes.nodes
+                + if num_dirty_leaves == 0 {
+                    1
+                } else {
+                    dirty_nodes.nodes
+                };
             #[cfg(feature = "metrics")]
             {
-                self.unpadded_merkle_height = unpadded_merkle_height;
+                self.unpadded_merkle_height = merkle_rows;
             }
             {
                 let _span = tracing::info_span!("poseidon2_prepare").entered();
-                self.prepare_poseidon2_records(out_num_records, unpadded_merkle_height);
+                self.prepare_poseidon2_records(out_num_records, num_dirty_leaves, merkle_rows);
             }
 
             // Cross-check the host-computed count against the device merge in
@@ -407,7 +441,7 @@ impl MemoryInventoryGPU {
                 .expect("inventory_to_merkle_records failed");
             }
             self.merkle_records = Some(d_merkle_records);
-            unpadded_merkle_height
+            merkle_rows
         };
 
         mem.tracing_info("merkle update");
@@ -415,7 +449,7 @@ impl MemoryInventoryGPU {
             let _span = tracing::info_span!("merkle_update").entered();
             self.merkle_tree.finalize();
             self.merkle_tree.update_with_touched_blocks(
-                unpadded_merkle_height,
+                merkle_rows,
                 self.merkle_records
                     .as_ref()
                     .expect("missing merkle records"),
@@ -437,10 +471,19 @@ impl MemoryInventoryGPU {
         ret
     }
 
-    fn prepare_poseidon2_records(&self, boundary_records: usize, merkle_height: usize) {
+    /// Sizes the shared Poseidon2 record buffer to the exact push count: the boundary
+    /// kernel records one initial hash per touched leaf plus one final hash per dirty
+    /// leaf, and every merkle trace row records exactly one compression. These counts
+    /// must stay in lockstep with `boundary.cu` / `merkle_tree.cu`.
+    fn prepare_poseidon2_records(
+        &self,
+        boundary_records: usize,
+        dirty_leaves: usize,
+        merkle_rows: usize,
+    ) {
         let num_records = boundary_records
-            .checked_mul(2)
-            .and_then(|n| n.checked_add(merkle_height))
+            .checked_add(dirty_leaves)
+            .and_then(|n| n.checked_add(merkle_rows))
             .expect("Poseidon2 records count overflow");
         self.hasher_chip.prepare_records(num_records);
     }

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -724,4 +724,93 @@ mod tests {
 
         assert_eq!(expected_root, gpu_merkle_root(&ctxs));
     }
+
+    /// CPU and GPU must generate the *same* Merkle trace, row for row.
+    #[test]
+    fn test_merkle_trace_matches_between_cpu_and_gpu() {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        use openvm_circuit::{
+            arch::ADDR_SPACE_OFFSET,
+            system::memory::{
+                merkle::{memory_to_vec_partition, MemoryMerkleChip},
+                persistent::DirtyLeaves,
+            },
+        };
+        use openvm_cuda_backend::data_transporter::assert_eq_host_and_device_matrix_col_maj;
+        use openvm_stark_backend::{interaction::PermutationCheckBus, prover::ColMajorMatrix};
+        use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
+
+        let (mem_config, memory) = single_block_setup();
+        let mut final_memory = memory.clone();
+        let touched_bytes = [101u8, 102, 103, 104, 105, 106, 107, 108];
+        let touched_bytes_late = [111u8, 112, 113, 114, 115, 116, 117, 118];
+        unsafe {
+            final_memory.write_bytes::<MEMORY_BLOCK_BYTES>(RV64_MEMORY_AS, 0, touched_bytes);
+            final_memory.write_bytes::<MEMORY_BLOCK_BYTES>(
+                RV64_MEMORY_AS,
+                MEMORY_BLOCK_BYTES as u32,
+                touched_bytes_late,
+            );
+        }
+
+        // GPU trace: both blocks written (is_dirty = 1), forming one dirty leaf.
+        let touched_memory = vec![
+            TouchedBlock {
+                address_space: RV64_MEMORY_AS,
+                ptr: 0,
+                is_dirty: 1,
+                timestamp: 1,
+                values: pack_u8_block_value(&touched_bytes.map(F::from_u8)),
+            },
+            TouchedBlock {
+                address_space: RV64_MEMORY_AS,
+                ptr: BLOCK_FE_WIDTH as u32,
+                is_dirty: 1,
+                timestamp: 3,
+                values: pack_u8_block_value(&touched_bytes_late.map(F::from_u8)),
+            },
+        ];
+        let ctxs = run_inventory(&mem_config, &memory.memory, touched_memory);
+        let gpu_merkle = ctxs
+            .iter()
+            .find(|ctx| ctx.public_values.len() >= 2 * VM_DIGEST_WIDTH)
+            .expect("missing merkle ctx");
+
+        // CPU reference trace via the merkle chip, which applies the reverse+swap that
+        // defines the committed row order.
+        let md = mem_config.memory_dimensions();
+        let hasher = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
+
+        // The two written blocks fall in one 8-cell leaf at (RV64_MEMORY_AS, label 0).
+        let touched_labels: BTreeSet<(u32, u32)> = BTreeSet::from([(RV64_MEMORY_AS, 0)]);
+        let final_partition: BTreeMap<(u32, u32), [F; VM_DIGEST_WIDTH]> =
+            memory_to_vec_partition::<F, VM_DIGEST_WIDTH>(&final_memory.memory, &md)
+                .into_iter()
+                .map(|(idx, values)| {
+                    let address_space = (idx >> md.address_height) as u32 + ADDR_SPACE_OFFSET;
+                    let label = (idx & ((1 << md.address_height) - 1)) as u32;
+                    ((address_space, label * VM_DIGEST_WIDTH as u32), values)
+                })
+                .filter(|((address_space, ptr), _)| {
+                    touched_labels.contains(&(*address_space, ptr / VM_DIGEST_WIDTH as u32))
+                })
+                .collect();
+        // Every touched block sets is_dirty = 1, so the leaf is dirty (matches the GPU input).
+        let dirty_leaves: DirtyLeaves = final_partition.keys().copied().collect();
+
+        let bus = PermutationCheckBus::new(0); // bus index does not affect the main trace
+        let mut cpu_chip = MemoryMerkleChip::<VM_DIGEST_WIDTH, F>::new(md, bus, bus);
+        cpu_chip.finalize(&memory.memory, &final_partition, &dirty_leaves, &hasher);
+        let cpu_trace = cpu_chip
+            .generate_proving_ctx::<BabyBearPoseidon2Config>()
+            .common_main;
+        let cpu_trace_cm = ColMajorMatrix::from_row_major(&cpu_trace);
+
+        let device_ctx = GpuDeviceCtx {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        };
+        assert_eq_host_and_device_matrix_col_maj(&cpu_trace_cm, &gpu_merkle.common_main, &device_ctx);
+    }
 }

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -20,8 +20,7 @@ use openvm_instructions::VM_DIGEST_WIDTH;
 use openvm_stark_backend::{
     p3_field::PrimeCharacteristicRing,
     p3_maybe_rayon::prelude::{
-        IndexedParallelIterator, IntoParallelIterator, ParallelIterator, ParallelSlice,
-        ParallelSliceMut,
+        IndexedParallelIterator, ParallelIterator, ParallelSlice, ParallelSliceMut,
     },
     prover::AirProvingContext,
 };
@@ -353,21 +352,6 @@ impl MemoryInventoryGPU {
                 .expect("merge_records failed");
             }
 
-            // The merged record count is a pure function of input adjacency
-            // (the device merge flags a record iff its (address_space,
-            // ptr / VM_DIGEST_WIDTH) differs from its predecessor's, and the
-            // partition is sorted), so it can be computed here and the
-            // mid-merge D2H sync dropped entirely.
-            let out_num_records = 1
-                + (1..in_num_records)
-                    .into_par_iter()
-                    .filter(|&i| {
-                        let (a, b) = (&partition[i], &partition[i - 1]);
-                        (a.address_space, a.ptr / VM_DIGEST_WIDTH as u32)
-                            != (b.address_space, b.ptr / VM_DIGEST_WIDTH as u32)
-                    })
-                    .count();
-
             // Host work overlapping the merge kernels: the compacted leaf keys and
             // their dirty bits are pure functions of the sorted partition (the same
             // dedup rule the device merge uses; a leaf is dirty iff some of its blocks
@@ -393,7 +377,9 @@ impl MemoryInventoryGPU {
                     num_dirty_leaves += 1;
                 }
             }
-            debug_assert_eq!(num_touched_leaves, out_num_records);
+            // The GPU merge groups records the same way, so this count avoids a
+            // device-to-host copy before the next kernels are queued.
+            let out_num_records = num_touched_leaves;
             // One initial row per touched node, one final row per dirty node; the
             // final root row exists even when nothing is dirty.
             let merkle_rows = touched_nodes.nodes

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -811,6 +811,10 @@ mod tests {
             device_id: get_device().unwrap() as u32,
             stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
         };
-        assert_eq_host_and_device_matrix_col_maj(&cpu_trace_cm, &gpu_merkle.common_main, &device_ctx);
+        assert_eq_host_and_device_matrix_col_maj(
+            &cpu_trace_cm,
+            &gpu_merkle.common_main,
+            &device_ctx,
+        );
     }
 }

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -60,10 +60,11 @@ pub mod merkle_tree {
             subtree_height: usize,
             child_buf: *mut u32,
             tmp_buf: *mut u32,
+            dirty_buf: *mut u32,
             tmp_storage: *mut u8,
             need_tmp_storage_bytes: usize,
             merkle_trace: *mut u32,
-            trace_height: usize,
+            unpadded_trace_height: usize,
             num_subtrees: usize,
             subtrees: *mut usize,        // is actually H**
             top_roots: *mut u32,         // are actually `H`s
@@ -177,6 +178,9 @@ pub mod merkle_tree {
         let num_leaves = touched_blocks.len() / MERKLE_TOUCHED_BLOCK_WIDTH;
         let num_subtrees = subtree_ptrs.len();
         let tmp_buffer = DeviceBuffer::<u32>::with_capacity_on(5 * num_leaves, device_ctx);
+        // Per-layer dirty flags / their inclusive prefix sum (layers only shrink, so
+        // `num_leaves` entries suffice).
+        let dirty_buffer = DeviceBuffer::<u32>::with_capacity_on(num_leaves, device_ctx);
         let mut need_tmp_storage_bytes = 0;
         get_prefix_scan_temp_bytes(
             &tmp_buffer,
@@ -195,6 +199,7 @@ pub mod merkle_tree {
             subtree_height,
             tmp_buffer.as_mut_ptr(),
             tmp_buffer.as_mut_ptr().add(2 * num_leaves),
+            dirty_buffer.as_mut_ptr(),
             tmp_storage.as_mut_ptr(),
             need_tmp_storage_bytes,
             trace.buffer().as_ptr() as *mut u32,

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -456,18 +456,13 @@ impl MemoryMerkleTree {
                 // The artificial touch (see the caller) seeds the walk so the root pair
                 // exists, but no boundary row supplies the leaf's claim, so the height-1
                 // initial row (the last row) must treat the leaf as *untouched*: consume
-                // nothing. The kernel already leaves its `left_extra_ref` at 0 (the node
-                // emits no final row) and sets `right_absent_ref` for the untouched
-                // sibling; only `left_absent_ref` needs the post-hoc fix. The trace is
-                // small then.
+                // nothing.
                 let mut output_vec = output.buffer().to_host_on(&self.device_ctx).unwrap();
-                // Column index within the column-major trace, derived from the column
-                // struct so it survives layout changes.
-                let left_absent_ref_col = std::mem::offset_of!(
+                let left_adj_ref_col = std::mem::offset_of!(
                     MemoryMerkleCols<F, VM_DIGEST_WIDTH>,
-                    left_absent_ref
+                    left_adj_ref
                 ) / std::mem::size_of::<F>();
-                output_vec[unpadded_height - 1 + left_absent_ref_col * padded_height] = F::ONE;
+                output_vec[unpadded_height - 1 + left_adj_ref_col * padded_height] = F::NEG_ONE;
                 DeviceMatrix::new(
                     Arc::new(output_vec.to_device_on(&self.device_ctx).unwrap()),
                     padded_height,

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -429,8 +429,20 @@ impl MemoryMerkleTree {
             if empty_touched_blocks {
                 // The trace is small then
                 let mut output_vec = output.buffer().to_host_on(&self.device_ctx).unwrap();
-                output_vec[unpadded_height - 1 + (width - 2) * padded_height] = F::ONE; // left_direction_different
-                output_vec[unpadded_height - 1 + (width - 1) * padded_height] = F::ONE; // right_direction_different
+                // TODO: update later
+                // Column indices within the column-major trace, derived from the column
+                // struct so they survive layout changes.
+                let col = |byte_offset: usize| byte_offset / std::mem::size_of::<F>();
+                let left_dd_col = col(std::mem::offset_of!(
+                    MemoryMerkleCols<F, VM_DIGEST_WIDTH>,
+                    left_direction_different
+                ));
+                let right_dd_col = col(std::mem::offset_of!(
+                    MemoryMerkleCols<F, VM_DIGEST_WIDTH>,
+                    right_direction_different
+                ));
+                output_vec[unpadded_height - 1 + left_dd_col * padded_height] = F::ONE;
+                output_vec[unpadded_height - 1 + right_dd_col * padded_height] = F::ONE;
                 DeviceMatrix::new(
                     Arc::new(output_vec.to_device_on(&self.device_ctx).unwrap()),
                     padded_height,

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -506,6 +506,7 @@ mod tests {
             memory::{
                 merkle::{MemoryMerkleChip, MerkleTree},
                 online::{GuestMemory, LinearMemory},
+                persistent::DirtyLeaves,
                 AddressMap, TimestampedValues,
             },
             poseidon2::Poseidon2PeripheryChip,
@@ -703,6 +704,21 @@ mod tests {
             .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
             .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
         assert!(!touched_ptrs.is_empty());
+        // Mirror the boundary chip's dirtiness definition: a touched leaf is dirty iff
+        // its final values differ from its initial values.
+        let dirty_leaves: DirtyLeaves = touched_ptrs
+            .iter()
+            .zip(new_data.iter())
+            .filter(|(&(address_space, ptr), values)| {
+                let init_values: [F; VM_DIGEST_WIDTH] = std::array::from_fn(|i| unsafe {
+                    initial_memory
+                        .memory
+                        .get_f::<F>(address_space, ptr + i as u32)
+                });
+                init_values != **values
+            })
+            .map(|(&key, _)| key)
+            .collect();
         cpu_merkle_tree.finalize(
             &cpu_hasher_chip,
             &(touched_ptrs
@@ -710,6 +726,7 @@ mod tests {
                 .copied()
                 .zip(new_data.iter().copied())
                 .collect()),
+            &dirty_leaves,
             &mem_config.memory_dimensions(),
         );
         let touched_blocks = touched_ptrs
@@ -883,7 +900,26 @@ mod tests {
             .copied()
             .zip(new_data.iter().copied())
             .collect();
-        cpu_merkle_chip.finalize(&initial_memory.memory, &final_partition, &cpu_hasher_chip);
+        // Mirror the boundary chip's dirtiness definition: a touched leaf is dirty iff
+        // its final values differ from its initial values.
+        let dirty_leaves: DirtyLeaves = final_partition
+            .iter()
+            .filter(|((address_space, ptr), values)| {
+                let init_values: [F; VM_DIGEST_WIDTH] = std::array::from_fn(|i| unsafe {
+                    initial_memory
+                        .memory
+                        .get_f::<F>(*address_space, *ptr + i as u32)
+                });
+                init_values != **values
+            })
+            .map(|(&key, _)| key)
+            .collect();
+        cpu_merkle_chip.finalize(
+            &initial_memory.memory,
+            &final_partition,
+            &dirty_leaves,
+            &cpu_hasher_chip,
+        );
         let cpu_ctx = cpu_merkle_chip.generate_proving_ctx::<SC>();
 
         // Run the GPU update and capture the resulting trace.

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -12,11 +12,7 @@ use openvm_cuda_common::{
     stream::{CudaEvent, GpuDeviceCtx},
 };
 use openvm_instructions::VM_DIGEST_WIDTH;
-use openvm_stark_backend::{
-    p3_maybe_rayon::prelude::{IntoParallelIterator, ParallelIterator},
-    p3_util::log2_ceil_usize,
-    prover::AirProvingContext,
-};
+use openvm_stark_backend::{p3_util::log2_ceil_usize, prover::AirProvingContext};
 use p3_field::PrimeCharacteristicRing;
 
 use super::{poseidon2::SharedBuffer, Poseidon2PeripheryChipGPU};
@@ -28,10 +24,40 @@ type H = [F; VM_DIGEST_WIDTH];
 /// Width of `((u32, u32), TimestampedValues<F, BLOCK_FE_WIDTH>)` in u32 units.
 /// = 2 (key) + 1 (timestamp) + BLOCK_FE_WIDTH (values)
 pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + BLOCK_FE_WIDTH;
-/// Width of `((u32, u32), TimestampedValues<F, VM_DIGEST_WIDTH>)` in u32 units.
-/// = 2 (key) + 1 (timestamp) + VM_DIGEST_WIDTH (values)
+/// Width of one merkle touched-block record in u32 units.
+/// = 2 (key) + 1 (is_dirty) + VM_DIGEST_WIDTH (values); see `MemoryMerkleRecord`.
 pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + VM_DIGEST_WIDTH;
 pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
+
+/// Exact number of distinct internal merkle nodes (heights `1..=tree_height`) on the
+/// paths from a sorted stream of global leaf indices to the root: the first leaf's path
+/// has `tree_height` nodes, and each subsequent leaf adds nodes only below the height at
+/// which its path merges with the previous one (`log2` of the index xor). Exact, not an
+/// upper bound.
+#[derive(Default)]
+pub(crate) struct SpanningNodeCounter {
+    prev_leaf_index: Option<u64>,
+    pub(crate) nodes: usize,
+}
+
+impl SpanningNodeCounter {
+    #[inline]
+    pub(crate) fn push(&mut self, leaf_index: u64, tree_height: usize) {
+        self.nodes += match self.prev_leaf_index {
+            None => tree_height,
+            Some(prev) => {
+                debug_assert!(prev <= leaf_index);
+                let xor = prev ^ leaf_index;
+                if xor == 0 {
+                    0
+                } else {
+                    xor.ilog2() as usize
+                }
+            }
+        };
+        self.prev_leaf_index = Some(leaf_index);
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -370,7 +396,7 @@ impl MemoryMerkleTree {
 
     /// Updates the tree and returns the merkle trace.
     ///
-    /// `d_touched_blocks` consists of `(as, ptr, ts, [F; VM_DIGEST_WIDTH])`.
+    /// `d_touched_blocks` consists of `(as, ptr, is_dirty, [F; VM_DIGEST_WIDTH])`.
     pub fn update_with_touched_blocks(
         &mut self,
         unpadded_height: usize,
@@ -427,22 +453,21 @@ impl MemoryMerkleTree {
             }
 
             if empty_touched_blocks {
-                // The trace is small then
+                // The artificial touch (see the caller) seeds the walk so the root pair
+                // exists, but no boundary row supplies the leaf's claim, so the height-1
+                // initial row (the last row) must treat the leaf as *untouched*: consume
+                // nothing. The kernel already leaves its `left_extra_ref` at 0 (the node
+                // emits no final row) and sets `right_absent_ref` for the untouched
+                // sibling; only `left_absent_ref` needs the post-hoc fix. The trace is
+                // small then.
                 let mut output_vec = output.buffer().to_host_on(&self.device_ctx).unwrap();
-                // TODO: update later
-                // Column indices within the column-major trace, derived from the column
-                // struct so they survive layout changes.
-                let col = |byte_offset: usize| byte_offset / std::mem::size_of::<F>();
-                let left_dd_col = col(std::mem::offset_of!(
+                // Column index within the column-major trace, derived from the column
+                // struct so it survives layout changes.
+                let left_absent_ref_col = std::mem::offset_of!(
                     MemoryMerkleCols<F, VM_DIGEST_WIDTH>,
-                    left_direction_different
-                ));
-                let right_dd_col = col(std::mem::offset_of!(
-                    MemoryMerkleCols<F, VM_DIGEST_WIDTH>,
-                    right_direction_different
-                ));
-                output_vec[unpadded_height - 1 + left_dd_col * padded_height] = F::ONE;
-                output_vec[unpadded_height - 1 + right_dd_col * padded_height] = F::ONE;
+                    left_absent_ref
+                ) / std::mem::size_of::<F>();
+                output_vec[unpadded_height - 1 + left_absent_ref_col * padded_height] = F::ONE;
                 DeviceMatrix::new(
                     Arc::new(output_vec.to_device_on(&self.device_ctx).unwrap()),
                     padded_height,
@@ -456,36 +481,6 @@ impl MemoryMerkleTree {
         public_values.extend(self.top_roots_host[0]);
 
         AirProvingContext::new(Vec::new(), merkle_trace, public_values)
-    }
-
-    /// An auxiliary function to calculate the required number of rows for the merkle trace.
-    /// Generic over BLOCK_SIZE since only addresses are used, not values.
-    pub fn calculate_unpadded_height<A: Sync>(
-        &self,
-        touched_memory: &[A],
-        address: impl Fn(&A) -> (u32, u32) + Sync,
-    ) -> usize {
-        let md = self.mem_config.memory_dimensions();
-        let tree_height = md.overall_height();
-        let shift_address = |(sp, ptr): (u32, u32)| (sp, ptr / VM_DIGEST_WIDTH as u32);
-        2 * if touched_memory.is_empty() {
-            tree_height
-        } else {
-            tree_height
-                + (0..(touched_memory.len() - 1))
-                    .into_par_iter()
-                    .map(|i| {
-                        let x = md.label_to_index(shift_address(address(&touched_memory[i])));
-                        let y = md.label_to_index(shift_address(address(&touched_memory[i + 1])));
-                        let xor = x ^ y;
-                        if xor == 0 {
-                            0
-                        } else {
-                            xor.ilog2() as usize
-                        }
-                    })
-                    .sum::<usize>()
-        }
     }
 }
 
@@ -529,12 +524,57 @@ mod tests {
     use rand::Rng;
 
     use super::{
-        MemoryMerkleSubTree, MemoryMerkleSubTreeLayout, MemoryMerkleTree, OMITTED_BOTTOM_LEVELS,
+        MemoryMerkleSubTree, MemoryMerkleSubTreeLayout, MemoryMerkleTree, SpanningNodeCounter,
+        OMITTED_BOTTOM_LEVELS,
     };
     use crate::{
         arch::testing::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
         system::cuda::Poseidon2PeripheryChipGPU,
     };
+
+    /// Builds the device merkle-record words and the exact unpadded merkle trace height
+    /// they imply. Dirtiness is per *write*; the tests treat exactly the leaves whose
+    /// values changed as written (the minimal valid dirty set). `touched_blocks` must be
+    /// sorted by (address space, pointer).
+    fn build_records_and_height(
+        initial_memory: &GuestMemory,
+        touched_blocks: &[((u32, u32), TimestampedValues<F, VM_DIGEST_WIDTH>)],
+        mem_config: &MemoryConfig,
+    ) -> (Vec<u32>, usize) {
+        let md = mem_config.memory_dimensions();
+        let tree_height = md.overall_height();
+        let mut words = Vec::with_capacity(touched_blocks.len() * MERKLE_TOUCHED_BLOCK_WIDTH);
+        let mut touched_nodes = SpanningNodeCounter::default();
+        let mut dirty_nodes = SpanningNodeCounter::default();
+        let mut dirty_leaves = 0usize;
+        for ((address_space, ptr), ts_values) in touched_blocks {
+            let init_values: [F; VM_DIGEST_WIDTH] = std::array::from_fn(|i| unsafe {
+                initial_memory
+                    .memory
+                    .get_f::<F>(*address_space, *ptr + i as u32)
+            });
+            let is_dirty = u32::from(init_values != ts_values.values);
+            let leaf_index = md.label_to_index((*address_space, *ptr / VM_DIGEST_WIDTH as u32));
+            touched_nodes.push(leaf_index, tree_height);
+            if is_dirty != 0 {
+                dirty_nodes.push(leaf_index, tree_height);
+                dirty_leaves += 1;
+            }
+            words.push(*address_space);
+            words.push(*ptr);
+            words.push(is_dirty);
+            for &v in &ts_values.values {
+                words.push(unsafe { std::mem::transmute::<F, u32>(v) });
+            }
+        }
+        let rows = touched_nodes.nodes
+            + if dirty_leaves == 0 {
+                1
+            } else {
+                dirty_nodes.nodes
+            };
+        (words, rows)
+    }
 
     #[test]
     fn test_cuda_merkle_subtree_layout_and_buffer_sizes() {
@@ -704,8 +744,8 @@ mod tests {
             .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
             .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
         assert!(!touched_ptrs.is_empty());
-        // Mirror the boundary chip's dirtiness definition: a touched leaf is dirty iff
-        // its final values differ from its initial values.
+        // Dirtiness is per *write*; the test scenario treats exactly the leaves whose
+        // values changed as written (the minimal valid dirty set).
         let dirty_leaves: DirtyLeaves = touched_ptrs
             .iter()
             .zip(new_data.iter())
@@ -742,23 +782,11 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let mut merkle_records =
-            Vec::<u32>::with_capacity(touched_blocks.len() * MERKLE_TOUCHED_BLOCK_WIDTH);
-        for (address, ts_values) in &touched_blocks {
-            let (address_space, ptr) = *address;
-            merkle_records.push(address_space);
-            merkle_records.push(ptr);
-            merkle_records.push(ts_values.timestamp);
-            for &v in &ts_values.values {
-                merkle_records.push(unsafe { std::mem::transmute::<F, u32>(v) });
-            }
-        }
+        let (merkle_records, unpadded_height) =
+            build_records_and_height(&initial_memory, &touched_blocks, &mem_config);
         let d_touched_blocks = merkle_records
             .to_device_on(&gpu_merkle_tree.device_ctx)
             .unwrap();
-
-        let unpadded_height =
-            gpu_merkle_tree.calculate_unpadded_height(&touched_blocks, |(addr, _)| *addr);
         gpu_hasher_chip.prepare_records(unpadded_height);
         gpu_merkle_tree.update_with_touched_blocks(unpadded_height, &d_touched_blocks, false);
 
@@ -881,10 +909,25 @@ mod tests {
                 ptrs
             })
             .collect::<Vec<_>>();
-        let new_data = touched_ptrs
+        let mut new_data = touched_ptrs
             .iter()
             .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
             .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
+        // Make every third touched leaf *clean* (final values equal to initial ones):
+        // random values are almost surely dirty, and the mixed case is what exercises
+        // skipped final rows, dd-borrows of clean leaves, and the reference-count flags.
+        for (i, (&(address_space, ptr), values)) in
+            touched_ptrs.iter().zip(new_data.iter_mut()).enumerate()
+        {
+            if i % 3 == 0 {
+                *values = std::array::from_fn(|j| unsafe {
+                    initial_memory
+                        .memory
+                        .get_f::<F>(address_space, ptr + j as u32)
+                });
+            }
+        }
+        let new_data = new_data;
         assert!(!touched_ptrs.is_empty());
 
         // Build the canonical CPU trace from the same initial memory and touched blocks, using a
@@ -900,8 +943,8 @@ mod tests {
             .copied()
             .zip(new_data.iter().copied())
             .collect();
-        // Mirror the boundary chip's dirtiness definition: a touched leaf is dirty iff
-        // its final values differ from its initial values.
+        // Dirtiness is per *write*; the test scenario treats exactly the leaves whose
+        // values changed as written (the minimal valid dirty set).
         let dirty_leaves: DirtyLeaves = final_partition
             .iter()
             .filter(|((address_space, ptr), values)| {
@@ -936,23 +979,11 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let mut merkle_records =
-            Vec::<u32>::with_capacity(touched_blocks.len() * MERKLE_TOUCHED_BLOCK_WIDTH);
-        for (address, ts_values) in &touched_blocks {
-            let (address_space, ptr) = *address;
-            merkle_records.push(address_space);
-            merkle_records.push(ptr);
-            merkle_records.push(ts_values.timestamp);
-            for &v in &ts_values.values {
-                merkle_records.push(unsafe { std::mem::transmute::<F, u32>(v) });
-            }
-        }
+        let (merkle_records, unpadded_height) =
+            build_records_and_height(&initial_memory, &touched_blocks, &mem_config);
         let d_touched_blocks = merkle_records
             .to_device_on(&gpu_merkle_tree.device_ctx)
             .unwrap();
-
-        let unpadded_height =
-            gpu_merkle_tree.calculate_unpadded_height(&touched_blocks, |(addr, _)| *addr);
         gpu_hasher_chip.prepare_records(unpadded_height);
         let merkle_ctx =
             gpu_merkle_tree.update_with_touched_blocks(unpadded_height, &d_touched_blocks, false);

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -456,13 +456,14 @@ impl MemoryMerkleTree {
                 // The artificial touch (see the caller) seeds the walk so the root pair
                 // exists, but no boundary row supplies the leaf's claim, so the height-1
                 // initial row (the last row) must treat the leaf as *untouched*: consume
-                // nothing.
+                // nothing, i.e. `left_child_mode = 0` (the kernel wrote 1 for the seeded
+                // leaf).
                 let mut output_vec = output.buffer().to_host_on(&self.device_ctx).unwrap();
-                let left_adj_ref_col = std::mem::offset_of!(
+                let left_child_mode_col = std::mem::offset_of!(
                     MemoryMerkleCols<F, VM_DIGEST_WIDTH>,
-                    left_adj_ref
+                    left_child_mode
                 ) / std::mem::size_of::<F>();
-                output_vec[unpadded_height - 1 + left_adj_ref_col * padded_height] = F::NEG_ONE;
+                output_vec[unpadded_height - 1 + left_child_mode_col * padded_height] = F::ZERO;
                 DeviceMatrix::new(
                     Arc::new(output_vec.to_device_on(&self.device_ctx).unwrap()),
                     padded_height,

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -911,7 +911,7 @@ mod tests {
             .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
         // Make every third touched leaf *clean* (final values equal to initial ones):
         // random values are almost surely dirty, and the mixed case is what exercises
-        // skipped final rows, dd-borrows of clean leaves, and the reference-count flags.
+        // skipped final rows, initial-state borrows, and the child modes.
         for (i, (&(address_space, ptr), values)) in
             touched_ptrs.iter().zip(new_data.iter_mut()).enumerate()
         {

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -188,7 +188,7 @@ impl<F: VmField> MemoryController<F> {
                 let mut values = std::array::from_fn(|i| unsafe {
                     initial_memory.get_f::<F>(*addr_space, ptr + i as u32)
                 });
-                for &(block_idx, _, block_values) in blocks {
+                for &(block_idx, _, _, block_values) in blocks {
                     for (i, val) in block_values.iter().enumerate() {
                         values[block_idx * BLOCK_FE_WIDTH + i] = *val;
                     }

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -176,7 +176,8 @@ impl<F: VmField> MemoryController<F> {
 
         let hasher = self.hasher_chip.as_ref().unwrap();
         let final_memory_by_leaf = group_touched_memory_by_leaf(&final_memory);
-        boundary_chip.finalize(initial_memory, &final_memory_by_leaf, hasher.as_ref());
+        let dirty_leaves =
+            boundary_chip.finalize(initial_memory, &final_memory_by_leaf, hasher.as_ref());
 
         // Regroup BLOCK_FE_WIDTH-cell blocks into VM_DIGEST_WIDTH-cell leaves for merkle_chip.
         // The equipartition key is (addr_space, ptr).
@@ -195,7 +196,12 @@ impl<F: VmField> MemoryController<F> {
                 ((*addr_space, ptr), values)
             })
             .collect();
-        merkle_chip.finalize(initial_memory, &final_memory_values, hasher.as_ref());
+        merkle_chip.finalize(
+            initial_memory,
+            &final_memory_values,
+            &dirty_leaves,
+            hasher.as_ref(),
+        );
 
         vec![
             boundary_chip.generate_proving_ctx(()),

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -62,20 +62,22 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder + AirBuilderWithPublicVal
             .when_ne(local.expand_direction, AB::F::NEG_ONE)
             .assert_zero(local.right_direction_different);
 
-        // The reference-count flags adjust how many copies of a child's initial claim an
-        // initial row consumes (see the child interactions in `eval_interactions`). They
-        // are meaningful only on initial rows: if `expand_direction` != 1, all must be 0.
-        for flag in [
-            local.left_extra_ref,
-            local.right_extra_ref,
-            local.left_absent_ref,
-            local.right_absent_ref,
-        ] {
-            builder.assert_bool(flag);
-            builder
-                .when_ne(local.expand_direction, AB::F::ONE)
-                .assert_zero(flag);
-        }
+        // left/right reference adjustment must be -1, 0, 1
+        builder.assert_eq(
+            local.left_adj_ref,
+            local.left_adj_ref * local.left_adj_ref * local.left_adj_ref,
+        );
+        builder.assert_eq(
+            local.right_adj_ref,
+            local.right_adj_ref * local.right_adj_ref * local.right_adj_ref,
+        );
+        // left/right reference adjustment must be set to 0 when expand_direction is not 1
+        builder
+            .when_ne(local.expand_direction, AB::F::ONE)
+            .assert_zero(local.left_adj_ref);
+        builder
+            .when_ne(local.expand_direction, AB::F::ONE)
+            .assert_zero(local.right_adj_ref);
 
         // rows should be sorted in descending order
         // independently by `parent_height`, `height_section`, `is_root`
@@ -193,8 +195,7 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             ]
             .into_iter()
             .chain(local.left_child_hash.into_iter().map(Into::into)),
-            (AB::Expr::ZERO - local.expand_direction)
-                * (AB::Expr::ONE - local.left_absent_ref + local.left_extra_ref),
+            (AB::Expr::ZERO - local.expand_direction) * (AB::Expr::ONE + local.left_adj_ref),
         );
 
         self.merkle_bus.interact(
@@ -209,8 +210,7 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             ]
             .into_iter()
             .chain(local.right_child_hash.into_iter().map(Into::into)),
-            (AB::Expr::ZERO - local.expand_direction)
-                * (AB::Expr::ONE - local.right_absent_ref + local.right_extra_ref),
+            (AB::Expr::ZERO - local.expand_direction) * (AB::Expr::ONE + local.right_adj_ref),
         );
 
         let compress_fields = iter::empty()

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -62,6 +62,21 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder + AirBuilderWithPublicVal
             .when_ne(local.expand_direction, AB::F::NEG_ONE)
             .assert_zero(local.right_direction_different);
 
+        // The reference-count flags adjust how many copies of a child's initial claim an
+        // initial row consumes (see the child interactions in `eval_interactions`). They
+        // are meaningful only on initial rows: if `expand_direction` != 1, all must be 0.
+        for flag in [
+            local.left_extra_ref,
+            local.right_extra_ref,
+            local.left_absent_ref,
+            local.right_absent_ref,
+        ] {
+            builder.assert_bool(flag);
+            builder
+                .when_ne(local.expand_direction, AB::F::ONE)
+                .assert_zero(flag);
+        }
+
         // rows should be sorted in descending order
         // independently by `parent_height`, `height_section`, `is_root`
         builder
@@ -164,6 +179,10 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             (AB::Expr::ONE - local.is_root) * local.expand_direction,
         );
 
+        // Child-reference multiplicity: `-expand_direction`, adjusted on initial rows by
+        // the reference-count flags (constrained zero on non-initial rows):
+        //   -1 * (1 - absent + extra) ∈ {0, -1, -2} on initial rows (how many copies of
+        //   the child's initial claim this row consumes), +1 on final rows (send).
         self.merkle_bus.interact(
             builder,
             [
@@ -174,7 +193,8 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             ]
             .into_iter()
             .chain(local.left_child_hash.into_iter().map(Into::into)),
-            -local.expand_direction.into(),
+            (AB::Expr::ZERO - local.expand_direction)
+                * (AB::Expr::ONE - local.left_absent_ref + local.left_extra_ref),
         );
 
         self.merkle_bus.interact(
@@ -189,7 +209,8 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             ]
             .into_iter()
             .chain(local.right_child_hash.into_iter().map(Into::into)),
-            -local.expand_direction.into(),
+            (AB::Expr::ZERO - local.expand_direction)
+                * (AB::Expr::ONE - local.right_absent_ref + local.right_extra_ref),
         );
 
         let compress_fields = iter::empty()

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -51,33 +51,20 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder + AirBuilderWithPublicVal
             local.expand_direction * local.expand_direction * local.expand_direction,
         );
 
-        builder.assert_bool(local.left_direction_different);
-        builder.assert_bool(local.right_direction_different);
-
-        // if `expand_direction` != -1, then `*_direction_different` should be 0
-        builder
-            .when_ne(local.expand_direction, AB::F::NEG_ONE)
-            .assert_zero(local.left_direction_different);
-        builder
-            .when_ne(local.expand_direction, AB::F::NEG_ONE)
-            .assert_zero(local.right_direction_different);
-
-        // left/right reference adjustment must be -1, 0, 1
-        builder.assert_eq(
-            local.left_adj_ref,
-            local.left_adj_ref * local.left_adj_ref * local.left_adj_ref,
-        );
-        builder.assert_eq(
-            local.right_adj_ref,
-            local.right_adj_ref * local.right_adj_ref * local.right_adj_ref,
-        );
-        // left/right reference adjustment must be set to 0 when expand_direction is not 1
-        builder
-            .when_ne(local.expand_direction, AB::F::ONE)
-            .assert_zero(local.left_adj_ref);
-        builder
-            .when_ne(local.expand_direction, AB::F::ONE)
-            .assert_zero(local.right_adj_ref);
+        // the following set of constrains enforces left/right_child_mode value depending on
+        // expand_direction
+        for m in [local.left_child_mode, local.right_child_mode] {
+            // mode must be in 0, 1, 2
+            builder.assert_zero(m * (AB::Expr::ONE - m) * (AB::Expr::TWO - m));
+            // mode must not be 2 when expand_direction=-1 or expand_direction=0
+            builder
+                .when_ne(local.expand_direction, AB::Expr::ONE)
+                .assert_zero(m * (AB::Expr::ONE - m));
+            // if mode is not 0, then expand direction is -1 or 1
+            builder
+                .when(m)
+                .assert_zero(AB::Expr::ONE - local.expand_direction * local.expand_direction);
+        }
 
         // rows should be sorted in descending order
         // independently by `parent_height`, `height_section`, `is_root`
@@ -181,27 +168,46 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             (AB::Expr::ONE - local.is_root) * local.expand_direction,
         );
 
-        // Child-reference multiplicity: `-expand_direction`, adjusted on initial rows by
-        // the reference-count flags (constrained zero on non-initial rows):
-        //   -1 * (1 - absent + extra) ∈ {0, -1, -2} on initial rows (how many copies of
-        //   the child's initial claim this row consumes), +1 on final rows (send).
+        // The child interactions reuse one `*_child_mode` column per side (see
+        // `MemoryMerkleCols`). Writing `dir = expand_direction` and `m = *_child_mode`:
+        //
+        //   tag   = dir + m*(1 - dir)
+        //             dir= 1 (initial):  1              (m does not affect the tag)
+        //             dir=-1 (final):    2*m - 1        (m is the dd bit: 0 -> -1, 1 -> +1)
+        //             dir= 0 (padding):  0              (m is forced 0)
+        //   count = (dir*(dir - 1) - m*(1 + dir)) / 2
+        //             dir= 1 (initial): -m              (consume the child's initial claim m times)
+        //             dir=-1 (final):   +1              (send; independent of m)
+        //             dir= 0 (padding):  0
+        let one_half = AB::F::TWO.inverse();
+
+        let left_tag = local.expand_direction
+            + local.left_child_mode * (AB::Expr::ONE - local.expand_direction);
+        let left_count = (local.expand_direction * (local.expand_direction - AB::Expr::ONE)
+            - local.left_child_mode * (AB::Expr::ONE + local.expand_direction))
+            * AB::Expr::from(one_half);
         self.merkle_bus.interact(
             builder,
             [
-                local.expand_direction + (local.left_direction_different * AB::F::TWO),
+                left_tag,
                 local.parent_height - AB::F::ONE,
                 local.parent_as_label * (AB::Expr::ONE + local.height_section),
                 local.parent_address_label * (AB::Expr::TWO - local.height_section),
             ]
             .into_iter()
             .chain(local.left_child_hash.into_iter().map(Into::into)),
-            (AB::Expr::ZERO - local.expand_direction) * (AB::Expr::ONE + local.left_adj_ref),
+            left_count,
         );
 
+        let right_tag = local.expand_direction
+            + local.right_child_mode * (AB::Expr::ONE - local.expand_direction);
+        let right_count = (local.expand_direction * (local.expand_direction - AB::Expr::ONE)
+            - local.right_child_mode * (AB::Expr::ONE + local.expand_direction))
+            * AB::Expr::from(one_half);
         self.merkle_bus.interact(
             builder,
             [
-                local.expand_direction + (local.right_direction_different * AB::F::TWO),
+                right_tag,
                 local.parent_height - AB::F::ONE,
                 (local.parent_as_label * (AB::Expr::ONE + local.height_section))
                     + local.height_section,
@@ -210,7 +216,7 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             ]
             .into_iter()
             .chain(local.right_child_hash.into_iter().map(Into::into)),
-            (AB::Expr::ZERO - local.expand_direction) * (AB::Expr::ONE + local.right_adj_ref),
+            right_count,
         );
 
         let compress_fields = iter::empty()

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -21,17 +21,17 @@ pub struct MemoryMerkleAir<const DIGEST_WIDTH: usize> {
 
 /// Returns the direction and multiplicity of one child interaction.
 ///
-/// On initial rows, `mode` is the number of initial interactions received. On final
-/// rows, mode 0 selects the final state and mode 1 selects the initial state.
+/// On initial rows, `mode` is the number of initial claims consumed. On final rows,
+/// mode 0 selects the final state and mode 1 selects the initial state.
 ///
-/// +---------+------------+-----------------+--------------+
-/// | Row     | mode       | child direction | multiplicity |
-/// +---------+------------+-----------------+--------------+
-/// | Initial | 0, 1, or 2 |               1 |        -mode |
-/// | Final   |          0 |              -1 |            1 |
-/// | Final   |          1 |               1 |            1 |
-/// | Padding |          0 |               0 |            0 |
-/// +---------+------------+-----------------+--------------+
+/// +---------+---------------+------------+-----------------+--------------+
+/// | Row     | row direction | mode       | child direction | multiplicity |
+/// +---------+---------------+------------+-----------------+--------------+
+/// | Initial |             1 | 0, 1, or 2 |               1 |        -mode |
+/// | Final   |            -1 |          0 |              -1 |            1 |
+/// | Final   |            -1 |          1 |               1 |            1 |
+/// | Padding |             0 |          0 |               0 |            0 |
+/// +---------+---------------+------------+-----------------+--------------+
 fn child_bus_interaction<AB: InteractionBuilder>(
     row_direction: AB::Var,
     mode: AB::Var,

--- a/crates/vm/src/system/memory/merkle/air.rs
+++ b/crates/vm/src/system/memory/merkle/air.rs
@@ -19,6 +19,33 @@ pub struct MemoryMerkleAir<const DIGEST_WIDTH: usize> {
     pub compression_bus: PermutationCheckBus,
 }
 
+/// Returns the direction and multiplicity of one child interaction.
+///
+/// On initial rows, `mode` is the number of initial interactions received. On final
+/// rows, mode 0 selects the final state and mode 1 selects the initial state.
+///
+/// +---------+------------+-----------------+--------------+
+/// | Row     | mode       | child direction | multiplicity |
+/// +---------+------------+-----------------+--------------+
+/// | Initial | 0, 1, or 2 |               1 |        -mode |
+/// | Final   |          0 |              -1 |            1 |
+/// | Final   |          1 |               1 |            1 |
+/// | Padding |          0 |               0 |            0 |
+/// +---------+------------+-----------------+--------------+
+fn child_bus_interaction<AB: InteractionBuilder>(
+    row_direction: AB::Var,
+    mode: AB::Var,
+) -> (AB::Expr, AB::Expr) {
+    let child_direction = row_direction + mode * (AB::Expr::ONE - row_direction);
+
+    // The numerator is -2*mode on initial rows, 2 on final rows, and 0 on padding rows.
+    let multiplicity = (row_direction * (row_direction - AB::Expr::ONE)
+        - mode * (AB::Expr::ONE + row_direction))
+        * AB::Expr::from(AB::F::TWO.inverse());
+
+    (child_direction, multiplicity)
+}
+
 impl<const DIGEST_WIDTH: usize, F: Field> PartitionedBaseAir<F> for MemoryMerkleAir<DIGEST_WIDTH> {}
 impl<const DIGEST_WIDTH: usize, F: Field> BaseAir<F> for MemoryMerkleAir<DIGEST_WIDTH> {
     fn width(&self) -> usize {
@@ -51,16 +78,15 @@ impl<const DIGEST_WIDTH: usize, AB: InteractionBuilder + AirBuilderWithPublicVal
             local.expand_direction * local.expand_direction * local.expand_direction,
         );
 
-        // the following set of constrains enforces left/right_child_mode value depending on
-        // expand_direction
+        // Child modes depend on `expand_direction`.
         for m in [local.left_child_mode, local.right_child_mode] {
-            // mode must be in 0, 1, 2
+            // Initial rows allow modes in {0, 1, 2}.
             builder.assert_zero(m * (AB::Expr::ONE - m) * (AB::Expr::TWO - m));
-            // mode must not be 2 when expand_direction=-1 or expand_direction=0
+            // Final and padding rows only allow modes in {0, 1}.
             builder
                 .when_ne(local.expand_direction, AB::Expr::ONE)
                 .assert_zero(m * (AB::Expr::ONE - m));
-            // if mode is not 0, then expand direction is -1 or 1
+            // Padding rows must have mode 0.
             builder
                 .when(m)
                 .assert_zero(AB::Expr::ONE - local.expand_direction * local.expand_direction);
@@ -168,46 +194,27 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             (AB::Expr::ONE - local.is_root) * local.expand_direction,
         );
 
-        // The child interactions reuse one `*_child_mode` column per side (see
-        // `MemoryMerkleCols`). Writing `dir = expand_direction` and `m = *_child_mode`:
-        //
-        //   tag   = dir + m*(1 - dir)
-        //             dir= 1 (initial):  1              (m does not affect the tag)
-        //             dir=-1 (final):    2*m - 1        (m is the dd bit: 0 -> -1, 1 -> +1)
-        //             dir= 0 (padding):  0              (m is forced 0)
-        //   count = (dir*(dir - 1) - m*(1 + dir)) / 2
-        //             dir= 1 (initial): -m              (consume the child's initial claim m times)
-        //             dir=-1 (final):   +1              (send; independent of m)
-        //             dir= 0 (padding):  0
-        let one_half = AB::F::TWO.inverse();
-
-        let left_tag = local.expand_direction
-            + local.left_child_mode * (AB::Expr::ONE - local.expand_direction);
-        let left_count = (local.expand_direction * (local.expand_direction - AB::Expr::ONE)
-            - local.left_child_mode * (AB::Expr::ONE + local.expand_direction))
-            * AB::Expr::from(one_half);
+        let (left_direction, left_multiplicity) =
+            child_bus_interaction::<AB>(local.expand_direction, local.left_child_mode);
         self.merkle_bus.interact(
             builder,
             [
-                left_tag,
+                left_direction,
                 local.parent_height - AB::F::ONE,
                 local.parent_as_label * (AB::Expr::ONE + local.height_section),
                 local.parent_address_label * (AB::Expr::TWO - local.height_section),
             ]
             .into_iter()
             .chain(local.left_child_hash.into_iter().map(Into::into)),
-            left_count,
+            left_multiplicity,
         );
 
-        let right_tag = local.expand_direction
-            + local.right_child_mode * (AB::Expr::ONE - local.expand_direction);
-        let right_count = (local.expand_direction * (local.expand_direction - AB::Expr::ONE)
-            - local.right_child_mode * (AB::Expr::ONE + local.expand_direction))
-            * AB::Expr::from(one_half);
+        let (right_direction, right_multiplicity) =
+            child_bus_interaction::<AB>(local.expand_direction, local.right_child_mode);
         self.merkle_bus.interact(
             builder,
             [
-                right_tag,
+                right_direction,
                 local.parent_height - AB::F::ONE,
                 (local.parent_as_label * (AB::Expr::ONE + local.height_section))
                     + local.height_section,
@@ -216,7 +223,7 @@ impl<const DIGEST_WIDTH: usize> MemoryMerkleAir<DIGEST_WIDTH> {
             ]
             .into_iter()
             .chain(local.right_child_hash.into_iter().map(Into::into)),
-            right_count,
+            right_multiplicity,
         );
 
         let compress_fields = iter::empty()

--- a/crates/vm/src/system/memory/merkle/columns.rs
+++ b/crates/vm/src/system/memory/merkle/columns.rs
@@ -29,16 +29,15 @@ pub struct MemoryMerkleCols<T, const DIGEST_WIDTH: usize> {
     pub right_direction_different: T,
 
     // Reference-count adjustments for the child interactions of *initial* rows
-    // (`expand_direction` = 1); all four must be 0 when `expand_direction` != 1.
+    // (`expand_direction` = 1): the child's initial claim is consumed `1 + adj` times.
     //
-    // `*_extra_ref` = 1 means this row's final counterpart dd-borrows the child's initial
-    // hash, so this row consumes the child's initial claim twice (multiplicity -2).
-    // `*_absent_ref` = 1 means the child is untouched and this node has no final row to
-    // prop the reference, so this row consumes nothing (multiplicity 0).
-    pub left_extra_ref: T,
-    pub right_extra_ref: T,
-    pub left_absent_ref: T,
-    pub right_absent_ref: T,
+    // In {-1, 0, 1}; both must be 0 when `expand_direction` != 1.
+    //  `+1` = this row's final counterpart dd-borrows the child's initial hash, so this
+    //         row consumes the child's initial claim twice (multiplicity -2).
+    //  `-1` = the child is untouched and this node has no final row to prop the
+    //         reference, so this row consumes nothing (multiplicity 0).
+    pub left_adj_ref: T,
+    pub right_adj_ref: T,
 }
 
 #[derive(Debug, Clone, Copy, AlignedBorrow, StructReflection)]

--- a/crates/vm/src/system/memory/merkle/columns.rs
+++ b/crates/vm/src/system/memory/merkle/columns.rs
@@ -35,9 +35,6 @@ pub struct MemoryMerkleCols<T, const DIGEST_WIDTH: usize> {
     // hash, so this row consumes the child's initial claim twice (multiplicity -2).
     // `*_absent_ref` = 1 means the child is untouched and this node has no final row to
     // prop the reference, so this row consumes nothing (multiplicity 0).
-    //
-    // NOTE: until real dirtiness is enabled in tracegen, all four are always 0 and the
-    // child multiplicities reduce to the previous `-expand_direction`.
     pub left_extra_ref: T,
     pub right_extra_ref: T,
     pub left_absent_ref: T,

--- a/crates/vm/src/system/memory/merkle/columns.rs
+++ b/crates/vm/src/system/memory/merkle/columns.rs
@@ -23,21 +23,21 @@ pub struct MemoryMerkleCols<T, const DIGEST_WIDTH: usize> {
     pub left_child_hash: [T; DIGEST_WIDTH],
     pub right_child_hash: [T; DIGEST_WIDTH],
 
-    // indicate whether `expand_direction` is different from origin
-    // when `expand_direction` != -1, must be 0
-    pub left_direction_different: T,
-    pub right_direction_different: T,
-
-    // Reference-count adjustments for the child interactions of *initial* rows
-    // (`expand_direction` = 1): the child's initial claim is consumed `1 + adj` times.
+    // One child-reference descriptor per side, in {0, 1, 2}. Its meaning depends on
+    // `expand_direction`
     //
-    // In {-1, 0, 1}; both must be 0 when `expand_direction` != 1.
-    //  `+1` = this row's final counterpart dd-borrows the child's initial hash, so this
-    //         row consumes the child's initial claim twice (multiplicity -2).
-    //  `-1` = the child is untouched and this node has no final row to prop the
-    //         reference, so this row consumes nothing (multiplicity 0).
-    pub left_adj_ref: T,
-    pub right_adj_ref: T,
+    // Initial row (`expand_direction` = 1): number of times this row consumes the child's
+    // *initial* claim (count `-mode`) — one copy for a touched child, plus one more when
+    // this node's final row dd-borrows the child's initial hash. An untouched child of a
+    // node that emits no final row consumes nothing (`mode` = 0).
+    //
+    // Final row (`expand_direction` = -1): the "direction different" bit in {0, 1} —
+    // 1 iff the child is borrowed from the initial tree (untouched or touched-clean)
+    // rather than expanded as the final child. The count is `+1` regardless.
+    //
+    // Padding row (`expand_direction` = 0): must be 0.
+    pub left_child_mode: T,
+    pub right_child_mode: T,
 }
 
 #[derive(Debug, Clone, Copy, AlignedBorrow, StructReflection)]

--- a/crates/vm/src/system/memory/merkle/columns.rs
+++ b/crates/vm/src/system/memory/merkle/columns.rs
@@ -27,6 +27,21 @@ pub struct MemoryMerkleCols<T, const DIGEST_WIDTH: usize> {
     // when `expand_direction` != -1, must be 0
     pub left_direction_different: T,
     pub right_direction_different: T,
+
+    // Reference-count adjustments for the child interactions of *initial* rows
+    // (`expand_direction` = 1); all four must be 0 when `expand_direction` != 1.
+    //
+    // `*_extra_ref` = 1 means this row's final counterpart dd-borrows the child's initial
+    // hash, so this row consumes the child's initial claim twice (multiplicity -2).
+    // `*_absent_ref` = 1 means the child is untouched and this node has no final row to
+    // prop the reference, so this row consumes nothing (multiplicity 0).
+    //
+    // NOTE: until real dirtiness is enabled in tracegen, all four are always 0 and the
+    // child multiplicities reduce to the previous `-expand_direction`.
+    pub left_extra_ref: T,
+    pub right_extra_ref: T,
+    pub left_absent_ref: T,
+    pub right_absent_ref: T,
 }
 
 #[derive(Debug, Clone, Copy, AlignedBorrow, StructReflection)]

--- a/crates/vm/src/system/memory/merkle/columns.rs
+++ b/crates/vm/src/system/memory/merkle/columns.rs
@@ -23,17 +23,25 @@ pub struct MemoryMerkleCols<T, const DIGEST_WIDTH: usize> {
     pub left_child_hash: [T; DIGEST_WIDTH],
     pub right_child_hash: [T; DIGEST_WIDTH],
 
-    // One child-reference descriptor per side, in {0, 1, 2}. Its meaning depends on
-    // `expand_direction`
+    // Each child has a mode in {0, 1, 2}. Its meaning depends on `expand_direction`.
     //
-    // Initial row (`expand_direction` = 1): number of times this row consumes the child's
-    // *initial* claim (count `-mode`) — one copy for a touched child, plus one more when
-    // this node's final row dd-borrows the child's initial hash. An untouched child of a
-    // node that emits no final row consumes nothing (`mode` = 0).
+    // +---------+------------------+------------+------------------------------------+
+    // | Row     | expand_direction | mode       | Child interaction                  |
+    // +---------+------------------+------------+------------------------------------+
+    // | Initial |                1 | 0, 1, or 2 | Initial multiplicity is `-mode`    |
+    // | Final   |               -1 |          0 | Final multiplicity is `+1`         |
+    // | Final   |               -1 |          1 | Initial multiplicity is `+1`       |
+    // | Padding |                0 |          0 | None                               |
+    // +---------+------------------+------------+------------------------------------+
     //
-    // Final row (`expand_direction` = -1): the "direction different" bit in {0, 1} —
-    // 1 iff the child is borrowed from the initial tree (untouched or touched-clean)
-    // rather than expanded as the final child. The count is `+1` regardless.
+    // Initial row (`expand_direction` = 1): the negative multiplicity of the child's
+    // initial interaction — one for a touched child, plus one when this node's final row
+    // uses the child's initial hash. An untouched child of a node with no final row has
+    // mode 0.
+    //
+    // Final row (`expand_direction` = -1): mode 1 borrows the child from the initial
+    // tree (untouched or touched-clean), while mode 0 uses the final child. The
+    // multiplicity is `+1` in either case.
     //
     // Padding row (`expand_direction` = 0): must be 0.
     pub left_child_mode: T,

--- a/crates/vm/src/system/memory/merkle/columns.rs
+++ b/crates/vm/src/system/memory/merkle/columns.rs
@@ -23,27 +23,7 @@ pub struct MemoryMerkleCols<T, const DIGEST_WIDTH: usize> {
     pub left_child_hash: [T; DIGEST_WIDTH],
     pub right_child_hash: [T; DIGEST_WIDTH],
 
-    // Each child has a mode in {0, 1, 2}. Its meaning depends on `expand_direction`.
-    //
-    // +---------+------------------+------------+------------------------------------+
-    // | Row     | expand_direction | mode       | Child interaction                  |
-    // +---------+------------------+------------+------------------------------------+
-    // | Initial |                1 | 0, 1, or 2 | Initial multiplicity is `-mode`    |
-    // | Final   |               -1 |          0 | Final multiplicity is `+1`         |
-    // | Final   |               -1 |          1 | Initial multiplicity is `+1`       |
-    // | Padding |                0 |          0 | None                               |
-    // +---------+------------------+------------+------------------------------------+
-    //
-    // Initial row (`expand_direction` = 1): the negative multiplicity of the child's
-    // initial interaction — one for a touched child, plus one when this node's final row
-    // uses the child's initial hash. An untouched child of a node with no final row has
-    // mode 0.
-    //
-    // Final row (`expand_direction` = -1): mode 1 borrows the child from the initial
-    // tree (untouched or touched-clean), while mode 0 uses the final child. The
-    // multiplicity is `+1` in either case.
-    //
-    // Padding row (`expand_direction` = 0): must be 0.
+    // Encodes each child's Merkle-bus interaction for this row.
     pub left_child_mode: T,
     pub right_child_mode: T,
 }

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -69,7 +69,7 @@ impl<const DIGEST_WIDTH: usize, F: PrimeField32> MemoryMerkleChip<DIGEST_WIDTH, 
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
+pub(crate) fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
     memory: &AddressMap,
     md: &MemoryDimensions,
 ) -> Vec<(u64, [F; N])> {

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -398,8 +398,8 @@ fn expand_test_negative() {
         for row in chip_ctx.common_main.rows_mut() {
             let row: &mut MemoryMerkleCols<_, VM_DIGEST_WIDTH> = row.borrow_mut();
             if row.expand_direction == BabyBear::NEG_ONE {
-                row.left_direction_different = BabyBear::ZERO;
-                row.right_direction_different = BabyBear::ZERO;
+                row.left_child_mode = BabyBear::ZERO;
+                row.right_child_mode = BabyBear::ZERO;
             }
         }
     }
@@ -432,6 +432,17 @@ fn final_direction_different(direction: BabyBear, child_has_expansion: bool) -> 
         BabyBear::ONE
     } else {
         BabyBear::ZERO
+    }
+}
+
+/// The merged `*_child_mode` value for these hand-built fixtures. They reference each
+/// touched child exactly once, so an initial row's mode is always 1; a final row's mode
+/// is the dd bit (1 iff the child is borrowed from the initial tree); padding is 0.
+fn child_mode(direction: BabyBear, child_has_expansion: bool) -> BabyBear {
+    if direction == BabyBear::ONE {
+        BabyBear::ONE
+    } else {
+        final_direction_different(direction, child_has_expansion)
     }
 }
 
@@ -534,16 +545,14 @@ fn build_below_leaf_swap_subtree(
             parent_hash,
             left_child_hash,
             right_child_hash,
-            left_direction_different: final_direction_different(
+            left_child_mode: child_mode(
                 direction,
                 left_has_path && child_depth < BELOW_LEAF_PATH_LEN,
             ),
-            right_direction_different: final_direction_different(
+            right_child_mode: child_mode(
                 direction,
                 right_has_path && child_depth < BELOW_LEAF_PATH_LEN,
             ),
-            left_adj_ref: BabyBear::ZERO,
-            right_adj_ref: BabyBear::ZERO,
         });
 
         parent_hash
@@ -664,10 +673,8 @@ fn build_counterexample_canonical_rows(
                 parent_hash: initial_hash,
                 left_child_hash: left_initial_hash,
                 right_child_hash: right_initial_hash,
-                left_direction_different: BabyBear::ZERO,
-                right_direction_different: BabyBear::ZERO,
-                left_adj_ref: BabyBear::ZERO,
-                right_adj_ref: BabyBear::ZERO,
+                left_child_mode: BabyBear::ONE,
+                right_child_mode: BabyBear::ONE,
             });
             rows_by_height[height].push(MemoryMerkleCols {
                 expand_direction: BabyBear::NEG_ONE,
@@ -680,10 +687,8 @@ fn build_counterexample_canonical_rows(
                 parent_hash: final_hash,
                 left_child_hash: left_final_hash,
                 right_child_hash: right_final_hash,
-                left_direction_different: BabyBear::from_bool(!left_changed),
-                right_direction_different: BabyBear::from_bool(!right_changed),
-                left_adj_ref: BabyBear::ZERO,
-                right_adj_ref: BabyBear::ZERO,
+                left_child_mode: BabyBear::from_bool(!left_changed),
+                right_child_mode: BabyBear::from_bool(!right_changed),
             });
 
             next.insert(parent_prefix, (initial_hash, final_hash));
@@ -729,10 +734,8 @@ fn build_hidden_leaf_expansion_row(
             parent_hash,
             left_child_hash: below_leaf_root,
             right_child_hash: unchanged_sibling_hash,
-            left_direction_different: final_direction_different(direction, true),
-            right_direction_different: final_direction_different(direction, false),
-            left_adj_ref: BabyBear::ZERO,
-            right_adj_ref: BabyBear::ZERO,
+            left_child_mode: child_mode(direction, true),
+            right_child_mode: child_mode(direction, false),
         },
     )
 }
@@ -860,10 +863,8 @@ fn build_below_leaf_swap_fraud_merkle(
             parent_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
             left_child_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
             right_child_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
-            left_direction_different: BabyBear::ZERO,
-            right_direction_different: BabyBear::ZERO,
-            left_adj_ref: BabyBear::ZERO,
-            right_adj_ref: BabyBear::ZERO,
+            left_child_mode: BabyBear::ZERO,
+            right_child_mode: BabyBear::ZERO,
         });
     }
 

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -95,8 +95,9 @@ fn test(
             touched_labels.contains(&(*address_space, pointer / VM_DIGEST_WIDTH as u32))
         })
         .collect();
-    // Mirror the boundary chip's dirtiness definition: a touched leaf is dirty iff its
-    // final values differ from its initial values.
+    // Dirtiness is per *write* and the test scenario defines its write pattern here:
+    // exactly the touched leaves whose values changed are treated as written (the
+    // minimal valid dirty set; any superset would also be sound).
     let dirty_leaves: DirtyLeaves = final_partition
         .iter()
         .filter(|((address_space, pointer), values)| {

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -510,6 +510,10 @@ fn build_below_leaf_swap_subtree(
                 direction,
                 right_has_path && child_depth < BELOW_LEAF_PATH_LEN,
             ),
+            left_extra_ref: BabyBear::ZERO,
+            right_extra_ref: BabyBear::ZERO,
+            left_absent_ref: BabyBear::ZERO,
+            right_absent_ref: BabyBear::ZERO,
         });
 
         parent_hash
@@ -632,6 +636,10 @@ fn build_counterexample_canonical_rows(
                 right_child_hash: right_initial_hash,
                 left_direction_different: BabyBear::ZERO,
                 right_direction_different: BabyBear::ZERO,
+                left_extra_ref: BabyBear::ZERO,
+                right_extra_ref: BabyBear::ZERO,
+                left_absent_ref: BabyBear::ZERO,
+                right_absent_ref: BabyBear::ZERO,
             });
             rows_by_height[height].push(MemoryMerkleCols {
                 expand_direction: BabyBear::NEG_ONE,
@@ -646,6 +654,10 @@ fn build_counterexample_canonical_rows(
                 right_child_hash: right_final_hash,
                 left_direction_different: BabyBear::from_bool(!left_changed),
                 right_direction_different: BabyBear::from_bool(!right_changed),
+                left_extra_ref: BabyBear::ZERO,
+                right_extra_ref: BabyBear::ZERO,
+                left_absent_ref: BabyBear::ZERO,
+                right_absent_ref: BabyBear::ZERO,
             });
 
             next.insert(parent_prefix, (initial_hash, final_hash));
@@ -693,6 +705,10 @@ fn build_hidden_leaf_expansion_row(
             right_child_hash: unchanged_sibling_hash,
             left_direction_different: final_direction_different(direction, true),
             right_direction_different: final_direction_different(direction, false),
+            left_extra_ref: BabyBear::ZERO,
+            right_extra_ref: BabyBear::ZERO,
+            left_absent_ref: BabyBear::ZERO,
+            right_absent_ref: BabyBear::ZERO,
         },
     )
 }
@@ -822,6 +838,10 @@ fn build_below_leaf_swap_fraud_merkle(
             right_child_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
             left_direction_different: BabyBear::ZERO,
             right_direction_different: BabyBear::ZERO,
+            left_extra_ref: BabyBear::ZERO,
+            right_extra_ref: BabyBear::ZERO,
+            left_absent_ref: BabyBear::ZERO,
+            right_absent_ref: BabyBear::ZERO,
         });
     }
 

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -32,6 +32,7 @@ use crate::{
                 MemoryMerkleChip, MemoryMerkleCols, MerkleTree,
             },
             online::{GuestMemory, LinearMemory},
+            persistent::DirtyLeaves,
             ptr_bits_from_address_height, AddressMap, MemoryImage,
         },
         poseidon2::Poseidon2PeripheryChip,
@@ -88,13 +89,30 @@ fn test(
                 ((address_space, label * (VM_DIGEST_WIDTH as u32)), values)
             })
             .collect();
-    let final_partition = final_partition
+    let final_partition: BTreeMap<_, _> = final_partition
         .into_iter()
         .filter(|((address_space, pointer), _)| {
             touched_labels.contains(&(*address_space, pointer / VM_DIGEST_WIDTH as u32))
         })
         .collect();
-    chip.finalize(initial_memory, &final_partition, &hash_test_chip);
+    // Mirror the boundary chip's dirtiness definition: a touched leaf is dirty iff its
+    // final values differ from its initial values.
+    let dirty_leaves: DirtyLeaves = final_partition
+        .iter()
+        .filter(|((address_space, pointer), values)| {
+            let init_values: [F; VM_DIGEST_WIDTH] = array::from_fn(|i| unsafe {
+                initial_memory.get_f::<F>(*address_space, *pointer + i as u32)
+            });
+            init_values != **values
+        })
+        .map(|(&key, _)| key)
+        .collect();
+    chip.finalize(
+        initial_memory,
+        &final_partition,
+        &dirty_leaves,
+        &hash_test_chip,
+    );
 
     assert_eq!(
         chip.final_state.as_ref().unwrap().final_root,
@@ -147,17 +165,20 @@ fn test(
             address_label,
             initial_values,
         );
-        let final_values = *final_partition
-            .get(&(address_space, address_label * (VM_DIGEST_WIDTH as u32)))
-            .unwrap();
-        interaction(
-            PermutationInteractionType::Send,
-            true,
-            0,
-            as_label,
-            address_label,
-            final_values,
-        );
+        let leaf_ptr = address_label * (VM_DIGEST_WIDTH as u32);
+        let final_values = *final_partition.get(&(address_space, leaf_ptr)).unwrap();
+        // Like the real boundary chip, the dummy references a leaf's final state only
+        // when the leaf is dirty (the final-claim multiplicity is `is_dirty`).
+        if dirty_leaves.contains(&(address_space, leaf_ptr)) {
+            interaction(
+                PermutationInteractionType::Send,
+                true,
+                0,
+                as_label,
+                address_label,
+                final_values,
+            );
+        }
     }
 
     while !(dummy_interaction_trace_rows.len() / (dummy_interaction_air.field_width() + 1))
@@ -315,7 +336,12 @@ fn expand_test_no_accesses() {
         COMPRESSION_BUS,
     );
 
-    chip.finalize(&memory, &BTreeMap::new(), &hash_test_chip);
+    chip.finalize(
+        &memory,
+        &BTreeMap::new(),
+        &DirtyLeaves::default(),
+        &hash_test_chip,
+    );
     let trace = chip.generate_proving_ctx();
     test_cpu_engine()
         .run_test(
@@ -360,7 +386,12 @@ fn expand_test_negative() {
         COMPRESSION_BUS,
     );
 
-    chip.finalize(&memory, &BTreeMap::new(), &hash_test_chip);
+    chip.finalize(
+        &memory,
+        &BTreeMap::new(),
+        &DirtyLeaves::default(),
+        &hash_test_chip,
+    );
     let mut chip_ctx = chip.generate_proving_ctx();
     {
         for row in chip_ctx.common_main.rows_mut() {
@@ -1018,7 +1049,14 @@ fn expand_test_label_rebinding_attack() {
 
     let merkle_bus = PermutationCheckBus::new(MEMORY_MERKLE_BUS);
     let mut chip = MemoryMerkleChip::<VM_DIGEST_WIDTH, _>::new(md, merkle_bus, COMPRESSION_BUS);
-    chip.finalize(&memory.memory, &final_partition_for_chip, &hash_test_chip);
+    // The touched leaf's final values equal its initial ones (the write happened before
+    // the initial snapshot), so no leaf is dirty.
+    chip.finalize(
+        &memory.memory,
+        &final_partition_for_chip,
+        &DirtyLeaves::default(),
+        &hash_test_chip,
+    );
     let mut chip_ctx = chip.generate_proving_ctx();
 
     {
@@ -1097,14 +1135,8 @@ fn expand_test_label_rebinding_attack() {
             address_label,
             values,
         );
-        interaction(
-            PermutationInteractionType::Send,
-            true,
-            0,
-            as_label,
-            address_label,
-            values,
-        );
+        // No final-state claim: the leaf is touched but clean, and a real boundary row
+        // would have `is_dirty = 0`.
     }
 
     while !(dummy_interaction_trace_rows.len() / (dummy_interaction_air.field_width() + 1))

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -542,10 +542,8 @@ fn build_below_leaf_swap_subtree(
                 direction,
                 right_has_path && child_depth < BELOW_LEAF_PATH_LEN,
             ),
-            left_extra_ref: BabyBear::ZERO,
-            right_extra_ref: BabyBear::ZERO,
-            left_absent_ref: BabyBear::ZERO,
-            right_absent_ref: BabyBear::ZERO,
+            left_adj_ref: BabyBear::ZERO,
+            right_adj_ref: BabyBear::ZERO,
         });
 
         parent_hash
@@ -668,10 +666,8 @@ fn build_counterexample_canonical_rows(
                 right_child_hash: right_initial_hash,
                 left_direction_different: BabyBear::ZERO,
                 right_direction_different: BabyBear::ZERO,
-                left_extra_ref: BabyBear::ZERO,
-                right_extra_ref: BabyBear::ZERO,
-                left_absent_ref: BabyBear::ZERO,
-                right_absent_ref: BabyBear::ZERO,
+                left_adj_ref: BabyBear::ZERO,
+                right_adj_ref: BabyBear::ZERO,
             });
             rows_by_height[height].push(MemoryMerkleCols {
                 expand_direction: BabyBear::NEG_ONE,
@@ -686,10 +682,8 @@ fn build_counterexample_canonical_rows(
                 right_child_hash: right_final_hash,
                 left_direction_different: BabyBear::from_bool(!left_changed),
                 right_direction_different: BabyBear::from_bool(!right_changed),
-                left_extra_ref: BabyBear::ZERO,
-                right_extra_ref: BabyBear::ZERO,
-                left_absent_ref: BabyBear::ZERO,
-                right_absent_ref: BabyBear::ZERO,
+                left_adj_ref: BabyBear::ZERO,
+                right_adj_ref: BabyBear::ZERO,
             });
 
             next.insert(parent_prefix, (initial_hash, final_hash));
@@ -737,10 +731,8 @@ fn build_hidden_leaf_expansion_row(
             right_child_hash: unchanged_sibling_hash,
             left_direction_different: final_direction_different(direction, true),
             right_direction_different: final_direction_different(direction, false),
-            left_extra_ref: BabyBear::ZERO,
-            right_extra_ref: BabyBear::ZERO,
-            left_absent_ref: BabyBear::ZERO,
-            right_absent_ref: BabyBear::ZERO,
+            left_adj_ref: BabyBear::ZERO,
+            right_adj_ref: BabyBear::ZERO,
         },
     )
 }
@@ -870,10 +862,8 @@ fn build_below_leaf_swap_fraud_merkle(
             right_child_hash: [BabyBear::ZERO; VM_DIGEST_WIDTH],
             left_direction_different: BabyBear::ZERO,
             right_direction_different: BabyBear::ZERO,
-            left_extra_ref: BabyBear::ZERO,
-            right_extra_ref: BabyBear::ZERO,
-            left_absent_ref: BabyBear::ZERO,
-            right_absent_ref: BabyBear::ZERO,
+            left_adj_ref: BabyBear::ZERO,
+            right_adj_ref: BabyBear::ZERO,
         });
     }
 

--- a/crates/vm/src/system/memory/merkle/tests/mod.rs
+++ b/crates/vm/src/system/memory/merkle/tests/mod.rs
@@ -436,8 +436,8 @@ fn final_direction_different(direction: BabyBear, child_has_expansion: bool) -> 
 }
 
 /// The merged `*_child_mode` value for these hand-built fixtures. They reference each
-/// touched child exactly once, so an initial row's mode is always 1; a final row's mode
-/// is the dd bit (1 iff the child is borrowed from the initial tree); padding is 0.
+/// touched child exactly once, so an initial row's mode is always 1. A final row uses
+/// mode 1 for an initial child state and mode 0 for a final child state. Padding uses 0.
 fn child_mode(direction: BabyBear, child_has_expansion: bool) -> BabyBear {
     if direction == BabyBear::ONE {
         BabyBear::ONE

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -12,6 +12,7 @@ use crate::{
     system::{
         memory::{
             merkle::{tree::MerkleTree, FinalState, MemoryMerkleChip, MemoryMerkleCols},
+            persistent::DirtyLeaves,
             Equipartition, MemoryImage,
         },
         poseidon2::{
@@ -21,17 +22,22 @@ use crate::{
 };
 
 impl<const DIGEST_WIDTH: usize, F: PrimeField32> MemoryMerkleChip<DIGEST_WIDTH, F> {
+    /// `dirty_leaves` must be exactly the set the boundary chip committed to (returned by
+    /// its `finalize`): the two chips' merkle-bus interactions balance only if they agree
+    /// on which leaves are dirty.
     #[instrument(name = "merkle_finalize", level = "debug", skip_all)]
     pub(crate) fn finalize(
         &mut self,
         initial_memory: &MemoryImage,
         final_memory: &Equipartition<F, DIGEST_WIDTH>,
+        dirty_leaves: &DirtyLeaves,
         hasher: &impl HasherChip<DIGEST_WIDTH, F>,
     ) {
         assert!(self.final_state.is_none(), "Merkle chip already finalized");
         let memory_dimensions = &self.air.memory_dimensions;
         let mut tree = MerkleTree::from_memory(initial_memory, memory_dimensions, hasher);
-        self.final_state = Some(tree.finalize(hasher, final_memory, memory_dimensions));
+        self.final_state =
+            Some(tree.finalize(hasher, final_memory, dirty_leaves, memory_dimensions));
         self.top_tree = tree.top_tree(memory_dimensions.addr_space_height);
     }
 }

--- a/crates/vm/src/system/memory/merkle/trace.rs
+++ b/crates/vm/src/system/memory/merkle/trace.rs
@@ -22,9 +22,9 @@ use crate::{
 };
 
 impl<const DIGEST_WIDTH: usize, F: PrimeField32> MemoryMerkleChip<DIGEST_WIDTH, F> {
-    /// `dirty_leaves` must be exactly the set the boundary chip committed to (returned by
-    /// its `finalize`): the two chips' merkle-bus interactions balance only if they agree
-    /// on which leaves are dirty.
+    /// `dirty_leaves` must be exactly the set the boundary chip committed to (the
+    /// written leaves tracked by `TracingMemory`): the two chips' merkle-bus
+    /// interactions balance only if they agree on which leaves are dirty.
     #[instrument(name = "merkle_finalize", level = "debug", skip_all)]
     pub(crate) fn finalize(
         &mut self,

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -31,6 +31,18 @@ fn parent_label_parts(
     (parent_as_label, parent_address_label)
 }
 
+/// Reference-count adjustment for a child of an initial row: the child's initial claim
+/// is consumed `1 + adj` times (see `MemoryMerkleCols::left_adj_ref`).
+fn child_adj_ref<F: PrimeField32>(emits_final: bool, changed: bool, dirty: bool) -> F {
+    if emits_final && changed && !dirty {
+        F::ONE
+    } else if !emits_final && !changed {
+        F::NEG_ONE
+    } else {
+        F::ZERO
+    }
+}
+
 #[derive(Debug)]
 pub struct MerkleTree<F, const DIGEST_WIDTH: usize> {
     /// Height of the tree -- the root is the only node at height `height`,
@@ -225,18 +237,21 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 right_child_hash: *old_right,
                                 left_direction_different: F::ZERO,
                                 right_direction_different: F::ZERO,
-                                // Reference counts (see MemoryMerkleCols docs): a
-                                // touched-clean child that our final row dd-borrows is
-                                // consumed twice; an untouched child with no final row
-                                // to prop it is not consumed.
-                                left_extra_ref: F::from_bool(
-                                    emits_final && changed_left && !left_dirty,
+                                // Reference-count adjustments (see MemoryMerkleCols
+                                // docs): +1 when our final row dd-borrows a
+                                // touched-clean child (consumed twice), -1 when the
+                                // child is untouched and no final row props it
+                                // (consumed zero times).
+                                left_adj_ref: child_adj_ref::<F>(
+                                    emits_final,
+                                    changed_left,
+                                    left_dirty,
                                 ),
-                                right_extra_ref: F::from_bool(
-                                    emits_final && changed_right && !right_dirty,
+                                right_adj_ref: child_adj_ref::<F>(
+                                    emits_final,
+                                    changed_right,
+                                    right_dirty,
                                 ),
-                                left_absent_ref: F::from_bool(!emits_final && !changed_left),
-                                right_absent_ref: F::from_bool(!emits_final && !changed_right),
                             };
                             let final_row = emits_final.then(|| MemoryMerkleCols {
                                 expand_direction: F::NEG_ONE,
@@ -254,10 +269,8 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 // tree.
                                 left_direction_different: F::from_bool(!left_dirty),
                                 right_direction_different: F::from_bool(!right_dirty),
-                                left_extra_ref: F::ZERO,
-                                right_extra_ref: F::ZERO,
-                                left_absent_ref: F::ZERO,
-                                right_absent_ref: F::ZERO,
+                                left_adj_ref: F::ZERO,
+                                right_adj_ref: F::ZERO,
                             });
                             (
                                 (par_index, combined, par_old_values, node_dirty),
@@ -346,10 +359,13 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
         if touched.is_empty() {
             // The artificial touch seeds the walk so the root pair exists, but there is
             // no boundary row supplying the leaf's claim, so the height-1 initial row
-            // (rows[0]) must treat the leaf as *untouched*: no extra reference if the
-            // row's final counterpart exists (root case), an absent reference otherwise.
-            rows[0].left_extra_ref = F::ZERO;
-            rows[0].left_absent_ref = F::from_bool(rows[0].is_root == F::ZERO);
+            // (rows[0]) must treat the leaf as *untouched*: one dd-borrowed reference if
+            // the row's final counterpart exists (root case), none otherwise.
+            rows[0].left_adj_ref = if rows[0].is_root == F::ZERO {
+                F::NEG_ONE
+            } else {
+                F::ZERO
+            };
         }
         let final_root = self.get_node(1);
         FinalState {

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -31,16 +31,12 @@ fn parent_label_parts(
     (parent_as_label, parent_address_label)
 }
 
-/// Reference-count adjustment for a child of an initial row: the child's initial claim
-/// is consumed `1 + adj` times (see `MemoryMerkleCols::left_adj_ref`).
-fn child_adj_ref<F: PrimeField32>(emits_final: bool, changed: bool, dirty: bool) -> F {
-    if emits_final && changed && !dirty {
-        F::ONE
-    } else if !emits_final && !changed {
-        F::NEG_ONE
-    } else {
-        F::ZERO
-    }
+/// The `*_child_mode` value for an *initial* row (see `MemoryMerkleCols`): how many
+/// times the row references the child's initial claim, in {0, 1, 2}. One reference if
+/// the child is on the touched path, plus one if this node's final row dd-borrows it
+/// (touched-clean or untouched child of a node that emits a final row).
+fn initial_child_mode<F: PrimeField32>(emits_final: bool, changed: bool, dirty: bool) -> F {
+    F::from_bool(changed) + F::from_bool(emits_final && !dirty)
 }
 
 #[derive(Debug)]
@@ -235,19 +231,14 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 parent_hash: par_old_values,
                                 left_child_hash: *old_left,
                                 right_child_hash: *old_right,
-                                left_direction_different: F::ZERO,
-                                right_direction_different: F::ZERO,
-                                // Reference-count adjustments (see MemoryMerkleCols
-                                // docs): +1 when our final row dd-borrows a
-                                // touched-clean child (consumed twice), -1 when the
-                                // child is untouched and no final row props it
-                                // (consumed zero times).
-                                left_adj_ref: child_adj_ref::<F>(
+                                // Initial-row child mode: reference count in {0, 1, 2}
+                                // (see MemoryMerkleCols).
+                                left_child_mode: initial_child_mode::<F>(
                                     emits_final,
                                     changed_left,
                                     left_dirty,
                                 ),
-                                right_adj_ref: child_adj_ref::<F>(
+                                right_child_mode: initial_child_mode::<F>(
                                     emits_final,
                                     changed_right,
                                     right_dirty,
@@ -264,13 +255,11 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 parent_hash: combined,
                                 left_child_hash: *left,
                                 right_child_hash: *right,
-                                // dd = "not expanded finally": untouched *or*
-                                // touched-clean children are borrowed from the initial
-                                // tree.
-                                left_direction_different: F::from_bool(!left_dirty),
-                                right_direction_different: F::from_bool(!right_dirty),
-                                left_adj_ref: F::ZERO,
-                                right_adj_ref: F::ZERO,
+                                // Final-row child mode = dd bit: 1 when the child is
+                                // "not expanded finally" (untouched *or* touched-clean,
+                                // borrowed from the initial tree), 0 when it is dirty.
+                                left_child_mode: F::from_bool(!left_dirty),
+                                right_child_mode: F::from_bool(!right_dirty),
                             });
                             (
                                 (par_index, combined, par_old_values, node_dirty),
@@ -360,12 +349,9 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
             // The artificial touch seeds the walk so the root pair exists, but there is
             // no boundary row supplying the leaf's claim, so the height-1 initial row
             // (rows[0]) must treat the leaf as *untouched*: one dd-borrowed reference if
-            // the row's final counterpart exists (root case), none otherwise.
-            rows[0].left_adj_ref = if rows[0].is_root == F::ZERO {
-                F::NEG_ONE
-            } else {
-                F::ZERO
-            };
+            // the row's final counterpart exists (root case, mode 1), none otherwise
+            // (mode 0).
+            rows[0].left_child_mode = F::from_bool(rows[0].is_root == F::ONE);
         }
         let final_root = self.get_node(1);
         FinalState {

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -197,6 +197,10 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                         right_child_hash: *old_right,
                                         left_direction_different: F::ZERO,
                                         right_direction_different: F::ZERO,
+                                        left_extra_ref: F::ZERO,
+                                        right_extra_ref: F::ZERO,
+                                        left_absent_ref: F::ZERO,
+                                        right_absent_ref: F::ZERO,
                                     },
                                     MemoryMerkleCols {
                                         expand_direction: F::NEG_ONE,
@@ -211,6 +215,10 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                         right_child_hash: *right,
                                         left_direction_different: F::from_bool(!changed_left),
                                         right_direction_different: F::from_bool(!changed_right),
+                                        left_extra_ref: F::ZERO,
+                                        right_extra_ref: F::ZERO,
+                                        left_absent_ref: F::ZERO,
+                                        right_absent_ref: F::ZERO,
                                     },
                                 ],
                             )

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -8,7 +8,8 @@ use super::{FinalState, MemoryMerkleCols};
 use crate::{
     arch::hasher::{Hasher, HasherChip},
     system::memory::{
-        dimensions::MemoryDimensions, merkle::memory_to_vec_partition, AddressMap, Equipartition,
+        dimensions::MemoryDimensions, merkle::memory_to_vec_partition, persistent::DirtyLeaves,
+        AddressMap, Equipartition,
     },
 };
 
@@ -76,9 +77,15 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
 
     #[allow(clippy::type_complexity)]
     /// Applies leaf updates upward to the root.
+    ///
+    /// Each layer entry carries an `is_dirty` bit: for leaves it originates at the
+    /// boundary chip (value inequality), and for inner nodes it is the OR of the
+    /// children's bits. A node emits a final-direction row (and records a final
+    /// compression) only if it is dirty — or if it is the root, whose final row is
+    /// pinned to the public values.
     fn process_layers<CompressFn>(
         &mut self,
-        layer: Vec<(u64, [F; DIGEST_WIDTH])>,
+        layer: Vec<(u64, [F; DIGEST_WIDTH], bool)>,
         md: &MemoryDimensions,
         mut rows: Option<&mut Vec<MemoryMerkleCols<F, DIGEST_WIDTH>>>,
         compress: CompressFn,
@@ -92,16 +99,16 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
         new_entries.reserve(initial_len.max(self.height));
         let mut layer = new_entries
             .par_iter()
-            .map(|(index, values)| {
+            .map(|(index, values, is_dirty)| {
                 let old_values = self.nodes.get(index).unwrap_or(&self.zero_nodes[0]);
-                (*index, *values, *old_values)
+                (*index, *values, *old_values, *is_dirty)
             })
             .collect::<Vec<_>>();
         for height in 1..=self.height {
             let new_layer = layer
                 .iter()
                 .enumerate()
-                .filter_map(|(i, (index, values, old_values))| {
+                .filter_map(|(i, (index, values, old_values, is_dirty))| {
                     if i > 0 && layer[i - 1].0 ^ 1 == *index {
                         return None;
                     }
@@ -109,16 +116,16 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                     let par_index = index >> 1;
 
                     if i + 1 < layer.len() && layer[i + 1].0 == index ^ 1 {
-                        let (_, sibling_values, sibling_old_values) = &layer[i + 1];
+                        let (_, sibling_values, sibling_old_values, sibling_dirty) = &layer[i + 1];
                         Some((
                             par_index,
-                            Some((values, old_values)),
-                            Some((sibling_values, sibling_old_values)),
+                            Some((values, old_values, *is_dirty)),
+                            Some((sibling_values, sibling_old_values, *sibling_dirty)),
                         ))
                     } else if index & 1 == 0 {
-                        Some((par_index, Some((values, old_values)), None))
+                        Some((par_index, Some((values, old_values, *is_dirty)), None))
                     } else {
-                        Some((par_index, None, Some((values, old_values))))
+                        Some((par_index, None, Some((values, old_values, *is_dirty))))
                     }
                 })
                 .collect::<Vec<_>>();
@@ -129,110 +136,156 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                         .into_par_iter()
                         .map(|(par_index, left, right)| {
                             let left_node;
-                            let left = if let Some(left) = left {
-                                left.0
+                            let (left, left_dirty) = if let Some((values, _, dirty)) = left {
+                                (values, dirty)
                             } else {
                                 left_node = self.get_node_at_height(2 * par_index, height - 1);
-                                &left_node
+                                (&left_node, false)
                             };
                             let right_node;
-                            let right = if let Some(right) = right {
-                                right.0
+                            let (right, right_dirty) = if let Some((values, _, dirty)) = right {
+                                (values, dirty)
                             } else {
                                 right_node = self.get_node_at_height(2 * par_index + 1, height - 1);
-                                &right_node
+                                (&right_node, false)
                             };
                             let combined = compress(left, right);
                             let par_old_values = self.get_node_at_height(par_index, height);
-                            (par_index, combined, par_old_values)
+                            (
+                                par_index,
+                                combined,
+                                par_old_values,
+                                left_dirty || right_dirty,
+                            )
                         })
                         .collect();
                 }
                 Some(ref mut rows) => {
                     let height_section = F::from_bool(height > md.address_height);
                     let parent_height = F::from_usize(height);
-                    let is_root = F::from_bool(height == md.overall_height());
+                    let is_root = height == md.overall_height();
                     let (tmp, new_rows): (
-                        Vec<(u64, [F; DIGEST_WIDTH], [F; DIGEST_WIDTH])>,
-                        Vec<[_; 2]>,
+                        Vec<(u64, [F; DIGEST_WIDTH], [F; DIGEST_WIDTH], bool)>,
+                        Vec<_>,
                     ) = new_layer
                         .into_par_iter()
                         .map(|(par_index, left, right)| {
                             let (parent_as_label, parent_address_label) =
                                 parent_label_parts(md, self.height, par_index, height);
+                            // `changed_*` says the child is on the touched path (its
+                            // layer entry exists); `*_dirty` says its value actually
+                            // changed. Untouched children carry `dirty = false`.
                             let left_node;
-                            let (left, old_left, changed_left) = match left {
-                                Some((left, old_left)) => (left, old_left, true),
+                            let (left, old_left, left_dirty, changed_left) = match left {
+                                Some((left, old_left, dirty)) => (left, old_left, dirty, true),
                                 None => {
                                     left_node = self.get_node_at_height(2 * par_index, height - 1);
-                                    (&left_node, &left_node, false)
+                                    (&left_node, &left_node, false, false)
                                 }
                             };
                             let right_node;
-                            let (right, old_right, changed_right) = match right {
-                                Some((right, old_right)) => (right, old_right, true),
+                            let (right, old_right, right_dirty, changed_right) = match right {
+                                Some((right, old_right, dirty)) => (right, old_right, dirty, true),
                                 None => {
                                     right_node =
                                         self.get_node_at_height(2 * par_index + 1, height - 1);
-                                    (&right_node, &right_node, false)
+                                    (&right_node, &right_node, false, false)
                                 }
                             };
-                            let combined = compress(left, right);
-                            // Record the old child pair on the compression bus.
-                            compress(old_left, old_right);
+                            let node_dirty = left_dirty || right_dirty;
+                            // Final rows are emitted only for dirty nodes, except the
+                            // root: the AIR pins the first two rows to the initial/final
+                            // root public values, so the root's final row always exists.
+                            // A forced root row does not redefine a clean root as dirty:
+                            // `node_dirty`, not `emits_final`, is what propagates upward.
+                            let emits_final = node_dirty || is_root;
+
                             let par_old_values = self.get_node_at_height(par_index, height);
+                            // Record the initial (old-children) compression for the
+                            // initial row.
+                            compress(old_left, old_right);
+                            // Only emitted final rows claim a final compression. A clean
+                            // node's new hash equals its stored one, so skip hashing.
+                            let combined = if emits_final {
+                                compress(left, right)
+                            } else {
+                                par_old_values
+                            };
+
+                            let initial_row = MemoryMerkleCols {
+                                expand_direction: F::ONE,
+                                height_section,
+                                parent_height,
+                                parent_height_inv: parent_height.inverse(),
+                                is_root: F::from_bool(is_root),
+                                parent_as_label: F::from_u32(parent_as_label),
+                                parent_address_label: F::from_u32(parent_address_label),
+                                parent_hash: par_old_values,
+                                left_child_hash: *old_left,
+                                right_child_hash: *old_right,
+                                left_direction_different: F::ZERO,
+                                right_direction_different: F::ZERO,
+                                // Reference counts (see MemoryMerkleCols docs): a
+                                // touched-clean child that our final row dd-borrows is
+                                // consumed twice; an untouched child with no final row
+                                // to prop it is not consumed.
+                                left_extra_ref: F::from_bool(
+                                    emits_final && changed_left && !left_dirty,
+                                ),
+                                right_extra_ref: F::from_bool(
+                                    emits_final && changed_right && !right_dirty,
+                                ),
+                                left_absent_ref: F::from_bool(!emits_final && !changed_left),
+                                right_absent_ref: F::from_bool(!emits_final && !changed_right),
+                            };
+                            let final_row = emits_final.then(|| MemoryMerkleCols {
+                                expand_direction: F::NEG_ONE,
+                                height_section,
+                                parent_height,
+                                parent_height_inv: parent_height.inverse(),
+                                is_root: F::from_bool(is_root),
+                                parent_as_label: F::from_u32(parent_as_label),
+                                parent_address_label: F::from_u32(parent_address_label),
+                                parent_hash: combined,
+                                left_child_hash: *left,
+                                right_child_hash: *right,
+                                // dd = "not expanded finally": untouched *or*
+                                // touched-clean children are borrowed from the initial
+                                // tree.
+                                left_direction_different: F::from_bool(!left_dirty),
+                                right_direction_different: F::from_bool(!right_dirty),
+                                left_extra_ref: F::ZERO,
+                                right_extra_ref: F::ZERO,
+                                left_absent_ref: F::ZERO,
+                                right_absent_ref: F::ZERO,
+                            });
                             (
-                                (par_index, combined, par_old_values),
-                                [
-                                    MemoryMerkleCols {
-                                        expand_direction: F::ONE,
-                                        height_section,
-                                        parent_height,
-                                        parent_height_inv: parent_height.inverse(),
-                                        is_root,
-                                        parent_as_label: F::from_u32(parent_as_label),
-                                        parent_address_label: F::from_u32(parent_address_label),
-                                        parent_hash: par_old_values,
-                                        left_child_hash: *old_left,
-                                        right_child_hash: *old_right,
-                                        left_direction_different: F::ZERO,
-                                        right_direction_different: F::ZERO,
-                                        left_extra_ref: F::ZERO,
-                                        right_extra_ref: F::ZERO,
-                                        left_absent_ref: F::ZERO,
-                                        right_absent_ref: F::ZERO,
-                                    },
-                                    MemoryMerkleCols {
-                                        expand_direction: F::NEG_ONE,
-                                        height_section,
-                                        parent_height,
-                                        parent_height_inv: parent_height.inverse(),
-                                        is_root,
-                                        parent_as_label: F::from_u32(parent_as_label),
-                                        parent_address_label: F::from_u32(parent_address_label),
-                                        parent_hash: combined,
-                                        left_child_hash: *left,
-                                        right_child_hash: *right,
-                                        left_direction_different: F::from_bool(!changed_left),
-                                        right_direction_different: F::from_bool(!changed_right),
-                                        left_extra_ref: F::ZERO,
-                                        right_extra_ref: F::ZERO,
-                                        left_absent_ref: F::ZERO,
-                                        right_absent_ref: F::ZERO,
-                                    },
-                                ],
+                                (par_index, combined, par_old_values, node_dirty),
+                                (initial_row, final_row),
                             )
                         })
                         .unzip();
-                    rows.extend(new_rows.into_iter().flatten());
+                    rows.extend(
+                        new_rows
+                            .into_iter()
+                            .flat_map(|(initial, fin)| std::iter::once(initial).chain(fin)),
+                    );
                     layer = tmp;
                 }
             }
-            new_entries.extend(layer.iter().map(|(idx, values, _)| (*idx, *values)));
+            new_entries.extend(
+                layer
+                    .iter()
+                    .map(|(idx, values, _, is_dirty)| (*idx, *values, *is_dirty)),
+            );
         }
 
         self.nodes.reserve(new_entries.len());
-        self.nodes.extend(new_entries);
+        self.nodes.extend(
+            new_entries
+                .into_iter()
+                .map(|(idx, values, _)| (idx, values)),
+        );
     }
 
     pub fn from_memory(
@@ -243,16 +296,20 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
         let mut tree = Self::new(md.overall_height(), hasher);
         let layer: Vec<_> = memory_to_vec_partition(memory, md)
             .par_iter()
-            .map(|(idx, v)| ((1 << tree.height) + idx, hasher.hash(v)))
+            .map(|(idx, v)| ((1 << tree.height) + idx, hasher.hash(v), false))
             .collect();
         tree.process_layers(layer, md, None, |left, right| hasher.compress(left, right));
         tree
     }
 
+    /// `dirty_leaves` must be the set committed to by the boundary chip (keyed by
+    /// `(address_space, leaf_ptr)`, like `touched`): its rows only reference a leaf's
+    /// final state when that leaf is in the set.
     pub fn finalize(
         &mut self,
         hasher: &impl HasherChip<DIGEST_WIDTH, F>,
         touched: &Equipartition<F, DIGEST_WIDTH>,
+        dirty_leaves: &DirtyLeaves,
         md: &MemoryDimensions,
     ) -> FinalState<DIGEST_WIDTH, F> {
         let init_root = self.get_node(1);
@@ -264,31 +321,35 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                         (1 << self.height)
                             + md.label_to_index((*addr_sp, *ptr / DIGEST_WIDTH as u32)),
                         hasher.hash(v),
+                        dirty_leaves.contains(&(*addr_sp, *ptr)),
                     )
                 })
                 .collect()
         } else {
+            // Artificial touch to seed the walk so the root row pair exists. It is not
+            // dirty, and no boundary row backs it (see the post-walk fix below).
             let index = 1 << self.height;
-            vec![(index, self.get_node(index))]
+            vec![(index, self.get_node(index), false)]
         };
-        let mut rows = Vec::with_capacity(if layer.is_empty() {
-            0
-        } else {
-            layer
-                .iter()
-                .zip(layer.iter().skip(1))
-                .fold(md.overall_height(), |acc, ((lhs, _), (rhs, _))| {
-                    acc + (lhs ^ rhs).ilog2() as usize
-                })
-        });
+        // Upper bound: one initial row per touched-spanning node plus at most one final
+        // row each.
+        let touched_spanning_nodes = layer
+            .iter()
+            .zip(layer.iter().skip(1))
+            .fold(md.overall_height(), |acc, ((lhs, _, _), (rhs, _, _))| {
+                acc + (lhs ^ rhs).ilog2() as usize
+            });
+        let mut rows = Vec::with_capacity(2 * touched_spanning_nodes);
         self.process_layers(layer, md, Some(&mut rows), |left, right| {
             hasher.compress_and_record(left, right)
         });
         if touched.is_empty() {
-            // If we made an artificial touch, we need to change the direction changes for the
-            // leaves
-            rows[1].left_direction_different = F::ONE;
-            rows[1].right_direction_different = F::ONE;
+            // The artificial touch seeds the walk so the root pair exists, but there is
+            // no boundary row supplying the leaf's claim, so the height-1 initial row
+            // (rows[0]) must treat the leaf as *untouched*: no extra reference if the
+            // row's final counterpart exists (root case), an absent reference otherwise.
+            rows[0].left_extra_ref = F::ZERO;
+            rows[0].left_absent_ref = F::from_bool(rows[0].is_root == F::ZERO);
         }
         let final_root = self.get_node(1);
         FinalState {

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -78,11 +78,11 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
     #[allow(clippy::type_complexity)]
     /// Applies leaf updates upward to the root.
     ///
-    /// Each layer entry carries an `is_dirty` bit: for leaves it originates at the
-    /// boundary chip (value inequality), and for inner nodes it is the OR of the
-    /// children's bits. A node emits a final-direction row (and records a final
-    /// compression) only if it is dirty — or if it is the root, whose final row is
-    /// pinned to the public values.
+    /// Each layer entry carries an `is_dirty` bit: for leaves it says the leaf was
+    /// *written* during execution (tracked by `TracingMemory`, independent of the
+    /// written content), and for inner nodes it is the OR of the children's bits. A node emits a
+    /// final-direction row (and records a final compression) only if it is dirty — or if it is
+    /// the root, whose final row is pinned to the public values.
     fn process_layers<CompressFn>(
         &mut self,
         layer: Vec<(u64, [F; DIGEST_WIDTH], bool)>,

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -250,9 +250,9 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 parent_hash: combined,
                                 left_child_hash: *left,
                                 right_child_hash: *right,
-                                // Final-row child mode = dd bit: 1 when the child is
-                                // "not expanded finally" (untouched *or* touched-clean,
-                                // borrowed from the initial tree), 0 when it is dirty.
+                                // Final-row child mode: 1 when the child is untouched or
+                                // touched-clean and therefore borrowed from the initial
+                                // tree, 0 when it is dirty.
                                 left_child_mode: F::from_bool(!left_dirty),
                                 right_child_mode: F::from_bool(!right_dirty),
                             });
@@ -328,22 +328,36 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
             let index = 1 << self.height;
             vec![(index, self.get_node(index), false)]
         };
-        // Upper bound: one initial row per touched-spanning node plus at most one final
-        // row each.
-        let touched_spanning_nodes = layer
-            .iter()
-            .zip(layer.iter().skip(1))
-            .fold(md.overall_height(), |acc, ((lhs, _, _), (rhs, _, _))| {
-                acc + (lhs ^ rhs).ilog2() as usize
-            });
-        let mut rows = Vec::with_capacity(2 * touched_spanning_nodes);
+        let tree_height = md.overall_height();
+        let mut touched_nodes = tree_height;
+        let mut dirty_nodes = 0;
+        let mut previous_touched = layer[0].0;
+        let mut previous_dirty: Option<u64> = None;
+        for &(index, _, is_dirty) in &layer {
+            if index != previous_touched {
+                touched_nodes += (index ^ previous_touched).ilog2() as usize;
+                previous_touched = index;
+            }
+            if is_dirty {
+                dirty_nodes += match previous_dirty {
+                    None => tree_height,
+                    Some(previous) => (index ^ previous).ilog2() as usize,
+                };
+                previous_dirty = Some(index);
+            }
+        }
+        // One initial row per touched node and one final row per dirty node. The final
+        // root row is present even when no node is dirty.
+        let num_rows = touched_nodes + dirty_nodes.max(1);
+        let mut rows = Vec::with_capacity(num_rows);
         self.process_layers(layer, md, Some(&mut rows), |left, right| {
             hasher.compress_and_record(left, right)
         });
+        debug_assert_eq!(rows.len(), num_rows);
         if touched.is_empty() {
             // The artificial touch seeds the walk so the root pair exists, but there is
             // no boundary row supplying the leaf's claim, so the height-1 initial row
-            // (rows[0]) must treat the leaf as *untouched*: one dd-borrowed reference if
+            // (rows[0]) must treat the leaf as *untouched*: one borrowed reference if
             // the row's final counterpart exists (root case, mode 1), none otherwise
             // (mode 0).
             rows[0].left_child_mode = F::from_bool(rows[0].is_root == F::ONE);

--- a/crates/vm/src/system/memory/merkle/tree.rs
+++ b/crates/vm/src/system/memory/merkle/tree.rs
@@ -31,12 +31,10 @@ fn parent_label_parts(
     (parent_as_label, parent_address_label)
 }
 
-/// The `*_child_mode` value for an *initial* row (see `MemoryMerkleCols`): how many
-/// times the row references the child's initial claim, in {0, 1, 2}. One reference if
-/// the child is on the touched path, plus one if this node's final row dd-borrows it
-/// (touched-clean or untouched child of a node that emits a final row).
-fn initial_child_mode<F: PrimeField32>(emits_final: bool, changed: bool, dirty: bool) -> F {
-    F::from_bool(changed) + F::from_bool(emits_final && !dirty)
+/// The `*_child_mode` value for an initial row: one if the child is present on the
+/// touched path, plus one if this node's final row uses the clean child's initial state.
+fn initial_child_mode<F: PrimeField32>(emits_final: bool, present: bool, dirty: bool) -> F {
+    F::from_bool(present) + F::from_bool(emits_final && !dirty)
 }
 
 #[derive(Debug)]
@@ -88,9 +86,9 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
     ///
     /// Each layer entry carries an `is_dirty` bit: for leaves it says the leaf was
     /// *written* during execution (tracked by `TracingMemory`, independent of the
-    /// written content), and for inner nodes it is the OR of the children's bits. A node emits a
-    /// final-direction row (and records a final compression) only if it is dirty — or if it is
-    /// the root, whose final row is pinned to the public values.
+    /// written content), and for inner nodes it is the OR of the children's bits. A node
+    /// emits a final-direction row (and records a final compression) only if it is dirty
+    /// — or if it is the root, whose final row is pinned to the public values.
     fn process_layers<CompressFn>(
         &mut self,
         layer: Vec<(u64, [F; DIGEST_WIDTH], bool)>,
@@ -180,11 +178,8 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                         .map(|(par_index, left, right)| {
                             let (parent_as_label, parent_address_label) =
                                 parent_label_parts(md, self.height, par_index, height);
-                            // `changed_*` says the child is on the touched path (its
-                            // layer entry exists); `*_dirty` says its value actually
-                            // changed. Untouched children carry `dirty = false`.
                             let left_node;
-                            let (left, old_left, left_dirty, changed_left) = match left {
+                            let (left, old_left, left_dirty, left_present) = match left {
                                 Some((left, old_left, dirty)) => (left, old_left, dirty, true),
                                 None => {
                                     left_node = self.get_node_at_height(2 * par_index, height - 1);
@@ -192,7 +187,7 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 }
                             };
                             let right_node;
-                            let (right, old_right, right_dirty, changed_right) = match right {
+                            let (right, old_right, right_dirty, right_present) = match right {
                                 Some((right, old_right, dirty)) => (right, old_right, dirty, true),
                                 None => {
                                     right_node =
@@ -204,8 +199,8 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                             // Final rows are emitted only for dirty nodes, except the
                             // root: the AIR pins the first two rows to the initial/final
                             // root public values, so the root's final row always exists.
-                            // A forced root row does not redefine a clean root as dirty:
-                            // `node_dirty`, not `emits_final`, is what propagates upward.
+                            // `node_dirty` propagates upward; `emits_final` controls row
+                            // emission.
                             let emits_final = node_dirty || is_root;
 
                             let par_old_values = self.get_node_at_height(par_index, height);
@@ -235,12 +230,12 @@ impl<F: PrimeField32, const DIGEST_WIDTH: usize> MerkleTree<F, DIGEST_WIDTH> {
                                 // (see MemoryMerkleCols).
                                 left_child_mode: initial_child_mode::<F>(
                                     emits_final,
-                                    changed_left,
+                                    left_present,
                                     left_dirty,
                                 ),
                                 right_child_mode: initial_child_mode::<F>(
                                     emits_final,
-                                    changed_right,
+                                    right_present,
                                     right_dirty,
                                 ),
                             };

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -542,6 +542,10 @@ pub struct TracingMemory {
     /// Maps `(addr_space, ptr / BLOCK_FE_WIDTH)` to the latest access timestamp.
     /// A value of 0 means the touched-memory slot has never been accessed.
     pub(super) meta: Vec<PagedVec<u32, PAGE_SIZE>>,
+    /// Maps `(addr_space, ptr / BLOCK_FE_WIDTH)` to whether the block was ever written
+    /// during this segment. Dirtiness is per write access, independent of the written
+    /// content; stamped into each [`TouchedBlock`] by [`Self::finalize`].
+    pub(super) is_dirty: Vec<PagedVec<bool, PAGE_SIZE>>,
 }
 
 impl TracingMemory {
@@ -558,9 +562,16 @@ impl TracingMemory {
             .iter()
             .map(|config| PagedVec::new(config.num_cells.div_ceil(BLOCK_FE_WIDTH)))
             .collect();
+        let is_dirty = image
+            .memory
+            .config
+            .iter()
+            .map(|config| PagedVec::new(config.num_cells.div_ceil(BLOCK_FE_WIDTH)))
+            .collect();
         Self {
             data: image,
             meta,
+            is_dirty,
             timestamp: INITIAL_TIMESTAMP + 1,
         }
     }
@@ -624,6 +635,13 @@ impl TracingMemory {
                 .size()
     }
 
+    #[inline(always)]
+    fn mark_dirty(&mut self, address_space: usize, block_idx: usize) {
+        // SAFETY: address_space is validated during instruction decoding
+        let dirty_page = unsafe { self.is_dirty.get_unchecked_mut(address_space) };
+        dirty_page.set(block_idx, true);
+    }
+
     /// Atomic cell read operation which increments the timestamp by 1.
     /// Returns `(t_prev, values)`.
     ///
@@ -668,6 +686,7 @@ impl TracingMemory {
     {
         self.assert_valid_access::<BLOCK_SIZE>(address_space, ptr);
         let t_prev = self.prev_access_time(address_space as usize, ptr as usize);
+        self.mark_dirty(address_space as usize, ptr as usize / BLOCK_FE_WIDTH);
         let values_prev = self.data.read(address_space, ptr);
         self.data.write(address_space, ptr, values);
         self.timestamp += 1;
@@ -709,6 +728,10 @@ impl TracingMemory {
     ) -> (u32, [u8; N]) {
         self.assert_valid_byte_access::<N>(address_space, byte_ptr);
         let t_prev = self.byte_prev_access_time(address_space as usize, byte_ptr as usize);
+        self.mark_dirty(
+            address_space as usize,
+            byte_ptr as usize / self.memory_block_bytes(address_space),
+        );
         let values_prev = self.data.read_bytes::<N>(address_space, byte_ptr);
         self.data.write_bytes::<N>(address_space, byte_ptr, values);
         self.timestamp += 1;
@@ -761,7 +784,8 @@ impl TracingMemory {
         touched_blocks
     }
 
-    /// Returns touched memory in `BLOCK_FE_WIDTH`-cell blocks.
+    /// Returns touched memory in `BLOCK_FE_WIDTH`-cell blocks, each stamped with its
+    /// per-write dirty bit.
     fn touched_blocks_to_equipartition<F: Field>(
         &self,
         touched_blocks: Vec<((u32, u32), u32)>,
@@ -781,9 +805,12 @@ impl TracingMemory {
                             cell_size,
                         ))
                 });
+                let is_dirty =
+                    self.is_dirty[addr_space as usize].get(ptr as usize / BLOCK_FE_WIDTH);
                 TouchedBlock {
                     address_space: addr_space,
                     ptr,
+                    is_dirty: is_dirty as u32,
                     timestamp,
                     values,
                 }
@@ -794,8 +821,17 @@ impl TracingMemory {
 
 #[cfg(test)]
 mod tests {
+    use openvm_instructions::VM_DIGEST_WIDTH;
+    use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
     use super::*;
-    use crate::arch::MemoryCellType;
+    use crate::{
+        arch::{AddressSpaceHostConfig, MemoryCellType},
+        system::memory::ptr_bits_from_address_height,
+    };
+
+    type F = BabyBear;
 
     #[test]
     fn recompute_touched_pages_reflects_current_memory() {
@@ -852,6 +888,59 @@ mod tests {
         assert_eq!(
             memory.touched_pages[1].touched_byte_ranges(memory.mem[1].size()),
             vec![(0, 3 * PAGE_SIZE)]
+        );
+    }
+
+    /// Dirtiness is per *write*: a write marks its leaf dirty regardless of the written
+    /// content (writing the values a leaf already holds keeps it dirty), and reads never
+    /// mark anything.
+    #[test]
+    fn write_tracking_marks_dirty_leaves() {
+        let height = 2; // 4 leaves of VM_DIGEST_WIDTH cells per address space
+        let mem_config = MemoryConfig::new(
+            1,
+            vec![
+                AddressSpaceHostConfig {
+                    num_cells: 0,
+                    layout: MemoryCellType::Null,
+                },
+                AddressSpaceHostConfig {
+                    num_cells: VM_DIGEST_WIDTH << height,
+                    layout: MemoryCellType::F { size: 4 },
+                },
+                AddressSpaceHostConfig {
+                    num_cells: VM_DIGEST_WIDTH << height,
+                    layout: MemoryCellType::F { size: 4 },
+                },
+            ],
+            ptr_bits_from_address_height(height),
+            20,
+            17,
+        );
+        let mut memory = TracingMemory::new(&mem_config);
+
+        let leaf = VM_DIGEST_WIDTH as u32;
+        // SAFETY: `F` matches the configured cell type and all pointers are
+        // block-aligned and in bounds.
+        unsafe {
+            // Leaf (1, 0): written with fresh values -> dirty.
+            let _ = memory.write::<F, BLOCK_FE_WIDTH>(1, 0, [F::ONE; BLOCK_FE_WIDTH]);
+            // Leaf (1, 8): only read -> touched but clean.
+            let _ = memory.read::<F, BLOCK_FE_WIDTH>(1, leaf);
+            // Leaf (1, 16): written with the values it already holds (zeros) -> dirty.
+            let _ = memory.write::<F, BLOCK_FE_WIDTH>(1, 2 * leaf, [F::ZERO; BLOCK_FE_WIDTH]);
+            // Leaf (2, 0): only read, in another address space -> touched but clean.
+            let _ = memory.read::<F, BLOCK_FE_WIDTH>(2, 0);
+        }
+
+        let touched_memory = memory.finalize::<F>();
+        let touched: Vec<(u32, u32, u32)> = touched_memory
+            .iter()
+            .map(|block| (block.address_space, block.ptr, block.is_dirty))
+            .collect();
+        assert_eq!(
+            touched,
+            vec![(1, 0, 1), (1, leaf, 0), (1, 2 * leaf, 1), (2, 0, 0)]
         );
     }
 }

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -193,19 +193,24 @@ pub struct FinalTouchedLabel<F, const DIGEST_WIDTH: usize> {
     final_hash: [F; DIGEST_WIDTH],
     /// Per-block timestamps. Each BLOCK_FE_WIDTH block has its own timestamp.
     final_timestamps: [u32; BLOCKS_PER_LEAF],
-    /// Whether the leaf's final values differ from its initial values. Dirtiness gates
-    /// all of the row's final-state interactions: a clean leaf's final hash equals its
-    /// initial one and is never recorded with the hasher.
+    /// Whether some block of the leaf was *written* during execution (independent of
+    /// the written content). Dirtiness gates all of the row's final-state interactions:
+    /// a clean leaf's final hash equals its initial one and is never recorded with the
+    /// hasher.
     is_dirty: bool,
 }
 
-/// Pointers `(address_space, leaf_ptr)` of the touched leaves whose values changed,
-/// keyed like `Equipartition<_, DIGEST_WIDTH>` so entries match the merkle chip's
-/// `final_memory` keys. Computed by [`PersistentBoundaryChip::finalize`] and consumed by
-/// the merkle chip, which emits final-direction rows only along dirty paths.
+/// Pointers `(address_space, leaf_ptr)` of the leaves containing at least one block
+/// *written* during execution (per-write dirtiness, tracked by `TracingMemory`:
+/// writing values equal to the existing ones still marks a leaf dirty), keyed like
+/// `Equipartition<_, DIGEST_WIDTH>` so entries match the merkle chip's `final_memory`
+/// keys. Computed by [`PersistentBoundaryChip::finalize`] from the touched blocks' bits
+/// and consumed by the merkle chip, which emits final-direction rows only along dirty
+/// paths.
 pub type DirtyLeaves = FxHashSet<(u32, u32)>;
 
-type BlockInfo<F> = (usize, u32, [F; BLOCK_FE_WIDTH]); // (block_idx, timestamp, values)
+// (block_idx, timestamp, is_dirty, values)
+type BlockInfo<F> = (usize, u32, bool, [F; BLOCK_FE_WIDTH]);
 type EnrichedEntry<F> = ((u32, u32), BlockInfo<F>); // ((addr_space, leaf_label), block_info)
 /// Touched memory grouped into merkle leaves: `(addr_space, leaf_label) -> blocks`.
 pub(crate) type LeafGroupedTouchedMemory<F> = Vec<((u32, u32), Vec<BlockInfo<F>>)>;
@@ -219,7 +224,12 @@ pub(crate) fn group_touched_memory_by_leaf<F: Copy + Send + Sync>(
             let leaf_label = block.ptr / VM_DIGEST_WIDTH as u32;
             let block_idx = ((block.ptr % VM_DIGEST_WIDTH as u32) / BLOCK_FE_WIDTH as u32) as usize;
             let key = (block.address_space, leaf_label);
-            let block_info = (block_idx, block.timestamp, block.values);
+            let block_info = (
+                block_idx,
+                block.timestamp,
+                block.is_dirty != 0,
+                block.values,
+            );
             (key, block_info)
         })
         .collect();
@@ -284,17 +294,22 @@ impl<const DIGEST_WIDTH: usize, F: PrimeField32> PersistentBoundaryChip<F, DIGES
                 let mut final_values = init_values;
                 let mut timestamps = [0u32; BLOCKS_PER_LEAF];
 
-                for &(block_idx, ts, values) in blocks {
+                for &(block_idx, ts, _, values) in blocks {
                     timestamps[block_idx] = ts;
                     for (i, &val) in values.iter().enumerate() {
                         final_values[block_idx * BLOCK_FE_WIDTH + i] = val;
                     }
                 }
 
-                // Value inequality is the single definition of dirtiness (equal values
-                // give equal hashes); a clean leaf's final hash equals the initial one,
-                // so the second hash is skipped entirely.
-                let is_dirty = final_values != init_values;
+                // Dirtiness is per *write*, tracked during execution: a leaf is dirty
+                // iff some block of it was written, even if the written values equal
+                // the initial ones. A clean (unwritten) leaf cannot have changed, so
+                // its final hash is the initial one.
+                let is_dirty = blocks.iter().any(|&(_, _, dirty, _)| dirty);
+                debug_assert!(
+                    is_dirty || final_values == init_values,
+                    "unwritten leaf ({addr_space}, {leaf_label}) changed values"
+                );
                 let initial_hash = hasher.hash(&init_values);
                 let final_hash = if is_dirty {
                     hasher.hash(&final_values)

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -17,6 +17,7 @@ use openvm_stark_backend::{
     prover::AirProvingContext,
     BaseAirWithPublicValues, PartitionedBaseAir, StarkProtocolConfig, Val,
 };
+use rustc_hash::FxHashSet;
 use tracing::instrument;
 
 use super::merkle::SerialReceiver;
@@ -192,7 +193,17 @@ pub struct FinalTouchedLabel<F, const DIGEST_WIDTH: usize> {
     final_hash: [F; DIGEST_WIDTH],
     /// Per-block timestamps. Each BLOCK_FE_WIDTH block has its own timestamp.
     final_timestamps: [u32; BLOCKS_PER_LEAF],
+    /// Whether the leaf's final values differ from its initial values. Dirtiness gates
+    /// all of the row's final-state interactions: a clean leaf's final hash equals its
+    /// initial one and is never recorded with the hasher.
+    is_dirty: bool,
 }
+
+/// Pointers `(address_space, leaf_ptr)` of the touched leaves whose values changed,
+/// keyed like `Equipartition<_, DIGEST_WIDTH>` so entries match the merkle chip's
+/// `final_memory` keys. Computed by [`PersistentBoundaryChip::finalize`] and consumed by
+/// the merkle chip, which emits final-direction rows only along dirty paths.
+pub type DirtyLeaves = FxHashSet<(u32, u32)>;
 
 type BlockInfo<F> = (usize, u32, [F; BLOCK_FE_WIDTH]); // (block_idx, timestamp, values)
 type EnrichedEntry<F> = ((u32, u32), BlockInfo<F>); // ((addr_space, leaf_label), block_info)
@@ -248,13 +259,17 @@ impl<const DIGEST_WIDTH: usize, F: PrimeField32> PersistentBoundaryChip<F, DIGES
     /// Finalize the boundary chip with touched memory grouped by Merkle leaf.
     ///
     /// Untouched blocks within a touched leaf get values from initial_memory and timestamp 0.
+    ///
+    /// Returns the [`DirtyLeaves`] this chip committed to, so the merkle chip consumes
+    /// the exact same bits instead of re-deriving dirtiness.
     #[instrument(name = "boundary_finalize", level = "debug", skip_all)]
     pub(crate) fn finalize<H>(
         &mut self,
         initial_memory: &MemoryImage,
         final_memory_by_leaf: &LeafGroupedTouchedMemory<F>,
         hasher: &H,
-    ) where
+    ) -> DirtyLeaves
+    where
         H: Hasher<DIGEST_WIDTH, F> + Sync + for<'a> SerialReceiver<&'a [F]>,
     {
         let final_touched_labels: Vec<_> = final_memory_by_leaf
@@ -276,8 +291,16 @@ impl<const DIGEST_WIDTH: usize, F: PrimeField32> PersistentBoundaryChip<F, DIGES
                     }
                 }
 
+                // Value inequality is the single definition of dirtiness (equal values
+                // give equal hashes); a clean leaf's final hash equals the initial one,
+                // so the second hash is skipped entirely.
+                let is_dirty = final_values != init_values;
                 let initial_hash = hasher.hash(&init_values);
-                let final_hash = hasher.hash(&final_values);
+                let final_hash = if is_dirty {
+                    hasher.hash(&final_values)
+                } else {
+                    initial_hash
+                };
                 FinalTouchedLabel {
                     address_space: *addr_space,
                     label: *leaf_label,
@@ -286,14 +309,25 @@ impl<const DIGEST_WIDTH: usize, F: PrimeField32> PersistentBoundaryChip<F, DIGES
                     init_hash: initial_hash,
                     final_hash,
                     final_timestamps: timestamps,
+                    is_dirty,
                 }
             })
             .collect();
         for l in &final_touched_labels {
             hasher.receive(&l.init_values);
-            hasher.receive(&l.final_values);
+            // A clean leaf's final compression has multiplicity `is_dirty = 0` on the
+            // compression bus, so it must not be recorded with the hasher chip.
+            if l.is_dirty {
+                hasher.receive(&l.final_values);
+            }
         }
+        let dirty_leaves = final_touched_labels
+            .iter()
+            .filter(|l| l.is_dirty)
+            .map(|l| (l.address_space, l.label * DIGEST_WIDTH as u32))
+            .collect();
         self.touched_labels = Some(final_touched_labels);
+        dirty_leaves
     }
 }
 
@@ -327,8 +361,7 @@ where
                 .for_each(|(row, touched_label)| {
                     *row.borrow_mut() = PersistentBoundaryCols {
                         is_valid: Val::<SC>::ONE,
-                        // TODO: set is_dirty only when it is actually dirty
-                        is_dirty: Val::<SC>::ONE,
+                        is_dirty: Val::<SC>::from_bool(touched_label.is_dirty),
                         address_space: Val::<SC>::from_u32(touched_label.address_space),
                         leaf_label: Val::<SC>::from_u32(touched_label.label),
                         initial_values: touched_label.init_values,

--- a/crates/vm/src/system/memory/persistent.rs
+++ b/crates/vm/src/system/memory/persistent.rs
@@ -204,9 +204,7 @@ pub struct FinalTouchedLabel<F, const DIGEST_WIDTH: usize> {
 /// *written* during execution (per-write dirtiness, tracked by `TracingMemory`:
 /// writing values equal to the existing ones still marks a leaf dirty), keyed like
 /// `Equipartition<_, DIGEST_WIDTH>` so entries match the merkle chip's `final_memory`
-/// keys. Computed by [`PersistentBoundaryChip::finalize`] from the touched blocks' bits
-/// and consumed by the merkle chip, which emits final-direction rows only along dirty
-/// paths.
+/// keys.
 pub type DirtyLeaves = FxHashSet<(u32, u32)>;
 
 // (block_idx, timestamp, is_dirty, values)

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -126,11 +126,6 @@ pub struct SystemRecords<F> {
 pub struct TouchedBlock<F> {
     pub address_space: u32,
     pub ptr: u32,
-    /// Whether the block was *written* during the segment (0/1), as tracked by
-    /// `TracingMemory`. Dirtiness is per write access, independent of the written
-    /// content: writing values equal to the existing ones still marks the block dirty.
-    /// Not consumed yet: a follow-up switches the boundary and merkle chips to commit
-    /// final state only for leaves containing a dirty block.
     pub is_dirty: u32,
     pub timestamp: u32,
     pub values: [F; BLOCK_FE_WIDTH],

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -119,13 +119,19 @@ pub struct SystemRecords<F> {
 ///
 /// `repr(C)` with 4-byte fields: for a 4-byte field type its bytes are plain
 /// data and the struct is exactly the GPU memory-inventory input-record
-/// layout (7 u32 words), so the device path uploads the vector's bytes
+/// layout (8 u32 words), so the device path uploads the vector's bytes
 /// without repacking. Keep in sync with `InRec` in `inventory.cu`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TouchedBlock<F> {
     pub address_space: u32,
     pub ptr: u32,
+    /// Whether the block was *written* during the segment (0/1), as tracked by
+    /// `TracingMemory`. Dirtiness is per write access, independent of the written
+    /// content: writing values equal to the existing ones still marks the block dirty.
+    /// Not consumed yet: a follow-up switches the boundary and merkle chips to commit
+    /// final state only for leaves containing a dirty block.
+    pub is_dirty: u32,
     pub timestamp: u32,
     pub values: [F; BLOCK_FE_WIDTH],
 }


### PR DESCRIPTION
This PR adds leaf level dirty bit tracking and modifies MemoryMerkleAir to only have final rows for dirty nodes.

The updated design tracks written blocks during preflight mode and derives dirty leaves from that knowledge. Depending on the leaf dirtiness, its parent is also considered dirty (and parent's parent too). By observing that only dirty nodes would have different final state at the end of the segment (w.r.t. the start of the segment), we only store dirty final rows for MemoryMerkleAir.

Consequently, by removing non-dirty final rows, we need to balance out the number of interactions that the removed non-dirty rows did. This is done by repurposing `direction_different` columns as `child_mode`, a column that acts as `direction_different` for final rows and interaction adjustment for initial rows.

In addition, as MerkleMemoryAir trace is no longer a fixed two rows per node, during GPU trace generation the device can't place the row by the static index. To mitigate it, we first compute the total height beforehand and actually compute were the row would go during tracegen. Both CPU and GPU tracegen are stored in interleaved fashion where first is final row and then initial row per node, except for the root where the first one is initial and second one is final. Not sure if it was originally intended to be in this format, maybe would be better to have initial and then final row? Might be later pr

This is continuation of PersistentBoundaryAir update PR (https://github.com/openvm-org/openvm/pull/3051). The next step, metered mode tracking is done in the follow up PR (https://github.com/openvm-org/openvm/pull/3061).

towards INT-8828