### PR TITLE
fix(v2.1): make rvr c sanitizers opt-in

### DIFF
--- a/crates/rvr/rvr-openvm/c/Makefile
+++ b/crates/rvr/rvr-openvm/c/Makefile
@@ -3,10 +3,9 @@ LINKER ?= lld
 OPT ?= -O3
 DEBUG ?=
 WARNINGS = -Weverything -Werror
-# `bounds` adds local array checks that are not part of the `undefined` group.
-# Trap mode keeps the generated shared library self-contained. Override with
-# `make SANITIZERS=` only for performance-sensitive runs.
-SANITIZERS ?= -fsanitize=undefined,bounds -fsanitize-trap=all
+# Sanitizer flags for debug/test builds, e.g.
+# `-fsanitize=undefined,bounds -fsanitize-trap=all`.
+SANITIZERS ?=
 
 # The generated sources target C2y, not C++ or older C language revisions.
 # This C-only project also does not use the libstdc++ installation selected by

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -202,6 +202,8 @@ pub struct CProject {
     pub num_airs: Option<u32>,
     /// Compile with native debug info (`-g -fno-omit-frame-pointer`).
     pub native_debug_info: bool,
+    /// Compile the generated C with trap-mode UBSan and bounds sanitizers.
+    pub sanitize: bool,
 }
 
 impl CProject {
@@ -222,6 +224,7 @@ impl CProject {
             chip_widths: None,
             num_airs: None,
             native_debug_info: false,
+            sanitize: false,
         }
     }
 
@@ -1279,6 +1282,9 @@ impl CProject {
         }
         if self.native_debug_info {
             args.push("DEBUG=-g -fno-omit-frame-pointer".to_string());
+        }
+        if self.sanitize {
+            args.push("SANITIZERS=-fsanitize=undefined,bounds -fsanitize-trap=all".to_string());
         }
         args
     }

--- a/crates/vm/src/arch/rvr/compile.rs
+++ b/crates/vm/src/arch/rvr/compile.rs
@@ -323,9 +323,15 @@ pub struct CompileOptions<'a> {
     pub guest_debug_map: Option<&'a GuestDebugMap>,
     /// Compile with `-g -fno-omit-frame-pointer` for profiling.
     pub native_debug_info: bool,
+    /// Compile the generated C with trap-mode UBSan and bounds sanitizers.
+    /// Too slow for production proving or profiling runs.
+    pub sanitize: bool,
     /// Keep the generated native project after the compiled library is dropped.
     pub keep_artifacts: bool,
 }
+
+/// Sanitize in debug/test builds, but never when profiling.
+const DEFAULT_SANITIZE: bool = cfg!(debug_assertions) && !cfg!(feature = "profiling");
 
 pub fn compile_with_options<F: PrimeField32>(
     exe: &VmExe<F>,
@@ -349,6 +355,7 @@ pub fn compile<F: PrimeField32>(
             chips: None,
             guest_debug_map,
             native_debug_info: cfg!(feature = "profiling"),
+            sanitize: DEFAULT_SANITIZE,
             keep_artifacts: false,
         },
     )
@@ -369,6 +376,7 @@ pub fn compile_with_instret_tracking<F: PrimeField32>(
             chips: None,
             guest_debug_map,
             native_debug_info: cfg!(feature = "profiling"),
+            sanitize: DEFAULT_SANITIZE,
             keep_artifacts: false,
         },
     )
@@ -390,6 +398,7 @@ pub fn compile_metered<F: PrimeField32>(
             chips: Some(chips),
             guest_debug_map,
             native_debug_info: cfg!(feature = "profiling"),
+            sanitize: DEFAULT_SANITIZE,
             keep_artifacts: false,
         },
     )
@@ -411,6 +420,7 @@ pub fn compile_metered_segment_boundary<F: PrimeField32>(
             chips: Some(chips),
             guest_debug_map,
             native_debug_info: cfg!(feature = "profiling"),
+            sanitize: DEFAULT_SANITIZE,
             keep_artifacts: false,
         },
     )
@@ -432,6 +442,7 @@ pub fn compile_metered_cost<F: PrimeField32>(
             chips: Some(chips),
             guest_debug_map,
             native_debug_info: cfg!(feature = "profiling"),
+            sanitize: DEFAULT_SANITIZE,
             keep_artifacts: false,
         },
     )
@@ -604,6 +615,7 @@ fn compile_impl<F: PrimeField32>(
     }
 
     project.native_debug_info = opts.native_debug_info;
+    project.sanitize = opts.sanitize;
 
     let entry_point = u64::from(exe.pc_start);
     let text_start = u64::from(exe.program.pc_base);


### PR DESCRIPTION
Sanitizers landed default-on in #3065 and slowed generated-code execution