### PR TITLE
feat: metered dirty tracking

### DIFF
--- a/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
+++ b/crates/rvr/rvr-openvm-ffi-common/src/lib.rs
@@ -38,6 +38,7 @@ extern "C" {
         base_addr: u64,
         num_words: u32,
         addr_space: u32,
+        is_write: bool,
     );
 
     // ── Hint stream (for extension phantom instructions) ──────────────
@@ -179,6 +180,8 @@ pub unsafe fn checked_peek_mem_words(
 
 /// Record the pages touched by `num_words` consecutive words in `addr_space`.
 /// This is metering data only; it does not record the accessed values.
+/// `is_write` marks the touched leaves as written (dirty), which costs
+/// final-direction Merkle rows and Poseidon2 compressions.
 ///
 /// `num_words` must be `>= 1`; see [`read_mem_words`] for rationale.
 ///
@@ -189,10 +192,11 @@ pub unsafe fn record_page_access_range(
     base_addr: u64,
     num_words: u32,
     addr_space: u32,
+    is_write: bool,
 ) {
     debug_assert!(
         num_words >= 1,
         "record_page_access_range requires num_words >= 1"
     );
-    record_page_access_u64_range_wrapper(state, base_addr, num_words, addr_space);
+    record_page_access_u64_range_wrapper(state, base_addr, num_words, addr_space, is_write);
 }

--- a/crates/rvr/rvr-openvm-ir/src/ext.rs
+++ b/crates/rvr/rvr-openvm-ir/src/ext.rs
@@ -180,7 +180,13 @@ pub trait ExtEmitCtx {
     /// Record the pages containing one fixed-width access for metering.
     ///
     /// This records the address, not the accessed value.
-    fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: PageAddressSpace);
+    fn trace_page_access(
+        &mut self,
+        addr: &str,
+        width: MemWidth,
+        addr_space: PageAddressSpace,
+        is_write: bool,
+    );
 
     /// Record pages touched by a dword range for metering (one dword is 8 bytes).
     ///
@@ -190,5 +196,6 @@ pub trait ExtEmitCtx {
         base_addr: &str,
         num_dwords: &str,
         addr_space: PageAddressSpace,
+        is_write: bool,
     );
 }

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.c
@@ -37,6 +37,7 @@ void write_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
 
 void record_page_access_u64_range_wrapper(RvState* state, uint64_t base_addr,
                                           uint32_t num_words,
-                                          uint32_t addr_space) {
-  trace_page_access_u64_range(state, base_addr, num_words, addr_space);
+                                          uint32_t addr_space, bool is_write) {
+  trace_page_access_u64_range(state, base_addr, num_words, addr_space,
+                              is_write);
 }

--- a/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
+++ b/crates/rvr/rvr-openvm/c/rvr_ext_wrappers.h
@@ -1,6 +1,7 @@
 #ifndef RVR_EXT_WRAPPERS_H
 #define RVR_EXT_WRAPPERS_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "openvm_state.h"
@@ -14,5 +15,5 @@ void write_mem_u64_range_wrapper(RvState* state, uint64_t base_addr,
                                  const uint64_t* vals, uint32_t num_words);
 void record_page_access_u64_range_wrapper(RvState* state, uint64_t base_addr,
                                           uint32_t num_words,
-                                          uint32_t addr_space);
+                                          uint32_t addr_space, bool is_write);
 #endif /* RVR_EXT_WRAPPERS_H */

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -48,9 +48,8 @@ typedef struct PageTouch {
   /* Align leaf_mask and make the shared 24-byte Rust/C layout explicit. */
   uint32_t _padding;
   uint64_t leaf_mask;
-  /* Leaves *written* in this page (subset of leaf_mask). Written leaves cost
-   * final-direction Merkle rows and Poseidon2 compressions; read-only leaves
-   * do not. Matches MeteredCtx's per-write dirtiness exactly. */
+  /* Leaves written in this page, always a subset of leaf_mask. A write adds
+   * final-direction Merkle rows and Poseidon2 compressions. */
   uint64_t dirty_mask;
 } PageTouch;
 

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered.h
@@ -8,6 +8,7 @@
 #ifndef OPENVM_TRACER_METERED_H
 #define OPENVM_TRACER_METERED_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "openvm_state.h"
@@ -42,11 +43,15 @@ static_assert(
     "DEFERRAL_PAGE_BUF_CAP too small for worst-case pages per flush interval");
 
 typedef struct PageTouch {
-  /* Page table index plus a 64-bit leaf mask for that page. */
+  /* Page table index plus 64-bit leaf masks for that page. */
   uint32_t page_id;
-  /* Align leaf_mask and make the shared 16-byte Rust/C layout explicit. */
+  /* Align leaf_mask and make the shared 24-byte Rust/C layout explicit. */
   uint32_t _padding;
   uint64_t leaf_mask;
+  /* Leaves *written* in this page (subset of leaf_mask). Written leaves cost
+   * final-direction Merkle rows and Poseidon2 compressions; read-only leaves
+   * do not. Matches MeteredCtx's per-write dirtiness exactly. */
+  uint64_t dirty_mask;
 } PageTouch;
 
 /* Direct SP-relative accesses use a separate pending page so alternating
@@ -57,6 +62,14 @@ typedef enum TraceMemoryCache {
   TRACE_MEMORY_CACHE_COUNT,
 } TraceMemoryCache;
 
+static_assert(sizeof(PageTouch) == 24, "PageTouch must match its Rust layout");
+static_assert(offsetof(PageTouch, page_id) == 0,
+              "PageTouch.page_id offset must match Rust");
+static_assert(offsetof(PageTouch, leaf_mask) == 8,
+              "PageTouch.leaf_mask offset must match Rust");
+static_assert(offsetof(PageTouch, dirty_mask) == 16,
+              "PageTouch.dirty_mask offset must match Rust");
+
 /* One page buffer per address space stores local page ids and leaf masks.
  * AS_REGISTER pages are handled entirely on the Rust side at init. */
 typedef struct TraceMemory {
@@ -65,6 +78,8 @@ typedef struct TraceMemory {
   /* Align last_leaf_mask and make the padding explicit. */
   uint32_t _padding;
   uint64_t last_leaf_mask[TRACE_MEMORY_CACHE_COUNT];
+  /* Written subset of last_leaf_mask for each pending page. */
+  uint64_t last_dirty_mask[TRACE_MEMORY_CACHE_COUNT];
   PageTouch* mem_page_buf;
 } TraceMemory;
 
@@ -109,15 +124,18 @@ static __attribute__((always_inline)) inline uint64_t leaf_mask_range(
 
 static __attribute__((always_inline)) inline void append_page_touch(
     PageTouch* restrict buf, uint32_t* restrict len, uint32_t page,
-    uint64_t leaf_mask) {
+    uint64_t leaf_mask, uint64_t dirty_mask) {
   PageTouch* slot = &buf[(*len)++];
   slot->page_id = page;
   slot->leaf_mask = leaf_mask;
+  /* Buffers are reused across drain rounds; always write the field so no
+   * stale mask from a previous round survives. */
+  slot->dirty_mask = dirty_mask;
 }
 
 static __attribute__((always_inline)) inline void append_page_touch_range(
     PageTouch* restrict buf, uint32_t* restrict len, uint32_t first_leaf,
-    uint32_t last_leaf) {
+    uint32_t last_leaf, bool is_write) {
   uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
   uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   for (uint32_t page = first_page; page <= last_page; page++) {
@@ -126,33 +144,40 @@ static __attribute__((always_inline)) inline void append_page_touch_range(
     uint32_t start =
         first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
     uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_touch(buf, len, page, leaf_mask_range(start, end));
+    uint64_t mask = leaf_mask_range(start, end);
+    append_page_touch(buf, len, page, mask, is_write ? mask : 0u);
   }
 }
 
 /* No bounds check — see MEM_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_mem_page(
-    MeteringState* metering, uint32_t page, uint64_t leaf_mask) {
+    MeteringState* metering, uint32_t page, uint64_t leaf_mask,
+    uint64_t dirty_mask) {
   if (likely(page == metering->last_mem_page)) {
-    metering->mem_page_buf[metering->mem_page_buf_len - 1u].leaf_mask |=
-        leaf_mask;
+    PageTouch* prev = &metering->mem_page_buf[metering->mem_page_buf_len - 1u];
+    prev->leaf_mask |= leaf_mask;
+    prev->dirty_mask |= dirty_mask;
     return;
   }
   metering->last_mem_page = page;
   append_page_touch(metering->mem_page_buf, &metering->mem_page_buf_len, page,
-                    leaf_mask);
+                    leaf_mask, dirty_mask);
 }
 
 static __attribute__((always_inline)) inline void record_mem_page_range(
-    MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf) {
+    MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf,
+    bool is_write) {
   uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
   uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   if (likely(first_page == metering->last_mem_page)) {
-    metering->mem_page_buf[metering->mem_page_buf_len - 1u].leaf_mask |=
+    uint64_t mask =
         leaf_mask_range(first_leaf,
                         first_page == last_page
                             ? last_leaf
                             : ((first_page + 1u) << TRACER_PAGE_BITS) - 1u);
+    PageTouch* prev = &metering->mem_page_buf[metering->mem_page_buf_len - 1u];
+    prev->leaf_mask |= mask;
+    prev->dirty_mask |= is_write ? mask : 0u;
     if (first_page == last_page) {
       return;
     }
@@ -165,8 +190,9 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
     uint32_t start =
         first_leaf > page_first_leaf ? first_leaf : page_first_leaf;
     uint32_t end = last_leaf < page_last_leaf ? last_leaf : page_last_leaf;
-    append_page_touch(metering->mem_page_buf, &len, page,
-                      leaf_mask_range(start, end));
+    uint64_t mask = leaf_mask_range(start, end);
+    append_page_touch(metering->mem_page_buf, &len, page, mask,
+                      is_write ? mask : 0u);
   }
   metering->mem_page_buf_len = len;
   metering->last_mem_page = last_page;
@@ -174,61 +200,68 @@ static __attribute__((always_inline)) inline void record_mem_page_range(
 
 /* No bounds check — see PV_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_pv_page(
-    MeteringState* metering, uint32_t page, uint64_t leaf_mask) {
+    MeteringState* metering, uint32_t page, uint64_t leaf_mask,
+    uint64_t dirty_mask) {
   append_page_touch(metering->pv_page_buf, &metering->pv_page_buf_len, page,
-                    leaf_mask);
+                    leaf_mask, dirty_mask);
 }
 
 static __attribute__((always_inline)) inline void record_pv_page_range(
-    MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf) {
+    MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf,
+    bool is_write) {
   uint32_t len = metering->pv_page_buf_len;
-  append_page_touch_range(metering->pv_page_buf, &len, first_leaf, last_leaf);
+  append_page_touch_range(metering->pv_page_buf, &len, first_leaf, last_leaf,
+                          is_write);
   metering->pv_page_buf_len = len;
 }
 
 /* No bounds check — see DEFERRAL_PAGE_BUF_CAP in metered.rs. */
 static __attribute__((always_inline)) inline void record_deferral_page(
-    MeteringState* metering, uint32_t page, uint64_t leaf_mask) {
+    MeteringState* metering, uint32_t page, uint64_t leaf_mask,
+    uint64_t dirty_mask) {
   append_page_touch(metering->deferral_page_buf,
-                    &metering->deferral_page_buf_len, page, leaf_mask);
+                    &metering->deferral_page_buf_len, page, leaf_mask,
+                    dirty_mask);
 }
 
 static __attribute__((always_inline)) inline void record_deferral_page_range(
-    MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf) {
+    MeteringState* metering, uint32_t first_leaf, uint32_t last_leaf,
+    bool is_write) {
   uint32_t len = metering->deferral_page_buf_len;
   append_page_touch_range(metering->deferral_page_buf, &len, first_leaf,
-                          last_leaf);
+                          last_leaf, is_write);
   metering->deferral_page_buf_len = len;
 }
 
 /* Record a single page access. `addr_space` is a compile-time constant at
  * every direct call site in generated C, so the branches below fold away. */
 static __attribute__((always_inline)) inline void record_page(
-    MeteringState* metering, uint32_t addr_space, uint64_t ptr, uint32_t size) {
+    MeteringState* metering, uint32_t addr_space, uint64_t ptr, uint32_t size,
+    bool is_write) {
   uint32_t first_leaf = addr_to_local_leaf(addr_space, ptr);
   uint32_t last_leaf = addr_to_local_leaf(addr_space, ptr + size - 1u);
   uint32_t first_page = first_leaf >> TRACER_PAGE_BITS;
   uint32_t last_page = last_leaf >> TRACER_PAGE_BITS;
   if (likely(addr_space == AS_MEMORY)) {
     if (likely(first_page == last_page)) {
-      record_mem_page(metering, first_page,
-                      leaf_mask_range(first_leaf, last_leaf));
+      uint64_t mask = leaf_mask_range(first_leaf, last_leaf);
+      record_mem_page(metering, first_page, mask, is_write ? mask : 0u);
     } else {
-      record_mem_page_range(metering, first_leaf, last_leaf);
+      record_mem_page_range(metering, first_leaf, last_leaf, is_write);
     }
   } else if (addr_space == AS_PUBLIC_VALUES) {
     if (first_page == last_page) {
-      record_pv_page(metering, first_page,
-                     leaf_mask_range(first_leaf, last_leaf));
+      uint64_t mask = leaf_mask_range(first_leaf, last_leaf);
+      record_pv_page(metering, first_page, mask, is_write ? mask : 0u);
     } else {
-      record_pv_page_range(metering, first_leaf, last_leaf);
+      record_pv_page_range(metering, first_leaf, last_leaf, is_write);
     }
   } else {
     if (first_page == last_page) {
-      record_deferral_page(metering, first_page,
-                           leaf_mask_range(first_leaf, last_leaf));
+      uint64_t mask = leaf_mask_range(first_leaf, last_leaf);
+      record_deferral_page(metering, first_page, mask, is_write ? mask : 0u);
     } else {
-      record_deferral_page_range(metering, first_leaf, last_leaf);
+      record_deferral_page_range(metering, first_leaf, last_leaf, is_write);
     }
   }
 }
@@ -237,15 +270,15 @@ static __attribute__((always_inline)) inline void record_page(
  * Rust-side checkpoint processing deduplicates by page mask. */
 static __attribute__((always_inline)) inline void record_page_range(
     MeteringState* metering, uint32_t addr_space, uint64_t first_addr,
-    uint64_t last_addr) {
+    uint64_t last_addr, bool is_write) {
   uint32_t first_leaf = addr_to_local_leaf(addr_space, first_addr);
   uint32_t last_leaf = addr_to_local_leaf(addr_space, last_addr);
   if (likely(addr_space == AS_MEMORY)) {
-    record_mem_page_range(metering, first_leaf, last_leaf);
+    record_mem_page_range(metering, first_leaf, last_leaf, is_write);
   } else if (addr_space == AS_PUBLIC_VALUES) {
-    record_pv_page_range(metering, first_leaf, last_leaf);
+    record_pv_page_range(metering, first_leaf, last_leaf, is_write);
   } else {
-    record_deferral_page_range(metering, first_leaf, last_leaf);
+    record_deferral_page_range(metering, first_leaf, last_leaf, is_write);
   }
 }
 
@@ -258,6 +291,7 @@ static __attribute__((always_inline)) inline TraceMemory trace_memory_setup(
       .mem_page_buf_len = metering->mem_page_buf_len,
       ._padding = 0,
       .last_leaf_mask = {0, 0},
+      .last_dirty_mask = {0, 0},
       .mem_page_buf = metering->mem_page_buf,
   };
   return memory;
@@ -269,12 +303,15 @@ static __attribute__((always_inline)) inline void trace_memory_drain_impl(
       memory->last_leaf_mask[cache] == 0) {
     memory->last_page[cache] = NO_LAST_PAGE;
     memory->last_leaf_mask[cache] = 0;
+    memory->last_dirty_mask[cache] = 0;
     return;
   }
   append_page_touch(memory->mem_page_buf, &memory->mem_page_buf_len,
-                    memory->last_page[cache], memory->last_leaf_mask[cache]);
+                    memory->last_page[cache], memory->last_leaf_mask[cache],
+                    memory->last_dirty_mask[cache]);
   memory->last_page[cache] = NO_LAST_PAGE;
   memory->last_leaf_mask[cache] = 0;
+  memory->last_dirty_mask[cache] = 0;
 }
 
 static __attribute__((always_inline)) inline void trace_memory_flush(
@@ -292,56 +329,64 @@ static __attribute__((always_inline)) inline void trace_memory_reload(
   memory->mem_page_buf_len = metering->mem_page_buf_len;
   memory->last_leaf_mask[TRACE_MEMORY_CACHE_DEFAULT] = 0;
   memory->last_leaf_mask[TRACE_MEMORY_CACHE_SP_RELATIVE] = 0;
+  memory->last_dirty_mask[TRACE_MEMORY_CACHE_DEFAULT] = 0;
+  memory->last_dirty_mask[TRACE_MEMORY_CACHE_SP_RELATIVE] = 0;
   memory->mem_page_buf = metering->mem_page_buf;
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_page_impl(
     TraceMemory* restrict memory, TraceMemoryCache cache, uint32_t page,
-    uint64_t leaf_mask) {
+    uint64_t leaf_mask, uint64_t dirty_mask) {
   /* Keep one pending AS_MEMORY page in registers for the current generated
-   * block. Consecutive accesses to that page merge by OR-ing leaf masks. */
+   * block. Consecutive accesses to that page merge by OR-ing masks. */
   if (likely(page == memory->last_page[cache])) {
     memory->last_leaf_mask[cache] |= leaf_mask;
+    memory->last_dirty_mask[cache] |= dirty_mask;
     return;
   }
   trace_memory_drain_impl(memory, cache);
   memory->last_page[cache] = page;
   memory->last_leaf_mask[cache] = leaf_mask;
+  memory->last_dirty_mask[cache] = dirty_mask;
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_leaf_impl(
-    TraceMemory* restrict memory, TraceMemoryCache cache, uint64_t addr) {
+    TraceMemory* restrict memory, TraceMemoryCache cache, uint64_t addr,
+    bool is_write) {
   uint32_t leaf = byte_addr_to_local_leaf(addr);
-  trace_memory_access_page_impl(memory, cache, leaf >> TRACER_PAGE_BITS,
-                                leaf_mask(leaf));
+  uint64_t mask = leaf_mask(leaf);
+  trace_memory_access_page_impl(memory, cache, leaf >> TRACER_PAGE_BITS, mask,
+                                is_write ? mask : 0u);
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_leaf(
-    TraceMemory* restrict memory, uint64_t addr) {
-  trace_memory_access_leaf_impl(memory, TRACE_MEMORY_CACHE_DEFAULT, addr);
+    TraceMemory* restrict memory, uint64_t addr, bool is_write) {
+  trace_memory_access_leaf_impl(memory, TRACE_MEMORY_CACHE_DEFAULT, addr,
+                                is_write);
 }
 
 static __attribute__((always_inline)) inline void trace_sp_memory_access_leaf(
-    TraceMemory* restrict memory, uint64_t addr) {
-  trace_memory_access_leaf_impl(memory, TRACE_MEMORY_CACHE_SP_RELATIVE, addr);
+    TraceMemory* restrict memory, uint64_t addr, bool is_write) {
+  trace_memory_access_leaf_impl(memory, TRACE_MEMORY_CACHE_SP_RELATIVE, addr,
+                                is_write);
 }
 
 /* Record every memory leaf overlapped by [addr, addr + size). Generated
  * accesses are no wider than one leaf, so at most two leaves are touched. */
 static __attribute__((always_inline)) inline void trace_memory_access_span_impl(
     TraceMemory* restrict memory, TraceMemoryCache cache, uint64_t addr,
-    uint32_t size) {
+    uint32_t size, bool is_write) {
   assume(size != 0u && size <= TRACER_BYTES_PER_LEAF);
   assume((size & (size - 1u)) == 0u);
   if (likely((addr & (size - 1u)) == 0u)) {
-    trace_memory_access_leaf_impl(memory, cache, addr);
+    trace_memory_access_leaf_impl(memory, cache, addr, is_write);
     return;
   }
 
   uint32_t leaf_offset = addr & TRACER_LEAF_BYTE_OFFSET_MASK;
   uint32_t bytes_until_next_leaf = TRACER_BYTES_PER_LEAF - leaf_offset;
   if (likely(size <= bytes_until_next_leaf)) {
-    trace_memory_access_leaf_impl(memory, cache, addr);
+    trace_memory_access_leaf_impl(memory, cache, addr, is_write);
     return;
   }
 
@@ -352,23 +397,29 @@ static __attribute__((always_inline)) inline void trace_memory_access_span_impl(
   uint64_t first_mask = leaf_mask(first_leaf);
   uint64_t last_mask = leaf_mask(last_leaf);
   if (likely(first_page == last_page)) {
-    trace_memory_access_page_impl(memory, cache, first_page,
-                                  first_mask | last_mask);
+    uint64_t mask = first_mask | last_mask;
+    trace_memory_access_page_impl(memory, cache, first_page, mask,
+                                  is_write ? mask : 0u);
   } else {
-    trace_memory_access_page_impl(memory, cache, first_page, first_mask);
-    trace_memory_access_page_impl(memory, cache, last_page, last_mask);
+    trace_memory_access_page_impl(memory, cache, first_page, first_mask,
+                                  is_write ? first_mask : 0u);
+    trace_memory_access_page_impl(memory, cache, last_page, last_mask,
+                                  is_write ? last_mask : 0u);
   }
 }
 
 static __attribute__((always_inline)) inline void trace_memory_access_span(
-    TraceMemory* restrict memory, uint64_t addr, uint32_t size) {
-  trace_memory_access_span_impl(memory, TRACE_MEMORY_CACHE_DEFAULT, addr, size);
+    TraceMemory* restrict memory, uint64_t addr, uint32_t size,
+    bool is_write) {
+  trace_memory_access_span_impl(memory, TRACE_MEMORY_CACHE_DEFAULT, addr, size,
+                                is_write);
 }
 
 static __attribute__((always_inline)) inline void trace_sp_memory_access_span(
-    TraceMemory* restrict memory, uint64_t addr, uint32_t size) {
+    TraceMemory* restrict memory, uint64_t addr, uint32_t size,
+    bool is_write) {
   trace_memory_access_span_impl(memory, TRACE_MEMORY_CACHE_SP_RELATIVE, addr,
-                                size);
+                                size, is_write);
 }
 
 /* Extension range access includes page accounting in metered mode. */
@@ -383,7 +434,8 @@ static __attribute__((always_inline)) inline void read_mem_u64_range(
   read_mem_u64_range_raw(state, base_addr, out, num_words);
   assume(num_words > 0);
   uint64_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
-  record_page_range(&state->mode_state, AS_MEMORY, base_addr, last_addr);
+  record_page_range(&state->mode_state, AS_MEMORY, base_addr, last_addr,
+                    /*is_write=*/false);
 }
 
 static __attribute__((always_inline)) inline void write_mem_u64_range(
@@ -391,7 +443,8 @@ static __attribute__((always_inline)) inline void write_mem_u64_range(
     uint32_t num_words) {
   assume(num_words > 0);
   uint64_t last_addr = base_addr + num_words * sizeof(uint64_t) - 1u;
-  record_page_range(&state->mode_state, AS_MEMORY, base_addr, last_addr);
+  record_page_range(&state->mode_state, AS_MEMORY, base_addr, last_addr,
+                    /*is_write=*/true);
   write_mem_u64_range_raw(state, base_addr, vals, num_words);
 }
 
@@ -410,17 +463,18 @@ static __attribute__((always_inline)) inline void peek_mem_u64_range(
 /* ── Page accounting ──────────────────────────────────────────────── */
 
 static __attribute__((always_inline)) inline void trace_page_access(
-    RvState* restrict state, uint64_t addr, uint32_t size,
-    uint32_t addr_space) {
-  record_page(&state->mode_state, addr_space, addr, size);
+    RvState* restrict state, uint64_t addr, uint32_t size, uint32_t addr_space,
+    bool is_write) {
+  record_page(&state->mode_state, addr_space, addr, size, is_write);
 }
 
 static __attribute__((always_inline)) inline void trace_page_access_u64_range(
     RvState* restrict state, uint64_t base_addr, uint64_t num_dwords,
-    uint32_t addr_space) {
+    uint32_t addr_space, bool is_write) {
   assume(num_dwords > 0);
   uint64_t last_addr = base_addr + num_dwords * WORD_SIZE - 1u;
-  record_page_range(&state->mode_state, addr_space, base_addr, last_addr);
+  record_page_range(&state->mode_state, addr_space, base_addr, last_addr,
+                    is_write);
 }
 
 /* Drain AS_MEMORY page touches while preserving the instruction counter and

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_metered_cost.h
@@ -40,7 +40,7 @@ static __attribute__((always_inline)) inline void peek_mem_u64_range(
 static __attribute__((always_inline)) inline void trace_page_access_u64_range(
     RvState* restrict state [[maybe_unused]],
     uint64_t base_addr [[maybe_unused]], uint64_t num_dwords [[maybe_unused]],
-    uint32_t addr_space [[maybe_unused]]) {}
+    uint32_t addr_space [[maybe_unused]], bool is_write [[maybe_unused]]) {}
 
 static __attribute__((always_inline)) inline void
 flush_main_memory_page_buffer(RvState* restrict state [[maybe_unused]]) {}

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_preflight.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_preflight.h
@@ -269,7 +269,7 @@ static __attribute__((always_inline)) inline void
 trace_page_access_u64_range(
     RvState* restrict state [[maybe_unused]],
     uint64_t base_addr [[maybe_unused]], uint64_t num_dwords [[maybe_unused]],
-    uint32_t addr_space [[maybe_unused]]) {}
+    uint32_t addr_space [[maybe_unused]], bool is_write [[maybe_unused]]) {}
 
 static __attribute__((always_inline)) inline void
 flush_main_memory_page_buffer(RvState* restrict state [[maybe_unused]]) {}

--- a/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
+++ b/crates/rvr/rvr-openvm/c/tracer/openvm_tracer_pure.h
@@ -41,7 +41,7 @@ static __attribute__((always_inline)) inline void peek_mem_u64_range(
 static __attribute__((always_inline)) inline void trace_page_access_u64_range(
     RvState* restrict state [[maybe_unused]],
     uint64_t base_addr [[maybe_unused]], uint64_t num_dwords [[maybe_unused]],
-    uint32_t addr_space [[maybe_unused]]) {}
+    uint32_t addr_space [[maybe_unused]], bool is_write [[maybe_unused]]) {}
 
 static __attribute__((always_inline)) inline void
 flush_main_memory_page_buffer(RvState* restrict state [[maybe_unused]]) {}

--- a/crates/rvr/rvr-openvm/src/emit/context.rs
+++ b/crates/rvr/rvr-openvm/src/emit/context.rs
@@ -426,7 +426,7 @@ impl<'a> EmitContext<'a> {
         self.write_line(&format!("{var_ty} {var} = {read_func}(memory, {addr});"));
         self.count_fixed_timestamp_slots(if width == 1 { 1 } else { 2 });
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width, sp_relative);
+            self.emit_inline_page_record(&addr, width, sp_relative, false);
         }
         var
     }
@@ -453,7 +453,7 @@ impl<'a> EmitContext<'a> {
 
         self.emit_memory_bounds_trap(&addr, width);
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(&addr, width, sp_relative);
+            self.emit_inline_page_record(&addr, width, sp_relative, true);
         }
         self.count_fixed_timestamp_slots(if width == 1 { 1 } else { 2 });
         self.write_line(&format!(
@@ -484,7 +484,7 @@ impl<'a> EmitContext<'a> {
 
         self.emit_memory_bounds_trap(addr, MEMORY_BLOCK_BYTES as u8);
         if self.mode.traces_memory_pages() {
-            self.emit_inline_page_record(addr, MEMORY_BLOCK_BYTES as u8, false);
+            self.emit_inline_page_record(addr, MEMORY_BLOCK_BYTES as u8, false, true);
         }
         self.count_fixed_timestamp_slots(1);
         self.write_line(&format!(
@@ -640,17 +640,25 @@ impl<'a> EmitContext<'a> {
         self.write_line("}");
     }
 
-    fn emit_inline_page_record(&mut self, addr: &str, width: u8, sp_relative: bool) {
+    fn emit_inline_page_record(
+        &mut self,
+        addr: &str,
+        width: u8,
+        sp_relative: bool,
+        is_write: bool,
+    ) {
         let prefix = if sp_relative {
             "trace_sp_memory"
         } else {
             "trace_memory"
         };
         if width == 1 {
-            self.write_line(&format!("{prefix}_access_leaf(&trace_memory, {addr});"));
+            self.write_line(&format!(
+                "{prefix}_access_leaf(&trace_memory, {addr}, {is_write});"
+            ));
         } else {
             self.write_line(&format!(
-                "{prefix}_access_span(&trace_memory, {addr}, {width}u);"
+                "{prefix}_access_span(&trace_memory, {addr}, {width}u, {is_write});"
             ));
         }
     }
@@ -771,7 +779,13 @@ impl<'a> EmitContext<'a> {
         self.write_line("}");
     }
 
-    pub fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: PageAddressSpace) {
+    pub fn trace_page_access(
+        &mut self,
+        addr: &str,
+        width: MemWidth,
+        addr_space: PageAddressSpace,
+        is_write: bool,
+    ) {
         if !matches!(self.mode, EmitMode::Metered { .. }) {
             return;
         }
@@ -781,8 +795,8 @@ impl<'a> EmitContext<'a> {
         }
         let size = width.bytes();
         self.write_line(&format!(
-            "trace_page_access(state, {addr}, {size}u, {}u);",
-            addr_space.id()
+            "trace_page_access(state, {addr}, {size}u, {}u, {is_write});",
+            addr_space.id(),
         ));
         if touches_memory {
             self.reload_page_locals();
@@ -794,6 +808,7 @@ impl<'a> EmitContext<'a> {
         base_addr: &str,
         num_dwords: &str,
         addr_space: PageAddressSpace,
+        is_write: bool,
     ) {
         if !matches!(self.mode, EmitMode::Metered { .. }) {
             return;
@@ -803,8 +818,8 @@ impl<'a> EmitContext<'a> {
             self.flush_page_locals();
         }
         self.write_line(&format!(
-            "trace_page_access_u64_range(state, {base_addr}, {num_dwords}, {}u);",
-            addr_space.id()
+            "trace_page_access_u64_range(state, {base_addr}, {num_dwords}, {}u, {is_write});",
+            addr_space.id(),
         ));
         if touches_memory {
             self.reload_page_locals();
@@ -969,8 +984,14 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         EmitContext::trace_chip_if_nonzero(self, chip_idx, count_expr);
     }
 
-    fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: PageAddressSpace) {
-        EmitContext::trace_page_access(self, addr, width, addr_space);
+    fn trace_page_access(
+        &mut self,
+        addr: &str,
+        width: MemWidth,
+        addr_space: PageAddressSpace,
+        is_write: bool,
+    ) {
+        EmitContext::trace_page_access(self, addr, width, addr_space, is_write);
     }
 
     fn trace_page_access_u64_range(
@@ -978,8 +999,9 @@ impl rvr_openvm_ir::ExtEmitCtx for EmitContext<'_> {
         base_addr: &str,
         num_dwords: &str,
         addr_space: PageAddressSpace,
+        is_write: bool,
     ) {
-        EmitContext::trace_page_access_u64_range(self, base_addr, num_dwords, addr_space);
+        EmitContext::trace_page_access_u64_range(self, base_addr, num_dwords, addr_space, is_write);
     }
 }
 
@@ -1306,7 +1328,7 @@ mod tests {
 
         assert_eq!(
             ctx.buf()
-                .matches("trace_memory_access_span(&trace_memory, addr, 8u);")
+                .matches("trace_memory_access_span(&trace_memory, addr, 8u, true);")
                 .count(),
             1
         );
@@ -1333,7 +1355,7 @@ mod tests {
 
         assert!(ctx
             .buf()
-            .contains("trace_memory_access_span(&trace_memory, addr, 8u);"));
+            .contains("trace_memory_access_span(&trace_memory, addr, 8u, false);"));
     }
 
     #[test]
@@ -1344,10 +1366,10 @@ mod tests {
 
         assert!(ctx
             .buf()
-            .contains("trace_sp_memory_access_leaf(&trace_memory, sp + 0x00000004u);"));
+            .contains("trace_sp_memory_access_leaf(&trace_memory, sp + 0x00000004u, false);"));
         assert!(ctx
             .buf()
-            .contains("trace_sp_memory_access_span(&trace_memory, sp - 0x00000008u, 8u);"));
+            .contains("trace_sp_memory_access_span(&trace_memory, sp - 0x00000008u, 8u, true);"));
         assert!(!ctx.buf().contains("trace_memory_access_leaf(&trace_memory"));
         assert!(!ctx.buf().contains("trace_memory_access_span(&trace_memory"));
     }

--- a/crates/vm/src/arch/execution_mode/metered/ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/ctx.rs
@@ -238,7 +238,7 @@ impl MeteredCtx {
 
 impl ExecutionCtxTrait for MeteredCtx {
     #[inline(always)]
-    fn on_memory_operation(&mut self, address_space: u32, ptr: u32, size: u32) {
+    fn on_memory_operation(&mut self, address_space: u32, ptr: u32, size: u32, is_write: bool) {
         debug_assert!(
             address_space != RV64_IMM_AS,
             "address space must not be immediate"
@@ -252,7 +252,7 @@ impl ExecutionCtxTrait for MeteredCtx {
         // Handle merkle tree updates
         if address_space != RV64_REGISTER_AS {
             self.memory_ctx
-                .update_boundary_merkle_heights(address_space, ptr, size);
+                .update_boundary_merkle_heights(address_space, ptr, size, is_write);
         }
     }
 

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -41,6 +41,10 @@ pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
     /// Memory leaves and nodes already counted in the current segment.
     segment_memory: SegmentMemoryTracker,
+    /// Written (dirty) leaves and nodes already counted in the current segment. Dirty
+    /// entities cost final-direction Merkle rows and Poseidon2 compressions; read-only
+    /// ones do not. Dirtiness is per write, matching tracegen's definition exactly.
+    segment_dirty: SegmentMemoryTracker,
     /// Memory leaves and nodes present in the baseline at the last checkpoint.
     baseline_memory: BaselineMemoryTracker,
     /// Touches since the last safe checkpoint, kept so they can be replayed into a new segment.
@@ -55,6 +59,11 @@ pub struct MemoryCtx {
     pending_segment_leaves: u32,
     /// Newly needed tree nodes waiting to be added to the Merkle row estimate.
     pending_segment_merkle_nodes: u32,
+    /// Newly written leaves waiting to be added to the final-direction estimates.
+    pending_dirty_leaves: u32,
+    /// Newly needed dirty-tree nodes waiting to be added to the final-direction
+    /// estimates.
+    pending_dirty_merkle_nodes: u32,
     /// Pending leaves and nodes that were absent at the last checkpoint.
     pending_first_touches: FirstTouchCounts,
     /// Reusable default-hash rows already charged in the current segment.
@@ -72,6 +81,7 @@ impl MemoryCtx {
         Self {
             memory_dimensions,
             segment_memory: SegmentMemoryTracker::new(upper_height),
+            segment_dirty: SegmentMemoryTracker::new(upper_height),
             baseline_memory: BaselineMemoryTracker::new(upper_height),
             page_indices_since_checkpoint: Vec::with_capacity(checkpoint_capacity),
             page_indices_since_checkpoint_len: 0,
@@ -79,6 +89,8 @@ impl MemoryCtx {
             pending_baseline_updates: Vec::with_capacity(checkpoint_capacity),
             pending_segment_leaves: 0,
             pending_segment_merkle_nodes: 0,
+            pending_dirty_leaves: 0,
+            pending_dirty_merkle_nodes: 0,
             pending_first_touches: FirstTouchCounts::default(),
             default_poseidon_rows: DefaultPoseidonRowTracker::default(),
         }
@@ -91,10 +103,15 @@ impl MemoryCtx {
 
     #[inline(always)]
     pub(crate) fn add_register_merkle_heights(&mut self) {
+        // Conservatively count the full register file as written. Generated RVR keeps
+        // registers outside the page-touch buffers, so metering cannot recover its
+        // exact written subset. This also covers the Merkle root's unconditional final
+        // row in a segment with no other writes.
         self.update_boundary_merkle_heights(
             RV64_REGISTER_AS,
             0,
             (RV64_NUM_REGISTERS * RV64_REGISTER_NUM_LIMBS) as u32,
+            true,
         );
     }
 
@@ -157,22 +174,26 @@ impl MemoryCtx {
     /// Records the memory-tree pages touched by `[ptr, ptr + size)`.
     /// For metered callbacks, DEFERRAL_AS ranges are AS-native F-cell ranges and
     /// u16-celled address space ranges are byte ranges.
+    /// Writes additionally mark the leaves as dirty.
     #[inline(always)]
     pub(crate) fn update_boundary_merkle_heights(
         &mut self,
         address_space: u32,
         ptr: u32,
         size: u32,
+        is_write: bool,
     ) {
         let (start_leaf_id, end_leaf_id) = self.leaf_id_range(address_space, ptr, size);
         let num_leaves = end_leaf_id - start_leaf_id;
         let start_page_id = start_leaf_id >> PAGE_MASK_LEAF_BITS;
 
         if num_leaves == 1 {
+            let leaf_mask = 1u64 << (start_leaf_id & ((1 << PAGE_MASK_LEAF_BITS) - 1));
             push_page_touch(
                 &mut self.page_indices_since_checkpoint,
                 start_page_id,
-                1u64 << (start_leaf_id & ((1 << PAGE_MASK_LEAF_BITS) - 1)),
+                leaf_mask,
+                if is_write { leaf_mask } else { 0 },
             );
             self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
             return;
@@ -194,7 +215,12 @@ impl MemoryCtx {
             let start = start_leaf_id.max(page_start) - page_start;
             let end = end_leaf_id.min(page_end) - page_start;
             let leaf_mask = leaf_mask_range(start, end);
-            push_page_touch(&mut self.page_indices_since_checkpoint, page_id, leaf_mask);
+            push_page_touch(
+                &mut self.page_indices_since_checkpoint,
+                page_id,
+                leaf_mask,
+                if is_write { leaf_mask } else { 0 },
+            );
         }
         self.page_indices_since_checkpoint_len = self.page_indices_since_checkpoint.len();
     }
@@ -225,8 +251,16 @@ impl MemoryCtx {
                     &mut self.pending_baseline_updates,
                     page_id,
                     delta.new_segment_leaf_mask,
+                    0,
                 );
                 self.pending_first_touches.add(delta.first_touches);
+            }
+            if touch.dirty_mask != 0 {
+                let (dirty_leaves, dirty_nodes) = self
+                    .segment_dirty
+                    .insert_counting(page_id as usize, touch.dirty_mask);
+                self.pending_dirty_leaves += dirty_leaves;
+                self.pending_dirty_merkle_nodes += dirty_nodes;
             }
         }
     }
@@ -235,12 +269,15 @@ impl MemoryCtx {
     #[inline(always)]
     pub(crate) fn reset_segment_without_replay(&mut self, trace_heights: &mut [u32]) {
         self.segment_memory.clear();
+        self.segment_dirty.clear();
         self.page_indices_since_checkpoint.clear();
         self.page_indices_since_checkpoint_len = 0;
         self.page_indices_applied_len = 0;
         self.pending_baseline_updates.clear();
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
+        self.pending_dirty_leaves = 0;
+        self.pending_dirty_merkle_nodes = 0;
         self.pending_first_touches = FirstTouchCounts::default();
         self.default_poseidon_rows = DefaultPoseidonRowTracker::default();
 
@@ -261,10 +298,13 @@ impl MemoryCtx {
     #[inline(always)]
     pub(crate) fn initialize_segment(&mut self, trace_heights: &mut [u32]) {
         self.segment_memory.clear();
+        self.segment_dirty.clear();
         self.page_indices_applied_len = 0;
         self.pending_baseline_updates.clear();
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
+        self.pending_dirty_leaves = 0;
+        self.pending_dirty_merkle_nodes = 0;
         self.pending_first_touches = FirstTouchCounts::default();
         self.default_poseidon_rows = DefaultPoseidonRowTracker::default();
 
@@ -298,31 +338,42 @@ impl MemoryCtx {
         self.pending_baseline_updates.clear();
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
+        self.pending_dirty_leaves = 0;
+        self.pending_dirty_merkle_nodes = 0;
         self.pending_first_touches = FirstTouchCounts::default();
     }
 
     /// Applies memory height deltas recorded since the last checkpoint.
     ///
-    /// - BOUNDARY_AIR: `segment_leaves` rows
-    /// - MERKLE_AIR:   `2 * segment_merkle_nodes` rows
-    /// - Poseidon2:    hashes at the end of the segment plus hashes at its start
+    /// - BOUNDARY_AIR: `segment_leaves` rows (one per touched leaf)
+    /// - MERKLE_AIR:   `segment_merkle_nodes + dirty_merkle_nodes` rows (an initial row per touched
+    ///   node, a final row per written-below node)
+    /// - Poseidon2:    hashes at the end of the segment (dirty entities only) plus hashes at its
+    ///   start (all touched entities)
     ///
     /// A leaf or node absent at the checkpoint starts from the hash of zero-filled memory. Equal
     /// starting hashes share a row: one for all zero leaves and one for each internal-node height.
     /// Therefore:
     ///
     /// ```text
-    /// Poseidon2 rows = end-of-segment hashes
+    /// Poseidon2 rows = end-of-segment hashes (dirty leaves + dirty nodes)
     ///                + nonzero checkpoint hashes
     ///                + shared zero-filled hashes
     /// ```
+    ///
+    /// "Written" is exactly tracegen's definition of dirty (per write, independent of the
+    /// written content), so the dirty terms match the realized trace heights.
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_segment_leaves;
         let mut merkle_nodes = self.pending_segment_merkle_nodes;
+        let mut dirty_leaves = self.pending_dirty_leaves;
+        let mut dirty_merkle_nodes = self.pending_dirty_merkle_nodes;
         let mut first_touches = self.pending_first_touches;
         self.pending_segment_leaves = 0;
         self.pending_segment_merkle_nodes = 0;
+        self.pending_dirty_leaves = 0;
+        self.pending_dirty_merkle_nodes = 0;
         self.pending_first_touches = FirstTouchCounts::default();
 
         let len = self.page_indices_since_checkpoint.len();
@@ -342,13 +393,23 @@ impl MemoryCtx {
                     &mut self.pending_baseline_updates,
                     touch.page_id,
                     delta.new_segment_leaf_mask,
+                    0,
                 );
                 first_touches.add(delta.first_touches);
+            }
+            // A write to an already-touched leaf adds no touched delta but can still be
+            // newly dirty, so this is not gated on the touched delta above.
+            if touch.dirty_mask != 0 {
+                let (new_dirty_leaves, new_dirty_nodes) = self
+                    .segment_dirty
+                    .insert_counting(touch.page_id as usize, touch.dirty_mask);
+                dirty_leaves += new_dirty_leaves;
+                dirty_merkle_nodes += new_dirty_nodes;
             }
         }
         self.page_indices_applied_len = len;
 
-        if leaves == 0 && merkle_nodes == 0 {
+        if leaves == 0 && merkle_nodes == 0 && dirty_leaves == 0 && dirty_merkle_nodes == 0 {
             return;
         }
 
@@ -357,29 +418,31 @@ impl MemoryCtx {
         let initial_default_poseidon_rows = self.default_poseidon_rows.count_new(first_touches);
         let initial_nondefault_poseidon_rows = (leaves + merkle_nodes)
             .saturating_sub(first_touches.leaves + first_touches.merkle_nodes);
-        let poseidon2_rows = leaves
-            + merkle_nodes
+        let poseidon2_rows = dirty_leaves
+            + dirty_merkle_nodes
             + initial_nondefault_poseidon_rows
             + initial_default_poseidon_rows;
         // SAFETY: BOUNDARY_AIR_ID, MERKLE_AIR_ID, and poseidon2_idx are all within bounds
         unsafe {
             *trace_heights.get_unchecked_mut(BOUNDARY_AIR_ID) += leaves;
             *trace_heights.get_unchecked_mut(poseidon2_idx) += poseidon2_rows;
-            // Merkle AIR: 2 rows per internal node (init + final tree)
-            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes * 2;
+            // Merkle AIR: an initial row per touched node plus a final row per dirty node
+            *trace_heights.get_unchecked_mut(MERKLE_AIR_ID) += merkle_nodes + dirty_merkle_nodes;
         }
     }
 }
 
 #[inline(always)]
-fn push_page_touch(touches: &mut Vec<PageTouch>, page_id: u32, leaf_mask: u64) {
+fn push_page_touch(touches: &mut Vec<PageTouch>, page_id: u32, leaf_mask: u64, dirty_mask: u64) {
     debug_assert!(leaf_mask != 0);
+    debug_assert!(dirty_mask & !leaf_mask == 0);
     let len = touches.len();
     if len != 0 {
         // SAFETY: len is non-zero, so len - 1 is in bounds.
         let prev = unsafe { touches.get_unchecked_mut(len - 1) };
         if prev.page_id == page_id {
             prev.leaf_mask |= leaf_mask;
+            prev.dirty_mask |= dirty_mask;
             return;
         }
     }
@@ -394,6 +457,7 @@ fn push_page_touch(touches: &mut Vec<PageTouch>, page_id: u32, leaf_mask: u64) {
             page_id,
             _padding: 0,
             leaf_mask,
+            dirty_mask,
         });
         touches.set_len(len + 1);
     }
@@ -412,9 +476,9 @@ mod tests {
         let mut range_ctx = MemoryCtx::new(&system_config);
         let mut explicit_ctx = MemoryCtx::new(&system_config);
 
-        range_ctx.update_boundary_merkle_heights(2, 0, 17);
+        range_ctx.update_boundary_merkle_heights(2, 0, 17, true);
         for ptr in [0, 16] {
-            explicit_ctx.update_boundary_merkle_heights(2, ptr, 1);
+            explicit_ctx.update_boundary_merkle_heights(2, ptr, 1, true);
         }
 
         let mut range_heights = vec![0; 6];
@@ -448,13 +512,55 @@ mod tests {
         }
     }
 
+    /// Reads pay only initial-direction rows; writes add one final-direction Merkle row
+    /// per spanning node and one Poseidon2 compression per dirty leaf/node. A later
+    /// write to an already-read leaf upgrades it to exactly the written cost.
+    #[test]
+    fn test_read_only_touches_cost_no_final_direction_rows() {
+        let system_config = test_system_config();
+        let mut read_ctx = MemoryCtx::new(&system_config);
+        let mut write_ctx = MemoryCtx::new(&system_config);
+        let mut read_heights = vec![0; 6];
+        let mut write_heights = vec![0; 6];
+
+        read_ctx.update_boundary_merkle_heights(2, 0, 1, false);
+        write_ctx.update_boundary_merkle_heights(2, 0, 1, true);
+        read_ctx.apply_height_updates(&mut read_heights);
+        write_ctx.apply_height_updates(&mut write_heights);
+
+        // Boundary: one row per touched leaf, written or not.
+        assert_eq!(
+            read_heights[BOUNDARY_AIR_ID],
+            write_heights[BOUNDARY_AIR_ID]
+        );
+        // Merkle: the write pays a final row per node on top of the shared initial rows.
+        let read_merkle = read_heights[MERKLE_AIR_ID];
+        assert!(read_merkle > 0);
+        assert_eq!(write_heights[MERKLE_AIR_ID], 2 * read_merkle);
+        // Poseidon2: the write additionally hashes the dirty leaf and each dirty node.
+        let poseidon2_idx = read_heights.len() - 2;
+        assert_eq!(
+            write_heights[poseidon2_idx],
+            read_heights[poseidon2_idx] + 1 + read_merkle
+        );
+
+        // Reading and then writing the same leaf costs exactly what writing it costs:
+        // the write upgrades the touched leaf to dirty.
+        let mut upgrade_ctx = MemoryCtx::new(&system_config);
+        let mut upgrade_heights = vec![0; 6];
+        upgrade_ctx.update_boundary_merkle_heights(2, 0, 1, false);
+        upgrade_ctx.update_boundary_merkle_heights(2, 0, 1, true);
+        upgrade_ctx.apply_height_updates(&mut upgrade_heights);
+        assert_eq!(upgrade_heights, write_heights);
+    }
+
     #[test]
     fn test_tentative_apply_does_not_commit_occupancy() {
         let system_config = test_system_config();
         let mut ctx = MemoryCtx::new(&system_config);
         let mut trace_heights = vec![0; 6];
 
-        ctx.update_boundary_merkle_heights(2, 0, 1);
+        ctx.update_boundary_merkle_heights(2, 0, 1, true);
         ctx.apply_height_updates(&mut trace_heights);
 
         let page_id = ((2 - ADDR_SPACE_OFFSET) << ctx.memory_dimensions.address_height) as usize
@@ -482,8 +588,8 @@ mod tests {
         let height = ctx.memory_dimensions.overall_height() as u32;
         let second_leaf_ptr = (U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
-        ctx.update_boundary_merkle_heights(2, 0, 1);
-        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+        ctx.update_boundary_merkle_heights(2, 0, 1, true);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1, true);
 
         let mut trace_heights = vec![0; 6];
         ctx.apply_height_updates(&mut trace_heights);
@@ -500,7 +606,7 @@ mod tests {
         let mut ctx = MemoryCtx::new(&system_config);
         let mut trace_heights = vec![0; 6];
 
-        ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 1);
+        ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 1, true);
         ctx.apply_height_updates(&mut trace_heights);
         ctx.update_checkpoint();
 
@@ -510,7 +616,7 @@ mod tests {
         let poseidon_before = trace_heights[poseidon2_idx];
         let next_page_ptr = ((1 << PAGE_MASK_LEAF_BITS) * U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
-        ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1);
+        ctx.update_boundary_merkle_heights(RV64_MEMORY_AS, next_page_ptr, 1, true);
         ctx.apply_height_updates(&mut trace_heights);
 
         assert_eq!(trace_heights[BOUNDARY_AIR_ID] - boundary_before, 1);
@@ -532,8 +638,8 @@ mod tests {
         ctx.seed_initial_memory(&SparseMemoryImage::from([((2, 0), 0)]));
         let second_leaf_ptr = (U16_CELL_SIZE * VM_DIGEST_WIDTH) as u32;
 
-        ctx.update_boundary_merkle_heights(2, 0, 1);
-        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+        ctx.update_boundary_merkle_heights(2, 0, 1, true);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1, true);
 
         let mut trace_heights = vec![0; 6];
         ctx.apply_height_updates(&mut trace_heights);
@@ -553,8 +659,8 @@ mod tests {
             ((2, second_leaf_ptr), 1),
         ]));
 
-        ctx.update_boundary_merkle_heights(2, 0, 1);
-        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1);
+        ctx.update_boundary_merkle_heights(2, 0, 1, true);
+        ctx.update_boundary_merkle_heights(2, second_leaf_ptr, 1, true);
 
         let mut trace_heights = vec![0; 6];
         ctx.apply_height_updates(&mut trace_heights);
@@ -575,8 +681,8 @@ mod tests {
             ((DEFERRAL_AS, second_leaf_byte_ptr), 1),
         ]));
 
-        ctx.update_boundary_merkle_heights(DEFERRAL_AS, 0, 1);
-        ctx.update_boundary_merkle_heights(DEFERRAL_AS, second_leaf_ptr, 1);
+        ctx.update_boundary_merkle_heights(DEFERRAL_AS, 0, 1, true);
+        ctx.update_boundary_merkle_heights(DEFERRAL_AS, second_leaf_ptr, 1, true);
 
         let mut trace_heights = vec![0; 6];
         ctx.apply_height_updates(&mut trace_heights);

--- a/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_ctx.rs
@@ -41,9 +41,8 @@ pub struct MemoryCtx {
     memory_dimensions: MemoryDimensions,
     /// Memory leaves and nodes already counted in the current segment.
     segment_memory: SegmentMemoryTracker,
-    /// Written (dirty) leaves and nodes already counted in the current segment. Dirty
-    /// entities cost final-direction Merkle rows and Poseidon2 compressions; read-only
-    /// ones do not. Dirtiness is per write, matching tracegen's definition exactly.
+    /// Written leaves and their tree nodes already counted in the current segment. A write adds
+    /// final-direction Merkle rows and Poseidon2 compressions, regardless of the written value.
     segment_dirty: SegmentMemoryTracker,
     /// Memory leaves and nodes present in the baseline at the last checkpoint.
     baseline_memory: BaselineMemoryTracker,
@@ -348,8 +347,8 @@ impl MemoryCtx {
     /// - BOUNDARY_AIR: `segment_leaves` rows (one per touched leaf)
     /// - MERKLE_AIR:   `segment_merkle_nodes + dirty_merkle_nodes` rows (an initial row per touched
     ///   node, a final row per written-below node)
-    /// - Poseidon2:    hashes at the end of the segment (dirty entities only) plus hashes at its
-    ///   start (all touched entities)
+    /// - Poseidon2:    end-of-segment hashes for written leaves and nodes, plus start-of-segment
+    ///   hashes for all touched leaves and nodes
     ///
     /// A leaf or node absent at the checkpoint starts from the hash of zero-filled memory. Equal
     /// starting hashes share a row: one for all zero leaves and one for each internal-node height.
@@ -361,8 +360,8 @@ impl MemoryCtx {
     ///                + shared zero-filled hashes
     /// ```
     ///
-    /// "Written" is exactly tracegen's definition of dirty (per write, independent of the
-    /// written content), so the dirty terms match the realized trace heights.
+    /// A leaf is dirty after any write, regardless of the written value. This matches trace
+    /// generation, so the dirty counts match the generated trace heights.
     #[inline(always)]
     pub(crate) fn apply_height_updates(&mut self, trace_heights: &mut [u32]) {
         let mut leaves = self.pending_segment_leaves;

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -26,10 +26,8 @@ pub struct PageTouch {
     pub _padding: u32,
     /// Leaves touched in this page, with one bit per leaf.
     pub leaf_mask: u64,
-    /// Leaves *written* in this page (`dirty_mask & !leaf_mask == 0`). Written leaves
-    /// are exactly the leaves tracegen commits final state for (dirtiness is per write,
-    /// independent of the written content), costing final-direction Merkle rows and
-    /// Poseidon2 compressions; read-only leaves do not.
+    /// Leaves written in this page (`dirty_mask & !leaf_mask == 0`). A write adds
+    /// final-direction Merkle rows and Poseidon2 compressions, regardless of the written value.
     pub dirty_mask: u64,
 }
 
@@ -436,9 +434,8 @@ impl SegmentMemoryTracker {
         count
     }
 
-    /// Leaf/node counting without baseline bookkeeping. Used for the dirty
-    /// (written-leaf) mirror: dirtiness has no first-touch/default-hash concept (those
-    /// are initial-side notions), only the size of the spanning tree matters.
+    /// Counts written leaves and their tree nodes. The baseline only affects initial-state rows,
+    /// so written leaves need only the size of their spanning tree.
     #[inline(always)]
     pub(super) fn insert_counting(&mut self, page_id: usize, leaf_mask: u64) -> (u32, u32) {
         debug_assert!(page_id < self.segment_leaf_masks.len());

--- a/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
+++ b/crates/vm/src/arch/execution_mode/metered/memory_tracker.rs
@@ -22,11 +22,24 @@ const FIRST_LEAF_PER_64_LEAVES: u64 = 0x0000_0000_0000_0001;
 pub struct PageTouch {
     /// Index of the 64-leaf page in the memory tree.
     pub page_id: u32,
-    /// Aligns `leaf_mask` and makes the shared 16-byte Rust/C layout explicit.
+    /// Aligns `leaf_mask` and makes the shared 24-byte Rust/C layout explicit.
     pub _padding: u32,
     /// Leaves touched in this page, with one bit per leaf.
     pub leaf_mask: u64,
+    /// Leaves *written* in this page (`dirty_mask & !leaf_mask == 0`). Written leaves
+    /// are exactly the leaves tracegen commits final state for (dirtiness is per write,
+    /// independent of the written content), costing final-direction Merkle rows and
+    /// Poseidon2 compressions; read-only leaves do not.
+    pub dirty_mask: u64,
 }
+
+const _: () = {
+    assert!(std::mem::size_of::<PageTouch>() == 24);
+    assert!(std::mem::align_of::<PageTouch>() == 8);
+    assert!(std::mem::offset_of!(PageTouch, page_id) == 0);
+    assert!(std::mem::offset_of!(PageTouch, leaf_mask) == 8);
+    assert!(std::mem::offset_of!(PageTouch, dirty_mask) == 16);
+};
 
 /// Leaves and tree nodes that must be created because they were absent at the last checkpoint.
 ///
@@ -421,6 +434,47 @@ impl SegmentMemoryTracker {
             }
         }
         count
+    }
+
+    /// Leaf/node counting without baseline bookkeeping. Used for the dirty
+    /// (written-leaf) mirror: dirtiness has no first-touch/default-hash concept (those
+    /// are initial-side notions), only the size of the spanning tree matters.
+    #[inline(always)]
+    pub(super) fn insert_counting(&mut self, page_id: usize, leaf_mask: u64) -> (u32, u32) {
+        debug_assert!(page_id < self.segment_leaf_masks.len());
+        debug_assert!(leaf_mask != 0);
+
+        let segment_leaf_mask = unsafe { self.segment_leaf_masks.get_unchecked_mut(page_id) };
+        let segment_leaf_mask_before = *segment_leaf_mask;
+        let segment_leaf_mask_after = segment_leaf_mask_before | leaf_mask;
+        if segment_leaf_mask_after == segment_leaf_mask_before {
+            return (0, 0);
+        }
+
+        *segment_leaf_mask = segment_leaf_mask_after;
+        if segment_leaf_mask_before == 0 {
+            self.dirty_page_ids.push(page_id);
+        }
+
+        let new_segment_leaf_mask = leaf_mask & !segment_leaf_mask_before;
+        let (leaves, mut merkle_nodes) = if new_segment_leaf_mask.is_power_of_two() {
+            (
+                1,
+                local_merkle_nodes_added_leaf(
+                    segment_leaf_mask_before,
+                    new_segment_leaf_mask.trailing_zeros(),
+                ),
+            )
+        } else {
+            (
+                new_segment_leaf_mask.count_ones(),
+                local_merkle_nodes_delta(segment_leaf_mask_before, new_segment_leaf_mask),
+            )
+        };
+        if segment_leaf_mask_before == 0 {
+            merkle_nodes += self.insert_upper_path(page_id);
+        }
+        (leaves, merkle_nodes)
     }
 }
 
@@ -876,6 +930,7 @@ mod tests {
             page_id: 0,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 0,
         }]);
         tracker.clear();
         let second = tracker.insert(0, 1, &baseline_memory).first_touches;

--- a/crates/vm/src/arch/execution_mode/metered_cost.rs
+++ b/crates/vm/src/arch/execution_mode/metered_cost.rs
@@ -45,7 +45,7 @@ impl MeteredCostCtx {
 
 impl ExecutionCtxTrait for MeteredCostCtx {
     #[inline(always)]
-    fn on_memory_operation(&mut self, address_space: u32, _ptr: u32, size: u32) {
+    fn on_memory_operation(&mut self, address_space: u32, _ptr: u32, size: u32, _is_write: bool) {
         debug_assert!(
             address_space != RV64_IMM_AS,
             "address space must not be immediate"

--- a/crates/vm/src/arch/execution_mode/mod.rs
+++ b/crates/vm/src/arch/execution_mode/mod.rs
@@ -18,7 +18,7 @@ pub use pure::ExecutionCtx;
 /// Hooks used by shared instruction handlers to notify an execution mode about observable state.
 /// Default no-op hooks let each mode implement only the events it records.
 pub trait ExecutionCtxTrait: Sized {
-    fn on_memory_operation(&mut self, address_space: u32, ptr: u32, size: u32);
+    fn on_memory_operation(&mut self, address_space: u32, ptr: u32, size: u32, is_write: bool);
 
     #[inline(always)]
     fn on_memory_read(

--- a/crates/vm/src/arch/execution_mode/preflight.rs
+++ b/crates/vm/src/arch/execution_mode/preflight.rs
@@ -255,7 +255,8 @@ unsafe fn read_canonical_field_block<F: PrimeField32>(
 
 impl ExecutionCtxTrait for PreflightCtx {
     #[inline(always)]
-    fn on_memory_operation(&mut self, _address_space: u32, _ptr: u32, _size: u32) {}
+    fn on_memory_operation(&mut self, _address_space: u32, _ptr: u32, _size: u32, _is_write: bool) {
+    }
 
     #[inline(always)]
     fn on_memory_read(

--- a/crates/vm/src/arch/execution_mode/pure.rs
+++ b/crates/vm/src/arch/execution_mode/pure.rs
@@ -18,7 +18,8 @@ impl ExecutionCtx {
 
 impl ExecutionCtxTrait for ExecutionCtx {
     #[inline(always)]
-    fn on_memory_operation(&mut self, _address_space: u32, _ptr: u32, _size: u32) {}
+    fn on_memory_operation(&mut self, _address_space: u32, _ptr: u32, _size: u32, _is_write: bool) {
+    }
 
     #[inline(always)]
     fn should_suspend(exec_state: &mut VmExecState<GuestMemory, Self>) -> bool {

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -640,16 +640,19 @@ mod tests {
             page_id: 7,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         with_interval_buffer.pv_page_buf[0] = PageTouch {
             page_id: 3,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         with_interval_buffer.deferral_page_buf[0] = PageTouch {
             page_id: 2,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         with_interval_buffer.initialize_segment_memory(1, 1, 1);
 
@@ -678,6 +681,7 @@ mod tests {
             page_id: 0,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         assert!(!seg_state.on_periodic_check(1, 0, 0, 0, 0));
 
@@ -687,6 +691,7 @@ mod tests {
             page_id: 1,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         assert!(!seg_state.on_periodic_check(1, 0, 0, 0, 0));
 
@@ -703,6 +708,7 @@ mod tests {
             page_id: 0,
             _padding: 0,
             leaf_mask: 0b11,
+            dirty_mask: 0b11,
         };
         buffered.on_termination(1, 0, 0, 0, 0);
 
@@ -710,7 +716,7 @@ mod tests {
         explicit
             .ctx
             .memory_ctx
-            .update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 17);
+            .update_boundary_merkle_heights(RV64_MEMORY_AS, 0, 17, true);
         explicit
             .ctx
             .memory_ctx
@@ -739,6 +745,7 @@ mod tests {
             page_id: 7,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         let initial_heights = drained.ctx.trace_heights.clone();
         let initial_instret = drained.ctx.segmentation_ctx.instret;
@@ -771,6 +778,7 @@ mod tests {
             page_id: 7,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         metering.mem_page_buf_len = 1;
         metering.last_mem_page = 7;
@@ -782,6 +790,7 @@ mod tests {
             page_id: 7,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
         once.on_termination(1, 0, 0, 0, 0);
 
@@ -794,6 +803,7 @@ mod tests {
             page_id: 7,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 1,
         };
 
         let mut drained = make_segmentation_state();

--- a/crates/vm/src/arch/rvr/metered.rs
+++ b/crates/vm/src/arch/rvr/metered.rs
@@ -228,6 +228,7 @@ impl SegmentationState {
             let merged = if let Some(previous) = self.drained_mem_page_touches.last_mut() {
                 if previous.page_id == touch.page_id {
                     previous.leaf_mask |= touch.leaf_mask;
+                    previous.dirty_mask |= touch.dirty_mask;
                     true
                 } else {
                     false
@@ -799,21 +800,27 @@ mod tests {
 
     #[test]
     fn test_memory_buffer_flush_replays_after_segmentation() {
-        let touch = PageTouch {
+        let clean_touch = PageTouch {
             page_id: 7,
             _padding: 0,
             leaf_mask: 1,
+            dirty_mask: 0,
+        };
+        let dirty_touch = PageTouch {
             dirty_mask: 1,
+            ..clean_touch
         };
 
         let mut drained = make_segmentation_state();
-        drained.mem_page_buf[0] = touch;
+        drained.mem_page_buf[0] = clean_touch;
+        drained.drain_main_memory_buffer(1);
+        drained.mem_page_buf[0] = dirty_touch;
         drained.drain_main_memory_buffer(1);
         *drained.ctx.trace_heights.last_mut().unwrap() = 4096;
         assert!(drained.on_periodic_check(0, 0, 0, 0, 0));
 
         let mut buffered = make_segmentation_state();
-        buffered.mem_page_buf[0] = touch;
+        buffered.mem_page_buf[0] = dirty_touch;
         *buffered.ctx.trace_heights.last_mut().unwrap() = 4096;
         assert!(buffered.on_periodic_check(1, 0, 0, 0, 0));
 

--- a/crates/vm/src/arch/state.rs
+++ b/crates/vm/src/arch/state.rs
@@ -161,7 +161,8 @@ where
     /// linear storage. Returns `N` bytes.
     #[inline(always)]
     pub fn vm_read_bytes<const N: usize>(&mut self, addr_space: u32, byte_ptr: u32) -> [u8; N] {
-        self.ctx.on_memory_operation(addr_space, byte_ptr, N as u32);
+        self.ctx
+            .on_memory_operation(addr_space, byte_ptr, N as u32, false);
         let value = self.host_read_bytes(addr_space, byte_ptr);
         self.ctx
             .on_memory_read(&self.vm_state.memory, addr_space, byte_ptr, N as u32);
@@ -176,7 +177,8 @@ where
         byte_ptr: u32,
         data: &[u8; N],
     ) {
-        self.ctx.on_memory_operation(addr_space, byte_ptr, N as u32);
+        self.ctx
+            .on_memory_operation(addr_space, byte_ptr, N as u32, true);
         self.ctx
             .on_memory_write_start(&self.vm_state.memory, addr_space, byte_ptr, N as u32);
         self.host_write_bytes(addr_space, byte_ptr, data);
@@ -191,7 +193,8 @@ where
         addr_space: u32,
         ptr: u32,
     ) -> [T; N] {
-        self.ctx.on_memory_operation(addr_space, ptr, N as u32);
+        self.ctx
+            .on_memory_operation(addr_space, ptr, N as u32, false);
         let value = self.host_read(addr_space, ptr);
         self.ctx.on_memory_read(
             &self.vm_state.memory,
@@ -210,7 +213,8 @@ where
         ptr: u32,
         data: &[T; N],
     ) {
-        self.ctx.on_memory_operation(addr_space, ptr, N as u32);
+        self.ctx
+            .on_memory_operation(addr_space, ptr, N as u32, true);
         self.ctx.on_memory_write_start(
             &self.vm_state.memory,
             addr_space,
@@ -228,7 +232,8 @@ where
         ptr: u32,
         len: usize,
     ) -> &[T] {
-        self.ctx.on_memory_operation(addr_space, ptr, len as u32);
+        self.ctx
+            .on_memory_operation(addr_space, ptr, len as u32, false);
         self.ctx.on_memory_read(
             &self.vm_state.memory,
             addr_space,

--- a/extensions/algebra/rvr/src/fp2.rs
+++ b/extensions/algebra/rvr/src/fp2.rs
@@ -206,6 +206,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -215,6 +216,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/algebra/rvr/src/modular.rs
+++ b/extensions/algebra/rvr/src/modular.rs
@@ -470,6 +470,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -479,6 +480,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/bigint/rvr/src/lib.rs
+++ b/extensions/bigint/rvr/src/lib.rs
@@ -596,6 +596,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -605,6 +606,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/deferral/rvr/c/rvr_ext_deferral.c
+++ b/extensions/deferral/rvr/c/rvr_ext_deferral.c
@@ -65,9 +65,9 @@ bool rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
   uint64_t input_acc_ptr = 2u * def_idx * DEFERRAL_DIGEST_SIZE;
   uint64_t output_acc_ptr = input_acc_ptr + DEFERRAL_DIGEST_SIZE;
   trace_page_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
-                              AS_DEFERRAL);
+                              AS_DEFERRAL, /*is_write=*/false);
   trace_page_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
-                              AS_DEFERRAL);
+                              AS_DEFERRAL, /*is_write=*/false);
 
   /* Look up output_key + update accumulators (Rust side, on byte buffers). */
   uint64_t key_words[OUTPUT_KEY_WORDS];
@@ -88,9 +88,9 @@ bool rvr_ext_deferral_call(RvState* restrict state, uint64_t output_ptr,
 
   /* Trace DEFERRAL_AS writes (new input_acc + new output_acc). */
   trace_page_access_u64_range(state, input_acc_ptr, DIGEST_MEMORY_OPS,
-                              AS_DEFERRAL);
+                              AS_DEFERRAL, /*is_write=*/true);
   trace_page_access_u64_range(state, output_acc_ptr, DIGEST_MEMORY_OPS,
-                              AS_DEFERRAL);
+                              AS_DEFERRAL, /*is_write=*/true);
   return true;
 }
 

--- a/extensions/deferral/rvr/src/lib.rs
+++ b/extensions/deferral/rvr/src/lib.rs
@@ -830,6 +830,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -839,6 +840,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/ecc/rvr/src/lib.rs
+++ b/extensions/ecc/rvr/src/lib.rs
@@ -426,6 +426,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -435,6 +436,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/keccak256/rvr/src/lib.rs
+++ b/extensions/keccak256/rvr/src/lib.rs
@@ -338,6 +338,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -347,6 +348,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/pairing/rvr/src/lib.rs
+++ b/extensions/pairing/rvr/src/lib.rs
@@ -243,6 +243,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -252,6 +253,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/riscv/circuit/src/adapters/mod.rs
+++ b/extensions/riscv/circuit/src/adapters/mod.rs
@@ -500,7 +500,9 @@ pub fn memory_read_from_state<Ctx, const N: usize>(
 where
     Ctx: ExecutionCtxTrait,
 {
-    state.ctx.on_memory_operation(address_space, ptr, N as u32);
+    state
+        .ctx
+        .on_memory_operation(address_space, ptr, N as u32, false);
 
     memory_read(state.memory, address_space, ptr)
 }
@@ -514,7 +516,9 @@ pub fn memory_write_from_state<Ctx, const N: usize>(
 ) where
     Ctx: ExecutionCtxTrait,
 {
-    state.ctx.on_memory_operation(address_space, ptr, N as u32);
+    state
+        .ctx
+        .on_memory_operation(address_space, ptr, N as u32, true);
 
     memory_write(state.memory, address_space, ptr, data)
 }

--- a/extensions/riscv/rvr/src/i/instruction.rs
+++ b/extensions/riscv/rvr/src/i/instruction.rs
@@ -500,6 +500,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
         }
 
@@ -508,6 +509,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
         }
     }

--- a/extensions/riscv/rvr/src/io.rs
+++ b/extensions/riscv/rvr/src/io.rs
@@ -47,6 +47,7 @@ impl ExtInstr for HintStoreWInstr {
                 &ptr,
                 MemWidth::Double,
                 PageAddressSpace::MainMemory(RV64_MEMORY_AS),
+                true,
             );
             return;
         }
@@ -128,7 +129,12 @@ impl ExtInstr for HintBufferInstr {
                 &[&ptr, &callback_count],
             );
             ctx.append_replay_memory_u64_range(&ptr, &callback_count);
-            ctx.trace_page_access_u64_range(&ptr, &n, PageAddressSpace::MainMemory(RV64_MEMORY_AS));
+            ctx.trace_page_access_u64_range(
+                &ptr,
+                &n,
+                PageAddressSpace::MainMemory(RV64_MEMORY_AS),
+                true,
+            );
         }
         // Block entry credits one row; runtime metering adds the remaining
         // `(n - 1)` rows.
@@ -192,7 +198,12 @@ impl ExtInstr for RevealInstr {
         // callback after materializing the crossing-access plan.
         ctx.reserve_preflight_timestamp_slots(slots);
         ctx.emit_checked_call("openvm_reveal", &["state", &src, &ptr, &addr, &width]);
-        ctx.trace_page_access(&addr, self.width, PageAddressSpace::Other(PUBLIC_VALUES_AS));
+        ctx.trace_page_access(
+            &addr,
+            self.width,
+            PageAddressSpace::Other(PUBLIC_VALUES_AS),
+            true,
+        );
     }
 
     fn clone_box(&self) -> Box<dyn ExtInstr> {
@@ -629,11 +640,17 @@ mod tests {
             self.write_line("}");
         }
 
-        fn trace_page_access(&mut self, addr: &str, width: MemWidth, addr_space: PageAddressSpace) {
+        fn trace_page_access(
+            &mut self,
+            addr: &str,
+            width: MemWidth,
+            addr_space: PageAddressSpace,
+            is_write: bool,
+        ) {
             let size = width.bytes();
             self.write_line(&format!(
-                "trace_page_access(state, {addr}, {size}u, {}u);",
-                addr_space.id()
+                "trace_page_access(state, {addr}, {size}u, {}u, {is_write});",
+                addr_space.id(),
             ));
         }
 
@@ -642,10 +659,11 @@ mod tests {
             base_addr: &str,
             num_dwords: &str,
             addr_space: PageAddressSpace,
+            is_write: bool,
         ) {
             self.write_line(&format!(
-                "trace_page_access_u64_range(state, {base_addr}, {num_dwords}, {}u);",
-                addr_space.id()
+                "trace_page_access_u64_range(state, {base_addr}, {num_dwords}, {}u, {is_write});",
+                addr_space.id(),
             ));
         }
     }
@@ -746,7 +764,9 @@ mod tests {
         assert_eq!(ctx.lines[2], "if (unlikely(!tmp1)) {");
         assert_eq!(
             ctx.lines[5],
-            format!("trace_page_access(state, (r10 + 0x0000000cull), 4u, {PUBLIC_VALUES_AS}u);")
+            format!(
+                "trace_page_access(state, (r10 + 0x0000000cull), 4u, {PUBLIC_VALUES_AS}u, true);"
+            )
         );
     }
 

--- a/extensions/riscv/rvr/src/phantom.rs
+++ b/extensions/riscv/rvr/src/phantom.rs
@@ -351,6 +351,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -360,6 +361,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }

--- a/extensions/sha2/rvr/src/lib.rs
+++ b/extensions/sha2/rvr/src/lib.rs
@@ -316,6 +316,7 @@ mod tests {
             _addr: &str,
             _width: MemWidth,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }
@@ -325,6 +326,7 @@ mod tests {
             _base_addr: &str,
             _num_dwords: &str,
             _addr_space: PageAddressSpace,
+            _is_write: bool,
         ) {
             unreachable!()
         }


### PR DESCRIPTION
This PR adds metered mode dirty leaf tracking. Continuation of previous PR (https://github.com/openvm-org/openvm/pull/3055). Right now, there is memory underestimation happening during reth-benchmark evaluation. 

towards INT-8828