### PR TITLE
fix(v2.1): compare suspend_signal in rvr MeteredSegment checkpoint

### DIFF
--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -946,7 +946,7 @@ impl CProject {
         )
         .unwrap();
         writeln!(out, "    check_counter = checkpoint.check_counter;").unwrap();
-        writeln!(out, "    if (unlikely(checkpoint.suspend_signal)) {{").unwrap();
+        writeln!(out, "    if (unlikely(checkpoint.suspend_signal != 0)) {{").unwrap();
         self.emit_suspend_return(out, pc);
         writeln!(out, "    }}").unwrap();
     }
@@ -1407,6 +1407,17 @@ mod tests {
         assert_eq!(project.hot_regs.len(), 22);
         #[cfg(not(target_arch = "aarch64"))]
         assert_eq!(project.hot_regs.len(), 9);
+    }
+
+    #[test]
+    fn metered_segment_checkpoint_compares_suspend_signal_as_int() {
+        let project = CProject::new(Path::new("unused"), "test", RvrExecutionKind::MeteredSegment);
+        let mut checkpoint = String::new();
+        project.emit_block_checkpoint_function(&mut checkpoint, &single_instruction_block());
+
+        assert!(checkpoint.contains("if (unlikely(checkpoint.suspend_signal != 0))"));
+        // The bare `unlikely(checkpoint.suspend_signal)` form is the bug.
+        assert!(!checkpoint.contains("if (unlikely(checkpoint.suspend_signal))"));
     }
 
     #[test]

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -1410,17 +1410,6 @@ mod tests {
     }
 
     #[test]
-    fn metered_segment_checkpoint_compares_suspend_signal_as_int() {
-        let project = CProject::new(Path::new("unused"), "test", RvrExecutionKind::MeteredSegment);
-        let mut checkpoint = String::new();
-        project.emit_block_checkpoint_function(&mut checkpoint, &single_instruction_block());
-
-        assert!(checkpoint.contains("if (unlikely(checkpoint.suspend_signal != 0))"));
-        // The bare `unlikely(checkpoint.suspend_signal)` form is the bug.
-        assert!(!checkpoint.contains("if (unlikely(checkpoint.suspend_signal))"));
-    }
-
-    #[test]
     fn oversized_block_abi_is_rejected() {
         let mut project = CProject::new(
             Path::new("unused"),


### PR DESCRIPTION
## Problem

  The `MeteredSegment` checkpoint codegen emits

  ```c
  if (unlikely(checkpoint.suspend_signal)) { ... }
```

  suspend_signal is a uint32_t (c/block/openvm_block_metered_segment.h) but
  unlikely() takes an int (c/openvm_util.h), so this passes an unsigned
  argument to a signed parameter. Under the Makefile's -Weverything -Werror
  that's a hard error:

```
  error: implicit conversion changes signedness: 'uint32_t' to 'int'
         [-Werror,-Wsign-conversion]
```

  Every other unlikely(...) call site passes a comparison (already int), so
  this is the only spot that trips it.
