### PR TITLE
fix(v2.1): rebuild touched pages from memory 

### DIFF
--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -4,7 +4,7 @@ use openvm_stark_backend::{
     interaction::PermutationCheckBus, p3_field::PrimeField32, p3_maybe_rayon::prelude::*,
 };
 
-use super::{controller::dimensions::MemoryDimensions, online::LinearMemory};
+use super::{controller::dimensions::MemoryDimensions, has_nonzero_byte, online::LinearMemory};
 use crate::{
     arch::AddressSpaceHostLayout,
     system::memory::{online::PAGE_SIZE, AddressMap},
@@ -84,13 +84,7 @@ fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
             let num_nonzero_pages = space_mem
                 .par_chunks(PAGE_SIZE)
                 .enumerate()
-                .flat_map(|(idx, page)| {
-                    if page.iter().any(|x| *x != 0) {
-                        Some(idx + 1)
-                    } else {
-                        None
-                    }
-                })
+                .filter_map(|(idx, page)| has_nonzero_byte(page).then_some(idx + 1))
                 .max()
                 .unwrap_or(0);
 

--- a/crates/vm/src/system/memory/mod.rs
+++ b/crates/vm/src/system/memory/mod.rs
@@ -35,6 +35,17 @@ pub const POINTER_MAX_BITS: usize = MEM_BITS - size_of::<u16>().ilog2() as usize
 // `u64` until a runtime bounds check proves that they are valid pointers.
 const _: () = assert!(MEM_BITS <= u32::BITS as usize);
 
+/// Returns whether `bytes` contains any non-zero byte.
+///
+/// Fixed-size comparisons allow the compiler to vectorize scans of mostly-zero memory pages.
+#[inline]
+pub(crate) fn has_nonzero_byte(bytes: &[u8]) -> bool {
+    const ZERO_CHUNK: [u8; 32] = [0; 32];
+
+    let mut chunks = bytes.chunks_exact(ZERO_CHUNK.len());
+    chunks.any(|chunk| chunk != ZERO_CHUNK) || chunks.remainder().iter().any(|&byte| byte != 0)
+}
+
 #[derive(PartialEq, Copy, Clone, Debug, Eq)]
 pub enum OpType {
     Read = 0,

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -152,9 +152,11 @@ pub struct AddressMap<M: LinearMemory = MemoryBackend> {
     ///
     /// Invariant: any path that writes non-zero data into memory that may later be transferred via
     /// `set_initial_memory` must mark the written pages (`set_from_sparse`,
-    /// `extend_touched_pages_from_touched`). Unmarked pages are transferred as zero. The untracked
-    /// write paths (`get_memory_mut`, `GuestMemory::write`/`write_bytes`) do not mark and must not
-    /// be the source of transferred initial memory.
+    /// `extend_touched_pages_from_touched`) or rebuild the metadata with
+    /// [`AddressMap::recompute_touched_pages`]. Unmarked pages are transferred as zero. The
+    /// untracked write paths (`get_memory_mut`, `GuestMemory::write`/`write_bytes`) do not mark,
+    /// so callers must recompute before transferring a memory image produced through those
+    /// paths.
     pub touched_pages: Vec<TouchedPages>,
 }
 
@@ -320,6 +322,33 @@ impl<M: LinearMemory> AddressMap<M> {
             let len = BLOCK_FE_WIDTH * cell_size;
             self.touched_pages[block.address_space as usize].mark_byte_range(start, len);
         }
+    }
+
+    /// Rebuilds the sparse host-to-device transfer metadata from the current memory image.
+    ///
+    /// This replaces all existing marks and is intended for snapshots produced through untracked
+    /// execution paths. Call it after the final untracked write and before transferring the image.
+    /// It scans all configured memory, so callers should use the incremental marking methods when
+    /// they already have reliable write information.
+    pub fn recompute_touched_pages(&mut self) {
+        const ZERO_CHUNK: [u8; 32] = [0; 32];
+
+        self.touched_pages = self
+            .mem
+            .iter()
+            .map(|mem| {
+                let mut rebuilt = TouchedPages::new(mem.size());
+                for (page_idx, page) in mem.as_slice().chunks(PAGE_SIZE).enumerate() {
+                    let mut chunks = page.chunks_exact(ZERO_CHUNK.len());
+                    let contains_nonzero = chunks.any(|chunk| chunk != ZERO_CHUNK)
+                        || chunks.remainder().iter().any(|&byte| byte != 0);
+                    if contains_nonzero {
+                        rebuilt.mark_byte_range(page_idx * PAGE_SIZE, page.len());
+                    }
+                }
+                rebuilt
+            })
+            .collect();
     }
 }
 
@@ -759,5 +788,69 @@ impl TracingMemory {
                 }
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arch::MemoryCellType;
+
+    #[test]
+    fn recompute_touched_pages_reflects_current_memory() {
+        let config = vec![
+            AddressSpaceHostConfig::new(0, MemoryCellType::Null),
+            AddressSpaceHostConfig::new(2 * PAGE_SIZE + 17, MemoryCellType::U8),
+            AddressSpaceHostConfig::new(PAGE_SIZE + 1, MemoryCellType::U8),
+            AddressSpaceHostConfig::new(PAGE_SIZE + 1, MemoryCellType::U8),
+        ];
+        let mut memory: AddressMap = AddressMap::new(config);
+
+        memory.mem[1].as_mut_slice()[0] = 1;
+        memory.mem[1].as_mut_slice()[2 * PAGE_SIZE + 16] = 2;
+        memory.mem[2].as_mut_slice()[PAGE_SIZE] = 3;
+        // Recomputing replaces stale metadata, including pages that are still all zero.
+        memory.touched_pages[1].mark_byte_range(PAGE_SIZE, 1);
+        memory.touched_pages[3].mark_byte_range(PAGE_SIZE, 1);
+
+        memory.recompute_touched_pages();
+
+        assert_eq!(
+            memory.touched_pages[1].touched_byte_ranges(memory.mem[1].size()),
+            vec![(0, PAGE_SIZE), (2 * PAGE_SIZE, 2 * PAGE_SIZE + 17)]
+        );
+        assert_eq!(
+            memory.touched_pages[2].touched_byte_ranges(memory.mem[2].size()),
+            vec![(PAGE_SIZE, PAGE_SIZE + 1)]
+        );
+        assert!(memory.touched_pages[3]
+            .touched_byte_ranges(memory.mem[3].size())
+            .is_empty());
+
+        memory.mem[1].as_mut_slice()[0] = 0;
+        memory.recompute_touched_pages();
+        assert_eq!(
+            memory.touched_pages[1].touched_byte_ranges(memory.mem[1].size()),
+            vec![(2 * PAGE_SIZE, 2 * PAGE_SIZE + 17)]
+        );
+    }
+
+    #[test]
+    fn recompute_touched_pages_detects_chunk_boundaries() {
+        let config = vec![
+            AddressSpaceHostConfig::new(0, MemoryCellType::Null),
+            AddressSpaceHostConfig::new(3 * PAGE_SIZE, MemoryCellType::U8),
+        ];
+        let mut memory: AddressMap = AddressMap::new(config);
+        for offset in [31, PAGE_SIZE + 32, 3 * PAGE_SIZE - 1] {
+            memory.mem[1].as_mut_slice()[offset] = 1;
+        }
+
+        memory.recompute_touched_pages();
+
+        assert_eq!(
+            memory.touched_pages[1].touched_byte_ranges(memory.mem[1].size()),
+            vec![(0, 3 * PAGE_SIZE)]
+        );
     }
 }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -9,6 +9,7 @@ use openvm_stark_backend::{
 use thiserror::Error;
 use tracing::instrument;
 
+use super::has_nonzero_byte;
 use crate::{
     arch::{AddressSpaceHostConfig, AddressSpaceHostLayout, MemoryConfig, BLOCK_FE_WIDTH},
     system::{TouchedBlock, TouchedMemory},
@@ -331,18 +332,13 @@ impl<M: LinearMemory> AddressMap<M> {
     /// It scans all configured memory, so callers should use the incremental marking methods when
     /// they already have reliable write information.
     pub fn recompute_touched_pages(&mut self) {
-        const ZERO_CHUNK: [u8; 32] = [0; 32];
-
         self.touched_pages = self
             .mem
             .iter()
             .map(|mem| {
                 let mut rebuilt = TouchedPages::new(mem.size());
                 for (page_idx, page) in mem.as_slice().chunks(PAGE_SIZE).enumerate() {
-                    let mut chunks = page.chunks_exact(ZERO_CHUNK.len());
-                    let contains_nonzero = chunks.any(|chunk| chunk != ZERO_CHUNK)
-                        || chunks.remainder().iter().any(|&byte| byte != 0);
-                    if contains_nonzero {
+                    if has_nonzero_byte(page) {
                         rebuilt.mark_byte_range(page_idx * PAGE_SIZE, page.len());
                     }
                 }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -337,10 +337,15 @@ impl<M: LinearMemory> AddressMap<M> {
             .iter()
             .map(|mem| {
                 let mut rebuilt = TouchedPages::new(mem.size());
-                for (page_idx, page) in mem.as_slice().chunks(PAGE_SIZE).enumerate() {
-                    if has_nonzero_byte(page) {
-                        rebuilt.mark_byte_range(page_idx * PAGE_SIZE, page.len());
-                    }
+                // Scan pages in parallel, then update the compact non-atomic bitset serially.
+                let nonzero_pages = mem
+                    .as_slice()
+                    .par_chunks(PAGE_SIZE)
+                    .enumerate()
+                    .filter_map(|(page_idx, page)| has_nonzero_byte(page).then_some(page_idx))
+                    .collect::<Vec<_>>();
+                for page_idx in nonzero_pages {
+                    rebuilt.mark_byte_range(page_idx * PAGE_SIZE, 1);
                 }
                 rebuilt
             })


### PR DESCRIPTION
- Adds a state-owned way to rebuild sparse H2D transfer metadata after untracked execution.
- Reuses the optimized nonzero-byte scan in touched-page reconstruction and CPU Merkle initialization.