### PR TITLE
feat: add cryptographic accelerators c interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4561,6 +4561,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-caci"
+version = "2.0.0"
+
+[[package]]
 name = "openvm-circuit"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
   "extensions/ecc/tests",
   "extensions/pairing/circuit",
   "extensions/pairing/guest",
+  "guest-libs/caci/",
   "guest-libs/ff_derive/",
   "guest-libs/k256/",
   "guest-libs/p256/",

--- a/docs/repo/layout.md
+++ b/docs/repo/layout.md
@@ -156,6 +156,7 @@ The toolchain, ISA, and VM are simultaneously extendable. All non-system functio
 
 Forked or custom libraries optimized for guest program execution inside the VM.
 
+- [`openvm-caci`](../../guest-libs/caci): OpenVM implementation of the eth-act zkVM Cryptographic Accelerators C Interface.
 - [`openvm-ff-derive`](../../guest-libs/ff_derive): OpenVM fork of `ff_derive` for finite field arithmetic.
 - [`k256`](../../guest-libs/k256): OpenVM fork of `k256`.
 - [`openvm-keccak256`](../../guest-libs/keccak256): OpenVM library for keccak256.

--- a/guest-libs/caci/Cargo.toml
+++ b/guest-libs/caci/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "openvm-caci"
+description = "OpenVM implementation of the eth-act zkVM Cryptographic Accelerators C Interface"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/guest-libs/caci/README.md
+++ b/guest-libs/caci/README.md
@@ -1,0 +1,5 @@
+# openvm-caci
+
+**C**ryptographic **A**ccelerators **C** **I**nterface.
+
+OpenVM's implementation of the [eth-act zkVM Cryptographic Accelerators C Interface](https://github.com/eth-act/zkvm-standards/tree/main/standards/c-interface-accelerators): a standard set of C-ABI functions that guest programs use to access accelerated cryptographic operations.

--- a/guest-libs/caci/src/lib.rs
+++ b/guest-libs/caci/src/lib.rs
@@ -1,0 +1,9 @@
+//! OpenVM implementation of the eth-act zkVM Cryptographic Accelerators C Interface.
+//!
+//! This crate provides OpenVM's accelerated cryptographic operations: each function is exported as
+//! a `#[no_mangle] extern "C"` symbol and delegates to the corresponding OpenVM accelerated guest
+//! library.
+
+#![no_std]
+
+pub mod types;

--- a/guest-libs/caci/src/types.rs
+++ b/guest-libs/caci/src/types.rs
@@ -1,0 +1,109 @@
+//! Rust mirrors of the C types declared in the standard's `zkvm_accelerators.h`.
+
+/// Status code returned by every accelerator function (`zkvm_status`).
+///
+/// C declares this as an enum with a negative member, which the C ABI represents as `int`.
+#[repr(i32)]
+pub enum ZkvmStatus {
+    /// `ZKVM_EOK`: success.
+    Ok = 0,
+    /// `ZKVM_EFAIL`: failure.
+    Fail = -1,
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes16 {
+    pub data: [u8; 16],
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes32 {
+    pub data: [u8; 32],
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes48 {
+    pub data: [u8; 48],
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes64 {
+    pub data: [u8; 64],
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes96 {
+    pub data: [u8; 96],
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes128 {
+    pub data: [u8; 128],
+}
+
+#[repr(C, align(8))]
+pub struct ZkvmBytes192 {
+    pub data: [u8; 192],
+}
+
+/// Hash types
+pub type ZkvmKeccak256Hash = ZkvmBytes32;
+pub type ZkvmSha256Hash = ZkvmBytes32;
+pub type ZkvmRipemd160Hash = ZkvmBytes32; // 20-byte hash padded to 32 bytes, first 12 bytes are zero.
+
+/// secp256k1 types
+pub type ZkvmSecp256k1Hash = ZkvmBytes32;
+pub type ZkvmSecp256k1Signature = ZkvmBytes64;
+pub type ZkvmSecp256k1Pubkey = ZkvmBytes64;
+
+/// secp256r1 (P-256) types
+pub type ZkvmSecp256r1Hash = ZkvmBytes32;
+pub type ZkvmSecp256r1Signature = ZkvmBytes64;
+pub type ZkvmSecp256r1Pubkey = ZkvmBytes64;
+
+/// BN254 types
+pub type ZkvmBn254G1Point = ZkvmBytes64;
+pub type ZkvmBn254G2Point = ZkvmBytes128;
+pub type ZkvmBn254Scalar = ZkvmBytes32;
+
+#[repr(C)]
+pub struct ZkvmBn254PairingPair {
+    pub g1: ZkvmBn254G1Point,
+    pub g2: ZkvmBn254G2Point,
+}
+
+/// BLS12-381 types
+pub type ZkvmBls12_381G1Point = ZkvmBytes96;
+pub type ZkvmBls12_381G2Point = ZkvmBytes192;
+pub type ZkvmBls12_381Scalar = ZkvmBytes32;
+
+pub type ZkvmBls12_381Fp = ZkvmBytes48;
+pub type ZkvmBls12_381Fp2 = ZkvmBytes96;
+
+#[repr(C)]
+pub struct ZkvmBls12_381G1MsmPair {
+    pub point: ZkvmBls12_381G1Point,
+    pub scalar: ZkvmBls12_381Scalar,
+}
+
+#[repr(C)]
+pub struct ZkvmBls12_381G2MsmPair {
+    pub point: ZkvmBls12_381G2Point,
+    pub scalar: ZkvmBls12_381Scalar,
+}
+
+#[repr(C)]
+pub struct ZkvmBls12_381PairingPair {
+    pub g1: ZkvmBls12_381G1Point,
+    pub g2: ZkvmBls12_381G2Point,
+}
+
+/// BLAKE2f types
+pub type ZkvmBlake2fState = ZkvmBytes64;
+pub type ZkvmBlake2fMessage = ZkvmBytes128;
+pub type ZkvmBlake2fOffset = ZkvmBytes16;
+
+/// KZG types
+pub type ZkvmKzgCommitment = ZkvmBytes48;
+pub type ZkvmKzgProof = ZkvmBytes48;
+pub type ZkvmKzgFieldElement = ZkvmBytes32;


### PR DESCRIPTION
This is a base PR for adding c interface for cryptographic accelerators according to [zkevm-standards](https://github.com/eth-act/zkevm-standards/tree/main/standards/c-interface-accelerators).

1. Keccak256 PR: https://github.com/openvm-org/openvm/pull/3076
2. Sha256 PR: https://github.com/openvm-org/openvm/pull/3077
3. Secp256k1 verify and ecrecover: https://github.com/openvm-org/openvm/pull/3079

towards INT-8880