### PR TITLE
fix(v2.1): derive `prev_timestamp` instead of materializing it

### DIFF
--- a/crates/circuits/primitives/cuda/include/primitives/less_than.cuh
+++ b/crates/circuits/primitives/cuda/include/primitives/less_than.cuh
@@ -6,7 +6,7 @@
 inline constexpr size_t AUX_LEN = 2;
 
 template <typename T, size_t AUX_LEN = AUX_LEN> struct LessThanAuxCols {
-    T lower_decomp[AUX_LEN];
+    T diff_decomp[AUX_LEN];
 };
 
 template <typename T, size_t NUM, size_t AUX_LEN = AUX_LEN> struct LessThanArrayAuxCols {
@@ -22,23 +22,23 @@ namespace AssertLessThan {
  *
  * @section Trace Context Parameters
  * @param rc Range checker histogram reference
- * @param max_bits Maximum number of bits the respresntation of x and y can be
+ * @param max_bits Maximum number of bits in the representation of x and y
  * @param x First value to compare (must be strictly less than y)
  * @param y Second value to compare
- * @param lower_decomp_len Number of columns needed to constrain x < y
+ * @param decomp_len Number of columns needed to constrain x < y
  *
  * @section Mutable Column Parameters
- * @param lower_decomp Columns used to constrain x < y
+ * @param diff_decomp Columns used to constrain x < y
  */
 __device__ __forceinline__ void generate_subrow(
     VariableRangeChecker &rc,
     const uint32_t max_bits,
     uint32_t x,
     uint32_t y,
-    const size_t lower_decomp_len,
-    RowSlice lower_decomp
+    const size_t decomp_len,
+    RowSlice diff_decomp
 ) {
-    rc.decompose(y - x - 1, max_bits, lower_decomp, lower_decomp_len);
+    rc.decompose(y - x - 1, max_bits, diff_decomp, decomp_len);
 }
 } // namespace AssertLessThan
 
@@ -48,7 +48,7 @@ namespace IsLessThan {
  *
  * @section Trace Context Parameters
  * @param rc Range checker histogram reference
- * @param max_bits Maximum number of bits the respresntation of x and y can be
+ * @param max_bits Maximum number of bits in the representation of x and y
  * @param x First value to compare
  * @param y Second value to compare
  * @param lower_decomp_len Number of columns needed to constrain out_flag == (x < y)

--- a/crates/circuits/primitives/src/assert_less_than/README.md
+++ b/crates/circuits/primitives/src/assert_less_than/README.md
@@ -17,7 +17,7 @@ Range checking is performed using a lookup table via interactions.
 - `count`: Activation flag $`s`$ (constraints only apply when $`s \neq 0`$)
 
 **Aux Columns:**
-- `lower_decomp`: Array of limbs for range checking
+- `diff_decomp`: Array of limbs for range checking
 
 **Proof**
 

--- a/crates/circuits/primitives/src/assert_less_than/README.md
+++ b/crates/circuits/primitives/src/assert_less_than/README.md
@@ -19,6 +19,23 @@ Range checking is performed using a lookup table via interactions.
 **Aux Columns:**
 - `diff_decomp`: Array of limbs for range checking
 
+## Deriving `x` from `diff_decomp`
+
+Since `diff_decomp` is a complete decomposition of `y - x - 1`, the constraint determines any one
+of `x`, `y`, `diff_decomp` from the other two. `eval_derive_x` uses this to return
+
+```math
+x = y - 1 - \texttt{compose(diff_decomp)}
+```
+
+of degree $`\max(1, \deg(y))`$. The returned expression uses `y` and the committed `diff_decomp`
+columns. The range checks bound $`\texttt{compose(diff_decomp)}`$ to
+$`[0, 2^{\texttt{max\_bits}})`$, so `x < y` holds.
+
+The prover chooses `diff_decomp`, which determines `x` through the expression above. The caller
+constrains that derived `x` outside this SubAir. The memory offline checker does this by matching on
+the memory bus.
+
 **Proof**
 
 Given input values $`x, y \in [0, 2^{\texttt{max\_bits}})`$.

--- a/crates/circuits/primitives/src/assert_less_than/mod.rs
+++ b/crates/circuits/primitives/src/assert_less_than/mod.rs
@@ -47,14 +47,14 @@ impl<T> AssertLessThanIo<T> {
     }
 }
 
-/// These columns are owned by the SubAir. Typically used with `T = AB::Var`.
-/// `AUX_LEN` is the number of AUX columns
-/// we have that AUX_LEN = max_bits.div_ceil(bus.range_max_bits)
+/// Auxiliary columns owned by the SubAir. Typically used with `T = AB::Var`.
+///
+/// `AUX_LEN` must equal `max_bits.div_ceil(bus.range_max_bits)`.
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Clone, Copy, Debug, new)]
 pub struct LessThanAuxCols<T, const AUX_LEN: usize> {
-    // diff_decomp consists of the limbs of size bus.range_max_bits that the SubAir range checks
-    // note: the final limb might have less than bus.range_max_bits bits
+    /// The decomposition limbs range checked by the SubAir. The final limb may use fewer bits than
+    /// `bus.range_max_bits`.
     pub diff_decomp: [T; AUX_LEN],
 }
 
@@ -103,31 +103,56 @@ impl AssertLtSubAir {
         self.bus.range_max_bits
     }
 
-    /// FOR INTERNAL USE ONLY.
-    /// This AIR is only sound if interactions are enabled
+    /// Reconstructs the value that `diff_decomp` decomposes.
     ///
-    /// Constraints between `io` and `aux` are only enforced when `count != 0`.
-    /// This means `aux` can be all zero independent on what `io` is by setting `count = 0`.
+    /// The returned expression has degree 1.
     #[inline(always)]
-    fn eval_without_range_checks<AB: AirBuilder<Var: Copy>>(
+    fn compose<AB: AirBuilder<Var: Copy>>(&self, diff_decomp: &[AB::Var]) -> AB::Expr {
+        assert_eq!(diff_decomp.len(), self.decomp_limbs);
+        diff_decomp
+            .iter()
+            .enumerate()
+            .fold(AB::Expr::ZERO, |acc, (i, &val)| {
+                acc + val * AB::Expr::from_usize(1 << (i * self.range_max_bits()))
+            })
+    }
+
+    /// Range checks `diff_decomp` and returns `x = y - 1 - compose(diff_decomp)`.
+    ///
+    /// Since `diff_decomp` is a complete decomposition of `y - x - 1`, the returned expression uses
+    /// `y` and the committed `diff_decomp` columns. It has degree `max(1, deg(y))`.
+    ///
+    /// When `count != 0`, the range checks bound `compose(diff_decomp)` to `[0, 2^max_bits)`, so
+    /// `x < y` holds. Callers use the returned value in their external constraints or interactions
+    /// on enabled rows.
+    #[must_use]
+    #[inline(always)]
+    pub fn eval_derive_x<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        y: AB::Expr,
+        diff_decomp: &[AB::Var],
+        count: impl Into<AB::Expr>,
+    ) -> AB::Expr {
+        self.eval_range_checks(builder, diff_decomp, count);
+        y - AB::Expr::ONE - self.compose::<AB>(diff_decomp)
+    }
+
+    /// Constrains `diff_decomp` to compose to `y - x - 1` when `io.count != 0`.
+    #[inline(always)]
+    fn eval_composition<AB: AirBuilder<Var: Copy>>(
         &self,
         builder: &mut AB,
         io: AssertLessThanIo<AB::Expr>,
         diff_decomp: &[AB::Var],
     ) {
-        assert_eq!(diff_decomp.len(), self.decomp_limbs);
         // this is the desired intermediate value (i.e. y - x - 1)
         // deg(intermed_val) = deg(io)
         let intermed_val = io.y - io.x - AB::Expr::ONE;
 
         // each limb of diff_decomp will be range checked
         // deg(composed) = 1
-        let composed = diff_decomp
-            .iter()
-            .enumerate()
-            .fold(AB::Expr::ZERO, |acc, (i, &val)| {
-                acc + val * AB::Expr::from_usize(1 << (i * self.range_max_bits()))
-            });
+        let composed = self.compose::<AB>(diff_decomp);
 
         // constrain that y - x - 1 is equal to the composed value.
         // this enforces that the intermediate value is in the range [0, 2^max_bits - 1], which is
@@ -179,7 +204,7 @@ impl<AB: InteractionBuilder> SubAir<AB> for AssertLtSubAir {
     {
         // Note: every AIR that uses this sub-AIR must include the range checks for soundness
         self.eval_range_checks(builder, diff_decomp, io.count.clone());
-        self.eval_without_range_checks(builder, io, diff_decomp);
+        self.eval_composition(builder, io, diff_decomp);
     }
 }
 

--- a/crates/circuits/primitives/src/assert_less_than/mod.rs
+++ b/crates/circuits/primitives/src/assert_less_than/mod.rs
@@ -53,9 +53,9 @@ impl<T> AssertLessThanIo<T> {
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Clone, Copy, Debug, new)]
 pub struct LessThanAuxCols<T, const AUX_LEN: usize> {
-    // lower_decomp consists of lower decomposed into limbs of size bus.range_max_bits
+    // diff_decomp consists of the limbs of size bus.range_max_bits that the SubAir range checks
     // note: the final limb might have less than bus.range_max_bits bits
-    pub lower_decomp: [T; AUX_LEN],
+    pub diff_decomp: [T; AUX_LEN],
 }
 
 /// This is intended for use as a **SubAir**, not as a standalone Air.
@@ -113,43 +113,42 @@ impl AssertLtSubAir {
         &self,
         builder: &mut AB,
         io: AssertLessThanIo<AB::Expr>,
-        lower_decomp: &[AB::Var],
+        diff_decomp: &[AB::Var],
     ) {
-        assert_eq!(lower_decomp.len(), self.decomp_limbs);
+        assert_eq!(diff_decomp.len(), self.decomp_limbs);
         // this is the desired intermediate value (i.e. y - x - 1)
         // deg(intermed_val) = deg(io)
         let intermed_val = io.y - io.x - AB::Expr::ONE;
 
-        // Construct lower from lower_decomp:
-        // - each limb of lower_decomp will be range checked
-        // deg(lower) = 1
-        let lower = lower_decomp
+        // each limb of diff_decomp will be range checked
+        // deg(composed) = 1
+        let composed = diff_decomp
             .iter()
             .enumerate()
             .fold(AB::Expr::ZERO, |acc, (i, &val)| {
                 acc + val * AB::Expr::from_usize(1 << (i * self.range_max_bits()))
             });
 
-        // constrain that y - x - 1 is equal to the constructed lower value.
+        // constrain that y - x - 1 is equal to the composed value.
         // this enforces that the intermediate value is in the range [0, 2^max_bits - 1], which is
         // equivalent to x < y
-        builder.when(io.count).assert_eq(intermed_val, lower);
+        builder.when(io.count).assert_eq(intermed_val, composed);
         // the degree of this constraint is expected to be deg(count) + max(deg(intermed_val),
-        // deg(lower)) since we are constraining count * intermed_val == count * lower
+        // deg(composed)) since we are constraining count * intermed_val == count * composed
     }
 
     #[inline(always)]
     fn eval_range_checks<AB: InteractionBuilder>(
         &self,
         builder: &mut AB,
-        lower_decomp: &[AB::Var],
+        diff_decomp: &[AB::Var],
         count: impl Into<AB::Expr>,
     ) {
         let count = count.into();
         let mut bits_remaining = self.max_bits;
-        // we range check the limbs of the lower_decomp so that we know each element
-        // of lower_decomp has the correct number of bits
-        for limb in lower_decomp {
+        // we range check the limbs of diff_decomp so that we know each element
+        // of diff_decomp has the correct number of bits
+        for limb in diff_decomp {
             // the last limb might have fewer than `bus.range_max_bits` bits
             let range_bits = bits_remaining.min(self.range_max_bits());
             self.bus
@@ -173,14 +172,14 @@ impl<AB: InteractionBuilder> SubAir<AB> for AssertLtSubAir {
     fn eval<'a>(
         &'a self,
         builder: &'a mut AB,
-        (io, lower_decomp): (AssertLessThanIo<AB::Expr>, &'a [AB::Var]),
+        (io, diff_decomp): (AssertLessThanIo<AB::Expr>, &'a [AB::Var]),
     ) where
         AB::Var: 'a,
         AB::Expr: 'a,
     {
         // Note: every AIR that uses this sub-AIR must include the range checks for soundness
-        self.eval_range_checks(builder, lower_decomp, io.count.clone());
-        self.eval_without_range_checks(builder, io, lower_decomp);
+        self.eval_range_checks(builder, diff_decomp, io.count.clone());
+        self.eval_without_range_checks(builder, io, diff_decomp);
     }
 }
 
@@ -189,7 +188,7 @@ impl<F: Field> TraceSubRowGenerator<F> for AssertLtSubAir {
     // x, y are u32 because memory records are storing u32 and there would be needless conversions.
     // It also prevents a F: PrimeField32 trait bound.
     type TraceContext<'a> = (&'a VariableRangeCheckerChip, u32, u32);
-    /// lower_decomp
+    /// diff_decomp
     type ColsMut<'a> = &'a mut [F];
 
     /// Should only be used when `io.count != 0` i.e. only on non-padding rows.
@@ -197,10 +196,10 @@ impl<F: Field> TraceSubRowGenerator<F> for AssertLtSubAir {
     fn generate_subrow<'a>(
         &'a self,
         (range_checker, x, y): (&'a VariableRangeCheckerChip, u32, u32),
-        lower_decomp: &'a mut [F],
+        diff_decomp: &'a mut [F],
     ) {
         debug_assert!(x < y, "assert {x} < {y} failed");
-        debug_assert_eq!(lower_decomp.len(), self.decomp_limbs);
+        debug_assert_eq!(diff_decomp.len(), self.decomp_limbs);
         debug_assert!(
             x < (1 << self.max_bits),
             "{x} has more than {} bits",
@@ -213,6 +212,6 @@ impl<F: Field> TraceSubRowGenerator<F> for AssertLtSubAir {
         );
 
         // Note: if x < y then y - x - 1 should already have <= max_bits bits
-        range_checker.decompose(y - x - 1, self.max_bits, lower_decomp);
+        range_checker.decompose(y - x - 1, self.max_bits, diff_decomp);
     }
 }

--- a/crates/circuits/primitives/src/assert_less_than/tests.rs
+++ b/crates/circuits/primitives/src/assert_less_than/tests.rs
@@ -69,7 +69,7 @@ impl<AB: InteractionBuilder, const AUX_LEN: usize> Air<AB> for AssertLtTestAir<A
         let local: &AssertLessThanCols<_, AUX_LEN> = (*local).borrow();
 
         let io = AssertLessThanIo::new(local.x, local.y, local.count);
-        self.0.eval(builder, (io, &local.aux.lower_decomp));
+        self.0.eval(builder, (io, &local.aux.diff_decomp));
     }
 }
 
@@ -102,7 +102,7 @@ impl<const AUX_LEN: usize> AssertLessThanChip<AUX_LEN> {
                 row.count = F::ONE;
                 self.air
                     .0
-                    .generate_subrow((&self.range_checker, x, y), &mut row.aux.lower_decomp);
+                    .generate_subrow((&self.range_checker, x, y), &mut row.aux.diff_decomp);
             });
 
         RowMajorMatrix::new(rows, width)
@@ -122,8 +122,8 @@ fn test_borrow_mut_roundtrip() {
     lt_cols.y = 8;
     lt_cols.count = 1;
 
-    lt_cols.aux.lower_decomp[0] = 1;
-    lt_cols.aux.lower_decomp[1] = 0;
+    lt_cols.aux.diff_decomp[0] = 1;
+    lt_cols.aux.diff_decomp[1] = 0;
 
     assert_eq!(all_cols[0], 2);
     assert_eq!(all_cols[1], 8);

--- a/crates/circuits/primitives/src/is_less_than_array/mod.rs
+++ b/crates/circuits/primitives/src/is_less_than_array/mod.rs
@@ -62,7 +62,7 @@ impl<'a, T, const NUM: usize, const AUX_LEN: usize> From<&'a IsLtArrayAuxCols<T,
         Self {
             diff_marker: &value.diff_marker,
             diff_inv: &value.diff_inv,
-            lt_decomp: &value.lt_aux.lower_decomp,
+            lt_decomp: &value.lt_aux.diff_decomp,
         }
     }
 }
@@ -74,7 +74,7 @@ impl<'a, T, const NUM: usize, const AUX_LEN: usize> From<&'a mut IsLtArrayAuxCol
         Self {
             diff_marker: &mut value.diff_marker,
             diff_inv: &mut value.diff_inv,
-            lt_decomp: &mut value.lt_aux.lower_decomp,
+            lt_decomp: &mut value.lt_aux.diff_decomp,
         }
     }
 }

--- a/crates/vm/cuda/include/system/memory/controller.cuh
+++ b/crates/vm/cuda/include/system/memory/controller.cuh
@@ -20,7 +20,6 @@ struct MemoryAuxColsFactory {
             AUX_LEN,
             row.slice_from(COL_INDEX(MemoryBaseAuxCols, timestamp_lt_aux))
         );
-        COL_WRITE_VALUE(row, MemoryBaseAuxCols, prev_timestamp, prev_timestamp);
     }
 
     __device__ void fill_zero(RowSlice row) {

--- a/crates/vm/cuda/include/system/memory/offline_checker.cuh
+++ b/crates/vm/cuda/include/system/memory/offline_checker.cuh
@@ -7,10 +7,8 @@
 using namespace riscv;
 
 template <typename T> struct MemoryBaseAuxCols {
-    /// The previous timestamps in which the cells were accessed.
-    T prev_timestamp;
-    /// The auxiliary columns to perform the less than check.
-    LessThanAuxCols<T, AUX_LEN> timestamp_lt_aux; // lower_decomp [T; AUX_LEN]
+    /// The limbs of `timestamp - prev_timestamp - 1` used to derive `prev_timestamp` in the AIR.
+    LessThanAuxCols<T, AUX_LEN> timestamp_lt_aux;
 };
 
 template <typename T> struct MemoryReadAuxCols {

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -243,12 +243,9 @@ pub struct MemoryAuxColsFactory<'a, F> {
 }
 
 impl<F: PrimeField32> MemoryAuxColsFactory<'_, F> {
-    /// Fill the trace assuming `prev_timestamp` is already provided in `buffer`.
+    /// Fills `timestamp_lt_aux` with the decomposition of `timestamp - prev_timestamp - 1`.
     pub fn fill(&self, prev_timestamp: u32, timestamp: u32, buffer: &mut MemoryBaseAuxCols<F>) {
         self.generate_timestamp_lt(prev_timestamp, timestamp, &mut buffer.timestamp_lt_aux);
-        // Safety: even if prev_timestamp were obtained by transmute_ref from
-        // `buffer.prev_timestamp`, this should still work because it is a direct assignment
-        buffer.prev_timestamp = F::from_u32(prev_timestamp);
     }
 
     /// # Safety

--- a/crates/vm/src/system/memory/controller/mod.rs
+++ b/crates/vm/src/system/memory/controller/mod.rs
@@ -269,7 +269,7 @@ impl<F: PrimeField32> MemoryAuxColsFactory<'_, F> {
         );
         self.timestamp_lt_air.generate_subrow(
             (self.range_checker, prev_timestamp, timestamp),
-            &mut buffer.lower_decomp,
+            &mut buffer.diff_decomp,
         );
     }
 }

--- a/crates/vm/src/system/memory/offline_checker/bridge.rs
+++ b/crates/vm/src/system/memory/offline_checker/bridge.rs
@@ -260,7 +260,7 @@ impl MemoryOfflineChecker {
     ) {
         let lt_io = AssertLessThanIo::new(base.prev_timestamp, timestamp.clone(), enabled);
         self.timestamp_lt_air
-            .eval(builder, (lt_io, &base.timestamp_lt_aux.lower_decomp));
+            .eval(builder, (lt_io, &base.timestamp_lt_aux.diff_decomp));
     }
 
     /// At the core, eval_bulk_access is a bunch of push_sends and push_receives.

--- a/crates/vm/src/system/memory/offline_checker/bridge.rs
+++ b/crates/vm/src/system/memory/offline_checker/bridge.rs
@@ -1,8 +1,6 @@
 use getset::CopyGetters;
 use openvm_circuit_primitives::{
-    assert_less_than::{AssertLessThanIo, AssertLtSubAir},
-    var_range::VariableRangeCheckerBus,
-    SubAir,
+    assert_less_than::AssertLtSubAir, var_range::VariableRangeCheckerBus,
 };
 use openvm_stark_backend::{interaction::InteractionBuilder, p3_field::PrimeCharacteristicRing};
 
@@ -152,7 +150,7 @@ pub struct MemoryReadOperation<'a, T, V> {
 }
 
 /// The max degree of constraints is:
-/// eval_timestamps: deg(enabled) + max(1, deg(self.timestamp))
+/// eval_prev_timestamp: deg(enabled) + max(1, deg(self.timestamp))
 /// eval_bulk_access: refer to private function MemoryOfflineChecker::eval_bulk_access
 impl<F: PrimeCharacteristicRing, V: Copy + Into<F>> MemoryReadOperation<'_, F, V> {
     /// Evaluate constraints and send/receive interactions.
@@ -165,7 +163,7 @@ impl<F: PrimeCharacteristicRing, V: Copy + Into<F>> MemoryReadOperation<'_, F, V
         // NOTE: We do not need to constrain `address_space != 0` since this is done implicitly by
         // the memory interactions argument together with initial/final memory chips.
 
-        self.offline_checker.eval_timestamps(
+        let prev_timestamp = self.offline_checker.eval_prev_timestamp(
             builder,
             self.timestamp.clone(),
             &self.aux.base,
@@ -178,7 +176,7 @@ impl<F: PrimeCharacteristicRing, V: Copy + Into<F>> MemoryReadOperation<'_, F, V
             &self.data,
             &self.data,
             self.timestamp.clone(),
-            self.aux.base.prev_timestamp,
+            prev_timestamp,
             enabled,
         );
     }
@@ -200,7 +198,7 @@ pub struct MemoryWriteOperation<'a, T, V> {
 }
 
 /// The max degree of constraints is:
-/// eval_timestamps: deg(enabled) + max(1, deg(self.timestamp))
+/// eval_prev_timestamp: deg(enabled) + max(1, deg(self.timestamp))
 /// eval_bulk_access: refer to private function MemoryOfflineChecker::eval_bulk_access
 impl<T: PrimeCharacteristicRing, V: Copy + Into<T>> MemoryWriteOperation<'_, T, V> {
     /// Evaluate constraints and send/receive interactions. `enabled` must be boolean.
@@ -209,7 +207,7 @@ impl<T: PrimeCharacteristicRing, V: Copy + Into<T>> MemoryWriteOperation<'_, T, 
         AB: InteractionBuilder<Var = V, Expr = T>,
     {
         let enabled = enabled.into();
-        self.offline_checker.eval_timestamps(
+        let prev_timestamp = self.offline_checker.eval_prev_timestamp(
             builder,
             self.timestamp.clone(),
             self.aux_base,
@@ -222,7 +220,7 @@ impl<T: PrimeCharacteristicRing, V: Copy + Into<T>> MemoryWriteOperation<'_, T, 
             &self.data,
             &self.prev_data,
             self.timestamp,
-            self.aux_base.prev_timestamp,
+            prev_timestamp,
             enabled,
         );
     }
@@ -248,19 +246,24 @@ impl MemoryOfflineChecker {
         }
     }
 
-    /// The max degree of constraints is:
-    /// deg(enabled) + max(1, deg(timestamp))
-    /// Note: deg(prev_timestamp) = 1 since prev_timestamp is Var
-    fn eval_timestamps<AB: InteractionBuilder>(
+    /// Range checks the timestamp difference limbs and returns
+    /// `prev_timestamp = timestamp - 1 - compose(timestamp_lt_aux)`.
+    ///
+    /// The returned expression has degree `max(1, deg(timestamp))` and is constrained to be less
+    /// than `timestamp`.
+    fn eval_prev_timestamp<AB: InteractionBuilder>(
         &self,
         builder: &mut AB,
         timestamp: AB::Expr,
         base: &MemoryBaseAuxCols<AB::Var>,
         enabled: AB::Expr,
-    ) {
-        let lt_io = AssertLessThanIo::new(base.prev_timestamp, timestamp.clone(), enabled);
-        self.timestamp_lt_air
-            .eval(builder, (lt_io, &base.timestamp_lt_aux.diff_decomp));
+    ) -> AB::Expr {
+        self.timestamp_lt_air.eval_derive_x(
+            builder,
+            timestamp,
+            &base.timestamp_lt_aux.diff_decomp,
+            enabled,
+        )
     }
 
     /// At the core, eval_bulk_access is a bunch of push_sends and push_receives.
@@ -275,7 +278,7 @@ impl MemoryOfflineChecker {
         data: &[AB::Expr; BLOCK_FE_WIDTH],
         prev_data: &[AB::Expr; BLOCK_FE_WIDTH],
         timestamp: AB::Expr,
-        prev_timestamp: AB::Var,
+        prev_timestamp: AB::Expr,
         enabled: AB::Expr,
     ) where
         AB: InteractionBuilder,

--- a/crates/vm/src/system/memory/offline_checker/columns.rs
+++ b/crates/vm/src/system/memory/offline_checker/columns.rs
@@ -5,7 +5,6 @@ use openvm_circuit_primitives::{
     is_less_than::LessThanAuxCols, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_stark_backend::p3_field::PrimeField32;
 
 use crate::system::memory::offline_checker::bridge::AUX_LEN;
 
@@ -15,17 +14,8 @@ use crate::system::memory::offline_checker::bridge::AUX_LEN;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, AlignedBorrow, StructReflection)]
 pub struct MemoryBaseAuxCols<T> {
-    /// The previous timestamps in which the cells were accessed.
-    pub prev_timestamp: T,
-    /// The auxiliary columns to perform the less than check.
+    /// The limbs of `timestamp - prev_timestamp - 1` used to derive `prev_timestamp` in the AIR.
     pub timestamp_lt_aux: LessThanAuxCols<T, AUX_LEN>,
-}
-
-impl<F: PrimeField32> MemoryBaseAuxCols<F> {
-    #[inline(always)]
-    pub fn set_prev(&mut self, prev_timestamp: F) {
-        self.prev_timestamp = prev_timestamp;
-    }
 }
 
 #[repr(C)]
@@ -67,25 +57,10 @@ pub struct MemoryReadAuxCols<T> {
     pub(in crate::system::memory) base: MemoryBaseAuxCols<T>,
 }
 
-impl<F: PrimeField32> MemoryReadAuxCols<F> {
-    pub fn new(prev_timestamp: u32, timestamp_lt_aux: LessThanAuxCols<F, AUX_LEN>) -> Self {
-        Self {
-            base: MemoryBaseAuxCols {
-                prev_timestamp: F::from_u32(prev_timestamp),
-                timestamp_lt_aux,
-            },
-        }
-    }
-
+impl<T> MemoryReadAuxCols<T> {
     #[inline(always)]
-    pub fn get_base(self) -> MemoryBaseAuxCols<F> {
+    pub fn get_base(self) -> MemoryBaseAuxCols<T> {
         self.base
-    }
-
-    /// Sets the previous timestamp **without** updating the less than auxiliary columns.
-    #[inline(always)]
-    pub fn set_prev(&mut self, timestamp: F) {
-        self.base.prev_timestamp = timestamp;
     }
 }
 

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_imm_u16.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_imm_u16.cuh
@@ -19,7 +19,7 @@ template <typename T> struct Rv64BaseAluWImmU16AdapterCols {
     MemoryWriteAuxCols<T, BLOCK_FE_WIDTH> writes_aux;
 };
 
-static_assert(sizeof(Rv64BaseAluWImmU16AdapterCols<uint8_t>) == 17);
+static_assert(sizeof(Rv64BaseAluWImmU16AdapterCols<uint8_t>) == 15);
 
 struct Rv64BaseAluWImmU16AdapterRecord {
     uint32_t from_pc;

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_reg_u16.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_reg_u16.cuh
@@ -21,7 +21,7 @@ template <typename T> struct Rv64BaseAluWRegU16AdapterCols {
     MemoryWriteAuxCols<T, BLOCK_FE_WIDTH> writes_aux;
 };
 
-static_assert(sizeof(Rv64BaseAluWRegU16AdapterCols<uint8_t>) == 23);
+static_assert(sizeof(Rv64BaseAluWRegU16AdapterCols<uint8_t>) == 20);
 
 struct Rv64BaseAluWRegU16AdapterRecord {
     uint32_t from_pc;

--- a/extensions/riscv/circuit/src/adapters/alu_w_imm_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_imm_u16.rs
@@ -57,7 +57,7 @@ pub struct Rv64BaseAluWImmU16AdapterCols<T> {
     pub writes_aux: MemoryWriteAuxCols<T, BLOCK_FE_WIDTH>,
 }
 
-const _: () = assert!(size_of::<Rv64BaseAluWImmU16AdapterCols<u8>>() == 17);
+const _: () = assert!(size_of::<Rv64BaseAluWImmU16AdapterCols<u8>>() == 15);
 
 #[derive(Clone, Copy, Debug, derive_new::new, ColumnsAir)]
 #[columns_via(Rv64BaseAluWImmU16AdapterCols<u8>)]

--- a/extensions/riscv/circuit/src/adapters/alu_w_reg_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_reg_u16.rs
@@ -1,6 +1,7 @@
 use std::{
     array,
     borrow::{Borrow, BorrowMut},
+    mem::size_of,
 };
 
 use openvm_circuit::{
@@ -54,6 +55,8 @@ pub struct Rv64BaseAluWRegU16AdapterCols<T> {
     pub reads_aux: [MemoryReadAuxCols<T>; 2],
     pub writes_aux: MemoryWriteAuxCols<T, BLOCK_FE_WIDTH>,
 }
+
+const _: () = assert!(size_of::<Rv64BaseAluWRegU16AdapterCols<u8>>() == 20);
 
 /// Exposes the low 32-bit words of two register operands to the core and sign-extends the result.
 #[derive(Clone, Copy, Debug, derive_new::new, ColumnsAir)]


### PR DESCRIPTION
## Summary

- Derives the memory-bus receive timestamp from each access timestamp and its range-checked decomposition.
- Removes one trace column and one equality constraint from every memory access, reducing `MemoryReadAuxCols` from 3 to 2 columns and `MemoryWriteAuxCols` from 7 to 6.
- Keeps the maximum interaction degree unchanged and updates the Rust and CUDA trace layouts.
- Renames `LessThanAuxCols::lower_decomp` to `decomp` to describe its use in both less-than sub-AIRs.

Resolves INT-8882