### PR TITLE
chore: track stark-backend main branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,12 +116,12 @@ lto = "thin"
 
 [workspace.dependencies]
 # Stark Backend
-openvm-stark-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
-openvm-stark-sdk = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
-openvm-cpu-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
-openvm-cuda-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
-openvm-cuda-builder = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
-openvm-cuda-common = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", tag = "v2.0.0", default-features = false }
+openvm-stark-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", branch = "main", default-features = false }
+openvm-stark-sdk = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", branch = "main", default-features = false }
+openvm-cpu-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", branch = "main", default-features = false }
+openvm-cuda-backend = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", branch = "main", default-features = false }
+openvm-cuda-builder = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", branch = "main", default-features = false }
+openvm-cuda-common = { version = "2.0.0", git = "https://github.com/openvm-org/stark-backend.git", branch = "main", default-features = false }
 
 # OpenVM
 openvm-mod-circuit-builder = { version = "2.0.1", path = "crates/circuits/mod-builder", default-features = false }


### PR DESCRIPTION
## Summary

Switches all six stark-backend workspace refs (`openvm-stark-backend`, `openvm-stark-sdk`, `openvm-cpu-backend`, `openvm-cuda-backend`, `openvm-cuda-builder`, `openvm-cuda-common`) from `tag = \"v2.0.0\"` to `branch = \"main\"`.

Post-v2.0.0, `openvm-cuda-common` gained `DeviceBuffer::mut_slice` (openvm-org/stark-backend#387). Downstream repos that want to reuse it (e.g. [halo2-gpu#15](https://github.com/axiom-crypto/halo2-gpu/pull/15)) can only unify the graph — cargo rejects two versions of a native-lib crate — if openvm also follows `main`.

Revert to a tagged version once stark-backend cuts a release including the new API.

## Test plan

- [x] `cargo update` locks all six crates on `stark-backend?branch=main#f86b55f4` in one workspace resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)