### PR TITLE
feat: support for Zbb, Zba and Zbs extensions

### DIFF
--- a/benchmarks/utils/src/lib.rs
+++ b/benchmarks/utils/src/lib.rs
@@ -26,7 +26,16 @@ pub fn build_elf_with_path(
     profile: impl ToString,
     elf_path: Option<&PathBuf>,
 ) -> Result<Elf> {
-    let guest_opts = GuestOptions::default().with_profile(profile.to_string());
+    // Mirror `cargo openvm build`: let callers inject codegen flags (e.g.
+    // `-C target-feature=+zba,+zbb,+zbs`) via RUSTFLAGS. `build_guest_package`
+    // otherwise overrides the inherited environment.
+    let guest_opts = GuestOptions::default()
+        .with_profile(profile.to_string())
+        .with_rustc_flags(
+            std::env::var("RUSTFLAGS")
+                .unwrap_or_default()
+                .split_whitespace(),
+        );
 
     let output_dir = match build_guest_package(pkg, &guest_opts, None, &None) {
         Ok(dir) => dir,

--- a/crates/rvr/rvr-openvm/src/emit/project.rs
+++ b/crates/rvr/rvr-openvm/src/emit/project.rs
@@ -1282,6 +1282,10 @@ impl CProject {
         }
         if self.native_debug_info {
             args.push("DEBUG=-g -fno-omit-frame-pointer".to_string());
+        } else {
+            // Avoid leaking unrelated environment variables such as
+            // DEBUG=release into the generated C compiler flags.
+            args.push("DEBUG=".to_string());
         }
         if self.sanitize {
             args.push("SANITIZERS=-fsanitize=undefined,bounds -fsanitize-trap=all".to_string());

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -482,8 +482,8 @@ impl VmBuilder<BabyBearPoseidon2GpuEngine> for SdkVmGpuBuilder {
         if let Some(io) = &config.io {
             VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, io, inventory)?;
         }
-        if config.rv64b.is_some() {
-            panic!("Rv64B does not have CUDA prover support yet");
+        if let Some(rv64b) = &config.rv64b {
+            VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, rv64b, inventory)?;
         }
         if let Some(keccak) = &config.keccak {
             VmProverExtension::<E, _, _>::extend_prover(&Keccak256GpuProverExt, keccak, inventory)?;

--- a/crates/sdk-config/src/lib.rs
+++ b/crates/sdk-config/src/lib.rs
@@ -68,6 +68,7 @@ pub struct SdkVmConfig {
     pub system: SdkSystemConfig,
     pub rv64i: Option<UnitStruct>,
     pub io: Option<UnitStruct>,
+    pub rv64b: Option<UnitStruct>,
     pub keccak: Option<UnitStruct>,
     pub sha2: Option<UnitStruct>,
 
@@ -188,6 +189,9 @@ impl TranspilerConfig<F> for SdkVmConfig {
         if self.io.is_some() {
             transpiler = transpiler.with_extension(Rv64IoTranspilerExtension);
         }
+        if self.rv64b.is_some() {
+            transpiler = transpiler.with_extension(Rv64BTranspilerExtension);
+        }
         if self.keccak.is_some() {
             transpiler = transpiler.with_extension(Keccak256TranspilerExtension);
         }
@@ -270,6 +274,7 @@ impl SdkVmConfig {
         let system = config.system.config.clone();
         let rv64i = config.rv64i.map(|_| Rv64I);
         let io = config.io.map(|_| Rv64Io);
+        let rv64b = config.rv64b.map(|_| Rv64B);
         let keccak = config.keccak.map(|_| Keccak256);
         let sha2 = config.sha2.map(|_| Sha2);
         let rv64m = config.rv64m;
@@ -284,6 +289,7 @@ impl SdkVmConfig {
             system,
             rv64i,
             io,
+            rv64b,
             keccak,
             sha2,
             rv64m,
@@ -313,6 +319,8 @@ pub struct SdkVmConfigInner {
     pub rv64i: Option<Rv64I>,
     #[extension(executor = "Rv64IoExecutor")]
     pub io: Option<Rv64Io>,
+    #[extension(executor = "Rv64BExecutor")]
+    pub rv64b: Option<Rv64B>,
     #[extension(executor = "Keccak256Executor")]
     pub keccak: Option<Keccak256>,
     #[extension(executor = "Sha2Executor")]
@@ -401,6 +409,9 @@ where
         if let Some(io) = &config.io {
             VmProverExtension::<E, _, _>::extend_prover(&Rv64ImCpuProverExt, io, inventory)?;
         }
+        if let Some(rv64b) = &config.rv64b {
+            VmProverExtension::<E, _, _>::extend_prover(&Rv64ImCpuProverExt, rv64b, inventory)?;
+        }
         if let Some(keccak) = &config.keccak {
             VmProverExtension::<E, _, _>::extend_prover(&Keccak256CpuProverExt, keccak, inventory)?;
         }
@@ -470,6 +481,9 @@ impl VmBuilder<BabyBearPoseidon2GpuEngine> for SdkVmGpuBuilder {
         }
         if let Some(io) = &config.io {
             VmProverExtension::<E, _, _>::extend_prover(&Rv64ImGpuProverExt, io, inventory)?;
+        }
+        if config.rv64b.is_some() {
+            panic!("Rv64B does not have CUDA prover support yet");
         }
         if let Some(keccak) = &config.keccak {
             VmProverExtension::<E, _, _>::extend_prover(&Keccak256GpuProverExt, keccak, inventory)?;
@@ -575,6 +589,12 @@ impl From<Rv64Io> for UnitStruct {
     }
 }
 
+impl From<Rv64B> for UnitStruct {
+    fn from(_: Rv64B) -> Self {
+        UnitStruct {}
+    }
+}
+
 impl From<Keccak256> for UnitStruct {
     fn from(_: Keccak256) -> Self {
         UnitStruct {}
@@ -594,6 +614,7 @@ struct SdkVmConfigWithDefaultDeser {
 
     pub rv64i: Option<UnitStruct>,
     pub io: Option<UnitStruct>,
+    pub rv64b: Option<UnitStruct>,
     pub keccak: Option<UnitStruct>,
     pub sha2: Option<UnitStruct>,
 
@@ -613,6 +634,7 @@ impl From<SdkVmConfigWithDefaultDeser> for SdkVmConfig {
             system: config.system,
             rv64i: config.rv64i,
             io: config.io,
+            rv64b: config.rv64b,
             keccak: config.keccak,
             sha2: config.sha2,
             rv64m: config.rv64m,

--- a/crates/toolchain/decoder/src/lib.rs
+++ b/crates/toolchain/decoder/src/lib.rs
@@ -10,7 +10,7 @@ pub mod process_instruction;
 #[cfg(test)]
 mod test_helpers;
 
-pub use process_instruction::process_instruction;
+pub use process_instruction::{is_bitmanip_instruction, process_instruction};
 
 /// A trait for objects which do something with RISC-V instructions (e.g. execute them or print a
 /// disassembly string).
@@ -115,4 +115,91 @@ pub trait InstructionProcessor {
     fn process_divuw(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
     fn process_remw(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
     fn process_remuw(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+
+    // Zba (address generation)
+    fn process_add_uw(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_sh1add(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_sh2add(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_sh3add(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_sh1add_uw(
+        &mut self,
+        dec_insn: instruction_formats::RType,
+    ) -> Self::InstructionResult;
+    fn process_sh2add_uw(
+        &mut self,
+        dec_insn: instruction_formats::RType,
+    ) -> Self::InstructionResult;
+    fn process_sh3add_uw(
+        &mut self,
+        dec_insn: instruction_formats::RType,
+    ) -> Self::InstructionResult;
+    fn process_slli_uw(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
+
+    // Zbb: logical with negate
+    fn process_andn(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_orn(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_xnor(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+
+    // Zbb: counts. These are unary (rd, rs1); the sub-operation is encoded in the
+    // rs2/shamt field of an I-type word, so the `imm` field carries the full funct12.
+    fn process_clz(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_ctz(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_cpop(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_clzw(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_ctzw(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_cpopw(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+
+    // Zbb: min/max
+    fn process_min(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_minu(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_max(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_maxu(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+
+    // Zbb: sign/zero extension (unary; zext.h is R-type with rs2 = 0)
+    fn process_sext_b(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_sext_h(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_zext_h(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+
+    // Zbb: rotates
+    fn process_rol(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_ror(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_rori(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
+    fn process_rolw(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_rorw(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_roriw(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
+
+    // Zbb: byte ops (unary)
+    fn process_orc_b(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+    fn process_rev8(&mut self, dec_insn: instruction_formats::IType) -> Self::InstructionResult;
+
+    // Zbs (single-bit)
+    fn process_bclr(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_bset(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_binv(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_bext(&mut self, dec_insn: instruction_formats::RType) -> Self::InstructionResult;
+    fn process_bclri(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
+    fn process_bseti(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
+    fn process_binvi(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
+    fn process_bexti(
+        &mut self,
+        dec_insn: instruction_formats::ITypeShamt,
+    ) -> Self::InstructionResult;
 }

--- a/crates/toolchain/decoder/src/process_instruction.rs
+++ b/crates/toolchain/decoder/src/process_instruction.rs
@@ -22,11 +22,16 @@ fn process_opcode_op<T: InstructionProcessor>(
         0b001 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_sll(dec_insn)),
             0b000_0001 => Some(processor.process_mulh(dec_insn)),
+            0b001_0100 => Some(processor.process_bset(dec_insn)),
+            0b010_0100 => Some(processor.process_bclr(dec_insn)),
+            0b011_0000 => Some(processor.process_rol(dec_insn)),
+            0b011_0100 => Some(processor.process_binv(dec_insn)),
             _ => None,
         },
         0b010 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_slt(dec_insn)),
             0b000_0001 => Some(processor.process_mulhsu(dec_insn)),
+            0b001_0000 => Some(processor.process_sh1add(dec_insn)),
             _ => None,
         },
         0b011 => match dec_insn.funct7 {
@@ -37,22 +42,33 @@ fn process_opcode_op<T: InstructionProcessor>(
         0b100 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_xor(dec_insn)),
             0b000_0001 => Some(processor.process_div(dec_insn)),
+            0b000_0101 => Some(processor.process_min(dec_insn)),
+            0b001_0000 => Some(processor.process_sh2add(dec_insn)),
+            0b010_0000 => Some(processor.process_xnor(dec_insn)),
             _ => None,
         },
         0b101 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_srl(dec_insn)),
             0b000_0001 => Some(processor.process_divu(dec_insn)),
+            0b000_0101 => Some(processor.process_minu(dec_insn)),
             0b010_0000 => Some(processor.process_sra(dec_insn)),
+            0b010_0100 => Some(processor.process_bext(dec_insn)),
+            0b011_0000 => Some(processor.process_ror(dec_insn)),
             _ => None,
         },
         0b110 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_or(dec_insn)),
             0b000_0001 => Some(processor.process_rem(dec_insn)),
+            0b000_0101 => Some(processor.process_max(dec_insn)),
+            0b001_0000 => Some(processor.process_sh3add(dec_insn)),
+            0b010_0000 => Some(processor.process_orn(dec_insn)),
             _ => None,
         },
         0b111 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_and(dec_insn)),
             0b000_0001 => Some(processor.process_remu(dec_insn)),
+            0b000_0101 => Some(processor.process_maxu(dec_insn)),
+            0b010_0000 => Some(processor.process_andn(dec_insn)),
             _ => None,
         },
         _ => None,
@@ -71,6 +87,18 @@ fn process_opcode_op_imm<T: InstructionProcessor>(
             let dec_insn_shamt = instruction_formats::ITypeShamt::new(insn_bits);
             match dec_insn_shamt.funct6 {
                 0b000_000 => Some(processor.process_slli(dec_insn_shamt)),
+                0b001_010 => Some(processor.process_bseti(dec_insn_shamt)),
+                0b010_010 => Some(processor.process_bclri(dec_insn_shamt)),
+                0b011_010 => Some(processor.process_binvi(dec_insn_shamt)),
+                // Unary Zbb ops: the sub-operation lives in the shamt field.
+                0b011_000 => match dec_insn_shamt.shamt {
+                    0b00000 => Some(processor.process_clz(dec_insn)),
+                    0b00001 => Some(processor.process_ctz(dec_insn)),
+                    0b00010 => Some(processor.process_cpop(dec_insn)),
+                    0b00100 => Some(processor.process_sext_b(dec_insn)),
+                    0b00101 => Some(processor.process_sext_h(dec_insn)),
+                    _ => None,
+                },
                 _ => None,
             }
         }
@@ -82,6 +110,14 @@ fn process_opcode_op_imm<T: InstructionProcessor>(
             match dec_insn_shamt.funct6 {
                 0b000_000 => Some(processor.process_srli(dec_insn_shamt)),
                 0b010_000 => Some(processor.process_srai(dec_insn_shamt)),
+                0b010_010 => Some(processor.process_bexti(dec_insn_shamt)),
+                0b011_000 => Some(processor.process_rori(dec_insn_shamt)),
+                0b001_010 if dec_insn_shamt.shamt == 0b000_111 => {
+                    Some(processor.process_orc_b(dec_insn))
+                }
+                0b011_010 if dec_insn_shamt.shamt == 0b111_000 => {
+                    Some(processor.process_rev8(dec_insn))
+                }
                 _ => None,
             }
         }
@@ -151,10 +187,21 @@ fn process_opcode_op_imm_32<T: InstructionProcessor>(
         0b000 => Some(processor.process_addiw(dec_insn)),
         0b001 => {
             let dec_insn_shamt = instruction_formats::ITypeShamt::new(insn_bits);
-            if dec_insn_shamt.funct6 == 0b000_000 && dec_insn_shamt.shamt < 32 {
-                Some(processor.process_slliw(dec_insn_shamt))
-            } else {
-                None
+            match dec_insn_shamt.funct6 {
+                0b000_000 if dec_insn_shamt.shamt < 32 => {
+                    Some(processor.process_slliw(dec_insn_shamt))
+                }
+                // slli.uw takes the full 6-bit shamt (it shifts a zero-extended
+                // 32-bit value within a 64-bit register).
+                0b000_010 => Some(processor.process_slli_uw(dec_insn_shamt)),
+                // Unary Zbb W-form ops: the sub-operation lives in the shamt field.
+                0b011_000 => match dec_insn_shamt.shamt {
+                    0b00000 => Some(processor.process_clzw(dec_insn)),
+                    0b00001 => Some(processor.process_ctzw(dec_insn)),
+                    0b00010 => Some(processor.process_cpopw(dec_insn)),
+                    _ => None,
+                },
+                _ => None,
             }
         }
         0b101 => {
@@ -165,6 +212,7 @@ fn process_opcode_op_imm_32<T: InstructionProcessor>(
             match dec_insn_shamt.funct6 {
                 0b000_000 => Some(processor.process_srliw(dec_insn_shamt)),
                 0b010_000 => Some(processor.process_sraiw(dec_insn_shamt)),
+                0b011_000 => Some(processor.process_roriw(dec_insn_shamt)),
                 _ => None,
             }
         }
@@ -182,25 +230,36 @@ fn process_opcode_op_32<T: InstructionProcessor>(
         0b000 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_addw(dec_insn)),
             0b000_0001 => Some(processor.process_mulw(dec_insn)),
+            0b000_0100 => Some(processor.process_add_uw(dec_insn)),
             0b010_0000 => Some(processor.process_subw(dec_insn)),
             _ => None,
         },
         0b001 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_sllw(dec_insn)),
+            0b011_0000 => Some(processor.process_rolw(dec_insn)),
+            _ => None,
+        },
+        0b010 => match dec_insn.funct7 {
+            0b001_0000 => Some(processor.process_sh1add_uw(dec_insn)),
             _ => None,
         },
         0b100 => match dec_insn.funct7 {
             0b000_0001 => Some(processor.process_divw(dec_insn)),
+            // zext.h shares funct7 with a reserved encoding space; only rs2 = 0 is valid.
+            0b000_0100 if dec_insn.rs2 == 0 => Some(processor.process_zext_h(dec_insn)),
+            0b001_0000 => Some(processor.process_sh2add_uw(dec_insn)),
             _ => None,
         },
         0b101 => match dec_insn.funct7 {
             0b000_0000 => Some(processor.process_srlw(dec_insn)),
             0b000_0001 => Some(processor.process_divuw(dec_insn)),
             0b010_0000 => Some(processor.process_sraw(dec_insn)),
+            0b011_0000 => Some(processor.process_rorw(dec_insn)),
             _ => None,
         },
         0b110 => match dec_insn.funct7 {
             0b000_0001 => Some(processor.process_remw(dec_insn)),
+            0b001_0000 => Some(processor.process_sh3add_uw(dec_insn)),
             _ => None,
         },
         0b111 => match dec_insn.funct7 {
@@ -253,6 +312,83 @@ pub fn process_instruction<T: InstructionProcessor>(
         instruction_formats::OPCODE_OP_IMM_32 => process_opcode_op_imm_32(processor, insn_bits),
         instruction_formats::OPCODE_OP_32 => process_opcode_op_32(processor, insn_bits),
         _ => None,
+    }
+}
+
+/// Returns whether `insn_bits` encodes a bit-manipulation (Zba/Zbb/Zbs) instruction.
+///
+/// This must stay in lockstep with the dispatch arms above (enforced by the
+/// `bitmanip_predicate_matches_dispatch` test). Transpiler extensions use it to
+/// decide which extension owns a word: the RV64IM extension skips exactly the
+/// words the bit-manipulation extension claims, so registering both never
+/// yields an ambiguous transpilation.
+pub fn is_bitmanip_instruction(insn_bits: u32) -> bool {
+    let opcode: u32 = insn_bits & 0x7f;
+
+    match opcode {
+        instruction_formats::OPCODE_OP => {
+            let dec_insn = instruction_formats::RType::new(insn_bits);
+            matches!(
+                (dec_insn.funct3, dec_insn.funct7),
+                (0b001, 0b001_0100)     // bset
+                    | (0b001, 0b010_0100) // bclr
+                    | (0b001, 0b011_0000) // rol
+                    | (0b001, 0b011_0100) // binv
+                    | (0b010, 0b001_0000) // sh1add
+                    | (0b100, 0b000_0101) // min
+                    | (0b100, 0b001_0000) // sh2add
+                    | (0b100, 0b010_0000) // xnor
+                    | (0b101, 0b000_0101) // minu
+                    | (0b101, 0b010_0100) // bext
+                    | (0b101, 0b011_0000) // ror
+                    | (0b110, 0b000_0101) // max
+                    | (0b110, 0b001_0000) // sh3add
+                    | (0b110, 0b010_0000) // orn
+                    | (0b111, 0b000_0101) // maxu
+                    | (0b111, 0b010_0000) // andn
+            )
+        }
+        instruction_formats::OPCODE_OP_32 => {
+            let dec_insn = instruction_formats::RType::new(insn_bits);
+            match (dec_insn.funct3, dec_insn.funct7) {
+                (0b000, 0b000_0100) => true,              // add.uw
+                (0b001, 0b011_0000) => true,              // rolw
+                (0b010, 0b001_0000) => true,              // sh1add.uw
+                (0b100, 0b000_0100) => dec_insn.rs2 == 0, // zext.h
+                (0b100, 0b001_0000) => true,              // sh2add.uw
+                (0b101, 0b011_0000) => true,              // rorw
+                (0b110, 0b001_0000) => true,              // sh3add.uw
+                _ => false,
+            }
+        }
+        instruction_formats::OPCODE_OP_IMM => {
+            let dec_insn = instruction_formats::ITypeShamt::new(insn_bits);
+            match (dec_insn.funct3, dec_insn.funct6) {
+                (0b001, 0b001_010) => true, // bseti
+                (0b001, 0b010_010) => true, // bclri
+                (0b001, 0b011_010) => true, // binvi
+                // clz/ctz/cpop/sext.b/sext.h
+                (0b001, 0b011_000) => {
+                    matches!(dec_insn.shamt, 0b00000..=0b00010 | 0b00100 | 0b00101)
+                }
+                (0b101, 0b001_010) => dec_insn.shamt == 0b000_111, // orc.b
+                (0b101, 0b010_010) => true,                        // bexti
+                (0b101, 0b011_000) => true,                        // rori
+                (0b101, 0b011_010) => dec_insn.shamt == 0b111_000, // rev8
+                _ => false,
+            }
+        }
+        instruction_formats::OPCODE_OP_IMM_32 => {
+            let dec_insn = instruction_formats::ITypeShamt::new(insn_bits);
+            match (dec_insn.funct3, dec_insn.funct6) {
+                (0b001, 0b000_010) => true, // slli.uw
+                // clzw/ctzw/cpopw
+                (0b001, 0b011_000) => dec_insn.shamt <= 0b00010,
+                (0b101, 0b011_000) => dec_insn.shamt < 32, // roriw
+                _ => false,
+            }
+        }
+        _ => false,
     }
 }
 
@@ -382,6 +518,62 @@ mod tests {
         Divuw   process_divuw   RType,
         Remw    process_remw    RType,
         Remuw   process_remuw   RType,
+
+        // Zba (OPCODE_OP / OPCODE_OP_32 / OPCODE_OP_IMM_32)
+        AddUw     process_add_uw     RType,
+        Sh1add    process_sh1add     RType,
+        Sh2add    process_sh2add     RType,
+        Sh3add    process_sh3add     RType,
+        Sh1addUw  process_sh1add_uw  RType,
+        Sh2addUw  process_sh2add_uw  RType,
+        Sh3addUw  process_sh3add_uw  RType,
+        SlliUw    process_slli_uw    ITypeShamt,
+
+        // Zbb: logical with negate (OPCODE_OP)
+        Andn    process_andn    RType,
+        Orn     process_orn     RType,
+        Xnor    process_xnor    RType,
+
+        // Zbb: counts (OPCODE_OP_IMM / OPCODE_OP_IMM_32, unary)
+        Clz     process_clz     IType,
+        Ctz     process_ctz     IType,
+        Cpop    process_cpop    IType,
+        Clzw    process_clzw    IType,
+        Ctzw    process_ctzw    IType,
+        Cpopw   process_cpopw   IType,
+
+        // Zbb: min/max (OPCODE_OP)
+        Min     process_min     RType,
+        Minu    process_minu    RType,
+        Max     process_max     RType,
+        Maxu    process_maxu    RType,
+
+        // Zbb: sign/zero extension
+        SextB   process_sext_b  IType,
+        SextH   process_sext_h  IType,
+        ZextH   process_zext_h  RType,
+
+        // Zbb: rotates
+        Rol     process_rol     RType,
+        Ror     process_ror     RType,
+        Rori    process_rori    ITypeShamt,
+        Rolw    process_rolw    RType,
+        Rorw    process_rorw    RType,
+        Roriw   process_roriw   ITypeShamt,
+
+        // Zbb: byte ops (unary)
+        OrcB    process_orc_b   IType,
+        Rev8    process_rev8    IType,
+
+        // Zbs (OPCODE_OP / OPCODE_OP_IMM)
+        Bclr    process_bclr    RType,
+        Bset    process_bset    RType,
+        Binv    process_binv    RType,
+        Bext    process_bext    RType,
+        Bclri   process_bclri   ITypeShamt,
+        Bseti   process_bseti   ITypeShamt,
+        Binvi   process_binvi   ITypeShamt,
+        Bexti   process_bexti   ITypeShamt,
     }
 
     // Per-format dispatch helpers. Each `check_*_dispatch` builds an
@@ -774,5 +966,289 @@ mod tests {
         // dispatch tree. The transpiler layer handles these earlier.
         check_rejects(0x00100073); // ebreak
         check_rejects(0x30001073); // csrrw x0, mstatus, x0
+    }
+
+    // ---- Bit-manipulation (Zba / Zbb / Zbs) dispatch --------------------
+
+    #[test]
+    fn dispatch_zba() {
+        check_r_dispatch(OPCODE_OP_32, 0x04, 0, 1, 2, 3, Called::AddUw);
+        check_r_dispatch(OPCODE_OP, 0x10, 2, 4, 5, 6, Called::Sh1add);
+        check_r_dispatch(OPCODE_OP, 0x10, 4, 7, 8, 9, Called::Sh2add);
+        check_r_dispatch(OPCODE_OP, 0x10, 6, 10, 11, 12, Called::Sh3add);
+        check_r_dispatch(OPCODE_OP_32, 0x10, 2, 13, 14, 15, Called::Sh1addUw);
+        check_r_dispatch(OPCODE_OP_32, 0x10, 4, 16, 17, 18, Called::Sh2addUw);
+        check_r_dispatch(OPCODE_OP_32, 0x10, 6, 19, 20, 21, Called::Sh3addUw);
+        // slli.uw takes the full 6-bit shamt, unlike slliw.
+        check_i_shamt6_dispatch(OPCODE_OP_IMM_32, 0x02, 1, 22, 23, 63, Called::SlliUw);
+        check_i_shamt6_dispatch(OPCODE_OP_IMM_32, 0x02, 1, 22, 23, 0, Called::SlliUw);
+    }
+
+    #[test]
+    fn dispatch_zbb_logic_minmax_rotates() {
+        check_r_dispatch(OPCODE_OP, 0x20, 7, 1, 2, 3, Called::Andn);
+        check_r_dispatch(OPCODE_OP, 0x20, 6, 4, 5, 6, Called::Orn);
+        check_r_dispatch(OPCODE_OP, 0x20, 4, 7, 8, 9, Called::Xnor);
+        check_r_dispatch(OPCODE_OP, 0x05, 4, 10, 11, 12, Called::Min);
+        check_r_dispatch(OPCODE_OP, 0x05, 5, 13, 14, 15, Called::Minu);
+        check_r_dispatch(OPCODE_OP, 0x05, 6, 16, 17, 18, Called::Max);
+        check_r_dispatch(OPCODE_OP, 0x05, 7, 19, 20, 21, Called::Maxu);
+        check_r_dispatch(OPCODE_OP, 0x30, 1, 22, 23, 24, Called::Rol);
+        check_r_dispatch(OPCODE_OP, 0x30, 5, 25, 26, 27, Called::Ror);
+        check_r_dispatch(OPCODE_OP_32, 0x30, 1, 28, 29, 30, Called::Rolw);
+        check_r_dispatch(OPCODE_OP_32, 0x30, 5, 31, 0, 1, Called::Rorw);
+        check_i_shamt6_dispatch(OPCODE_OP_IMM, 0x18, 5, 2, 3, 63, Called::Rori);
+        check_i_shamt5_dispatch(OPCODE_OP_IMM_32, 0x30, 5, 4, 5, 31, Called::Roriw);
+    }
+
+    #[test]
+    fn dispatch_zbb_unary() {
+        // Unary Zbb ops encode the sub-operation in the shamt/rs2 field, so
+        // dispatch is on the full 12-bit immediate. The processor receives
+        // the plain IType (imm carries the funct12 value).
+        check_i_dispatch(OPCODE_OP_IMM, 1, 1, 2, 0x600, Called::Clz);
+        check_i_dispatch(OPCODE_OP_IMM, 1, 3, 4, 0x601, Called::Ctz);
+        check_i_dispatch(OPCODE_OP_IMM, 1, 5, 6, 0x602, Called::Cpop);
+        check_i_dispatch(OPCODE_OP_IMM, 1, 7, 8, 0x604, Called::SextB);
+        check_i_dispatch(OPCODE_OP_IMM, 1, 9, 10, 0x605, Called::SextH);
+        check_i_dispatch(OPCODE_OP_IMM_32, 1, 11, 12, 0x600, Called::Clzw);
+        check_i_dispatch(OPCODE_OP_IMM_32, 1, 13, 14, 0x601, Called::Ctzw);
+        check_i_dispatch(OPCODE_OP_IMM_32, 1, 15, 16, 0x602, Called::Cpopw);
+        check_i_dispatch(OPCODE_OP_IMM, 5, 17, 18, 0x287, Called::OrcB);
+        check_i_dispatch(OPCODE_OP_IMM, 5, 19, 20, 0x6b8, Called::Rev8);
+        // zext.h is R-type on OPCODE_OP_32 with rs2 hardwired to 0.
+        check_r_dispatch(OPCODE_OP_32, 0x04, 4, 21, 22, 0, Called::ZextH);
+    }
+
+    #[test]
+    fn dispatch_zbs() {
+        check_r_dispatch(OPCODE_OP, 0x24, 1, 1, 2, 3, Called::Bclr);
+        check_r_dispatch(OPCODE_OP, 0x14, 1, 4, 5, 6, Called::Bset);
+        check_r_dispatch(OPCODE_OP, 0x34, 1, 7, 8, 9, Called::Binv);
+        check_r_dispatch(OPCODE_OP, 0x24, 5, 10, 11, 12, Called::Bext);
+        check_i_shamt6_dispatch(OPCODE_OP_IMM, 0x12, 1, 13, 14, 63, Called::Bclri);
+        check_i_shamt6_dispatch(OPCODE_OP_IMM, 0x0a, 1, 15, 16, 0, Called::Bseti);
+        check_i_shamt6_dispatch(OPCODE_OP_IMM, 0x1a, 1, 17, 18, 32, Called::Binvi);
+        check_i_shamt6_dispatch(OPCODE_OP_IMM, 0x12, 5, 19, 20, 50, Called::Bexti);
+    }
+
+    /// Golden encodings generated with
+    /// `llvm-mc -triple=riscv64 -mattr=+zba,+zbb,+zbs -show-encoding` (LLVM 22),
+    /// i.e. the exact words the guest compiler emits. Pins both the funct-space
+    /// mapping and the operand field extraction for every B-ext instruction.
+    #[test]
+    fn dispatch_bitmanip_llvm_golden_words() {
+        #[rustfmt::skip]
+        let cases: &[(u32, Called)] = &[
+            // add.uw x5, x6, x7
+            (0x087302bb, Called::AddUw(RType { funct7: 0x04, rs2: 7, rs1: 6, funct3: 0, rd: 5 })),
+            // sh1add x8, x9, x10
+            (0x20a4a433, Called::Sh1add(RType { funct7: 0x10, rs2: 10, rs1: 9, funct3: 2, rd: 8 })),
+            // sh2add x11, x12, x13
+            (0x20d645b3, Called::Sh2add(RType { funct7: 0x10, rs2: 13, rs1: 12, funct3: 4, rd: 11 })),
+            // sh3add x14, x15, x16
+            (0x2107e733, Called::Sh3add(RType { funct7: 0x10, rs2: 16, rs1: 15, funct3: 6, rd: 14 })),
+            // sh1add.uw x17, x18, x19
+            (0x213928bb, Called::Sh1addUw(RType { funct7: 0x10, rs2: 19, rs1: 18, funct3: 2, rd: 17 })),
+            // sh2add.uw x20, x21, x22
+            (0x216aca3b, Called::Sh2addUw(RType { funct7: 0x10, rs2: 22, rs1: 21, funct3: 4, rd: 20 })),
+            // sh3add.uw x23, x24, x25
+            (0x219c6bbb, Called::Sh3addUw(RType { funct7: 0x10, rs2: 25, rs1: 24, funct3: 6, rd: 23 })),
+            // slli.uw x26, x27, 37
+            (0x0a5d9d1b, Called::SlliUw(ITypeShamt { funct6: 0x02, shamt: 37, rs1: 27, funct3: 1, rd: 26 })),
+            // andn x5, x6, x7
+            (0x407372b3, Called::Andn(RType { funct7: 0x20, rs2: 7, rs1: 6, funct3: 7, rd: 5 })),
+            // orn x8, x9, x10
+            (0x40a4e433, Called::Orn(RType { funct7: 0x20, rs2: 10, rs1: 9, funct3: 6, rd: 8 })),
+            // xnor x11, x12, x13
+            (0x40d645b3, Called::Xnor(RType { funct7: 0x20, rs2: 13, rs1: 12, funct3: 4, rd: 11 })),
+            // clz x14, x15
+            (0x60079713, Called::Clz(IType { imm: 0x600, rs1: 15, funct3: 1, rd: 14 })),
+            // ctz x16, x17
+            (0x60189813, Called::Ctz(IType { imm: 0x601, rs1: 17, funct3: 1, rd: 16 })),
+            // cpop x18, x19
+            (0x60299913, Called::Cpop(IType { imm: 0x602, rs1: 19, funct3: 1, rd: 18 })),
+            // clzw x20, x21
+            (0x600a9a1b, Called::Clzw(IType { imm: 0x600, rs1: 21, funct3: 1, rd: 20 })),
+            // ctzw x22, x23
+            (0x601b9b1b, Called::Ctzw(IType { imm: 0x601, rs1: 23, funct3: 1, rd: 22 })),
+            // cpopw x24, x25
+            (0x602c9c1b, Called::Cpopw(IType { imm: 0x602, rs1: 25, funct3: 1, rd: 24 })),
+            // min x5, x6, x7
+            (0x0a7342b3, Called::Min(RType { funct7: 0x05, rs2: 7, rs1: 6, funct3: 4, rd: 5 })),
+            // minu x8, x9, x10
+            (0x0aa4d433, Called::Minu(RType { funct7: 0x05, rs2: 10, rs1: 9, funct3: 5, rd: 8 })),
+            // max x11, x12, x13
+            (0x0ad665b3, Called::Max(RType { funct7: 0x05, rs2: 13, rs1: 12, funct3: 6, rd: 11 })),
+            // maxu x14, x15, x16
+            (0x0b07f733, Called::Maxu(RType { funct7: 0x05, rs2: 16, rs1: 15, funct3: 7, rd: 14 })),
+            // sext.b x17, x18
+            (0x60491893, Called::SextB(IType { imm: 0x604, rs1: 18, funct3: 1, rd: 17 })),
+            // sext.h x19, x20
+            (0x605a1993, Called::SextH(IType { imm: 0x605, rs1: 20, funct3: 1, rd: 19 })),
+            // zext.h x21, x22
+            (0x080b4abb, Called::ZextH(RType { funct7: 0x04, rs2: 0, rs1: 22, funct3: 4, rd: 21 })),
+            // rol x5, x6, x7
+            (0x607312b3, Called::Rol(RType { funct7: 0x30, rs2: 7, rs1: 6, funct3: 1, rd: 5 })),
+            // ror x8, x9, x10
+            (0x60a4d433, Called::Ror(RType { funct7: 0x30, rs2: 10, rs1: 9, funct3: 5, rd: 8 })),
+            // rori x11, x12, 45
+            (0x62d65593, Called::Rori(ITypeShamt { funct6: 0x18, shamt: 45, rs1: 12, funct3: 5, rd: 11 })),
+            // rolw x13, x14, x15
+            (0x60f716bb, Called::Rolw(RType { funct7: 0x30, rs2: 15, rs1: 14, funct3: 1, rd: 13 })),
+            // rorw x16, x17, x18
+            (0x6128d83b, Called::Rorw(RType { funct7: 0x30, rs2: 18, rs1: 17, funct3: 5, rd: 16 })),
+            // roriw x19, x20, 21
+            (0x615a599b, Called::Roriw(ITypeShamt { funct6: 0x18, shamt: 21, rs1: 20, funct3: 5, rd: 19 })),
+            // orc.b x22, x23
+            (0x287bdb13, Called::OrcB(IType { imm: 0x287, rs1: 23, funct3: 5, rd: 22 })),
+            // rev8 x24, x25
+            (0x6b8cdc13, Called::Rev8(IType { imm: 0x6b8, rs1: 25, funct3: 5, rd: 24 })),
+            // bclr x5, x6, x7
+            (0x487312b3, Called::Bclr(RType { funct7: 0x24, rs2: 7, rs1: 6, funct3: 1, rd: 5 })),
+            // bset x8, x9, x10
+            (0x28a49433, Called::Bset(RType { funct7: 0x14, rs2: 10, rs1: 9, funct3: 1, rd: 8 })),
+            // binv x11, x12, x13
+            (0x68d615b3, Called::Binv(RType { funct7: 0x34, rs2: 13, rs1: 12, funct3: 1, rd: 11 })),
+            // bext x14, x15, x16
+            (0x4907d733, Called::Bext(RType { funct7: 0x24, rs2: 16, rs1: 15, funct3: 5, rd: 14 })),
+            // bclri x17, x18, 47
+            (0x4af91893, Called::Bclri(ITypeShamt { funct6: 0x12, shamt: 47, rs1: 18, funct3: 1, rd: 17 })),
+            // bseti x19, x20, 48
+            (0x2b0a1993, Called::Bseti(ITypeShamt { funct6: 0x0a, shamt: 48, rs1: 20, funct3: 1, rd: 19 })),
+            // binvi x21, x22, 49
+            (0x6b1b1a93, Called::Binvi(ITypeShamt { funct6: 0x1a, shamt: 49, rs1: 22, funct3: 1, rd: 21 })),
+            // bexti x23, x24, 50
+            (0x4b2c5b93, Called::Bexti(ITypeShamt { funct6: 0x12, shamt: 50, rs1: 24, funct3: 5, rd: 23 })),
+        ];
+        for (bits, expected) in cases {
+            assert_eq!(
+                process_instruction(&mut Recorder, *bits).as_ref(),
+                Some(expected),
+                "golden word {bits:#010x} did not dispatch as expected"
+            );
+            assert!(
+                is_bitmanip_instruction(*bits),
+                "golden word {bits:#010x} not classified as bit-manipulation"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bitmanip_reserved_encodings() {
+        // Reserved shamt values in the unary Zbb funct12 space (only
+        // 0..=2, 4, 5 are defined under funct6 = 0b011000, funct3 = 001).
+        check_rejects(enc_i(OPCODE_OP_IMM, 0x603, 1, 1, 2));
+        check_rejects(enc_i(OPCODE_OP_IMM, 0x606, 1, 1, 2));
+        check_rejects(enc_i(OPCODE_OP_IMM_32, 0x603, 1, 1, 2));
+        check_rejects(enc_i(OPCODE_OP_IMM_32, 0x604, 1, 1, 2)); // no sext.b W-form
+                                                                // orc.b / rev8 are single points in their funct6 space, not ranges.
+        check_rejects(enc_i(OPCODE_OP_IMM, 0x286, 1, 5, 2)); // orc.b low bits - 1
+        check_rejects(enc_i(OPCODE_OP_IMM, 0x6b9, 1, 5, 2)); // rev8 low bits + 1
+                                                             // zext.h requires rs2 = 0 (nonzero rs2 would be packw, unsupported).
+        check_rejects(enc_r(OPCODE_OP_32, 0x04, 1, 2, 4, 3));
+        // roriw is a 5-bit shamt; bit 25 set (shamt >= 32) is reserved.
+        check_rejects(enc_i_shamt6(OPCODE_OP_IMM_32, 0x18, 32, 1, 5, 2));
+        // No W-forms exist for min/max, single-bit ops, or logic-with-negate.
+        check_rejects(enc_r(OPCODE_OP_32, 0x05, 1, 2, 4, 3));
+        check_rejects(enc_r(OPCODE_OP_32, 0x24, 1, 2, 1, 3));
+        check_rejects(enc_r(OPCODE_OP_32, 0x20, 1, 2, 7, 3));
+    }
+
+    /// `is_bitmanip_instruction` must classify a word as bit-manipulation
+    /// exactly when dispatch lands on a B-ext processor method. Sweeps the
+    /// whole funct space of the four affected major opcodes.
+    #[test]
+    fn bitmanip_predicate_matches_dispatch() {
+        fn is_bitmanip_called(called: &Called) -> bool {
+            matches!(
+                called,
+                Called::AddUw(_)
+                    | Called::Sh1add(_)
+                    | Called::Sh2add(_)
+                    | Called::Sh3add(_)
+                    | Called::Sh1addUw(_)
+                    | Called::Sh2addUw(_)
+                    | Called::Sh3addUw(_)
+                    | Called::SlliUw(_)
+                    | Called::Andn(_)
+                    | Called::Orn(_)
+                    | Called::Xnor(_)
+                    | Called::Clz(_)
+                    | Called::Ctz(_)
+                    | Called::Cpop(_)
+                    | Called::Clzw(_)
+                    | Called::Ctzw(_)
+                    | Called::Cpopw(_)
+                    | Called::Min(_)
+                    | Called::Minu(_)
+                    | Called::Max(_)
+                    | Called::Maxu(_)
+                    | Called::SextB(_)
+                    | Called::SextH(_)
+                    | Called::ZextH(_)
+                    | Called::Rol(_)
+                    | Called::Ror(_)
+                    | Called::Rori(_)
+                    | Called::Rolw(_)
+                    | Called::Rorw(_)
+                    | Called::Roriw(_)
+                    | Called::OrcB(_)
+                    | Called::Rev8(_)
+                    | Called::Bclr(_)
+                    | Called::Bset(_)
+                    | Called::Binv(_)
+                    | Called::Bext(_)
+                    | Called::Bclri(_)
+                    | Called::Bseti(_)
+                    | Called::Binvi(_)
+                    | Called::Bexti(_)
+            )
+        }
+
+        let check = |bits: u32| {
+            let dispatched_bitmanip = process_instruction(&mut Recorder, bits)
+                .as_ref()
+                .is_some_and(is_bitmanip_called);
+            assert_eq!(
+                is_bitmanip_instruction(bits),
+                dispatched_bitmanip,
+                "predicate/dispatch mismatch for word {bits:#010x}"
+            );
+        };
+
+        // R-type space: all funct3 x funct7, with rs2 = 0 as well to cover the
+        // zext.h special case.
+        for opcode in [OPCODE_OP, OPCODE_OP_32] {
+            for funct3 in 0..8 {
+                for funct7 in 0..128 {
+                    for rs2 in [0, 3] {
+                        check(enc_r(opcode, funct7, rs2, 2, funct3, 1));
+                    }
+                }
+            }
+        }
+        // I-type space: all funct3 x full 12-bit immediate (covers every
+        // funct6/shamt split and the unary funct12 points).
+        for opcode in [OPCODE_OP_IMM, OPCODE_OP_IMM_32] {
+            for funct3 in 0..8 {
+                for imm12 in 0..4096 {
+                    check(enc_i(opcode, imm12, 2, funct3, 1));
+                }
+            }
+        }
+        // Other major opcodes are never bit-manipulation.
+        for opcode in [
+            OPCODE_LOAD,
+            OPCODE_STORE,
+            OPCODE_BRANCH,
+            OPCODE_JAL,
+            OPCODE_JALR,
+            OPCODE_LUI,
+            OPCODE_AUIPC,
+            OPCODE_MISC_MEM,
+        ] {
+            check(enc_i(opcode, 0, 2, 0, 1));
+        }
     }
 }

--- a/crates/toolchain/tests/src/lib.rs
+++ b/crates/toolchain/tests/src/lib.rs
@@ -63,8 +63,26 @@ pub fn build_example_program_at_path_with_features<S: AsRef<str>>(
     features: impl IntoIterator<Item = S> + Clone,
     init_config: &impl InitFileGenerator,
 ) -> Result<Elf> {
+    build_example_program_at_path_with_features_and_rustc_flags::<S, &str>(
+        manifest_dir,
+        example_name,
+        features,
+        [],
+        init_config,
+    )
+}
+
+pub fn build_example_program_at_path_with_features_and_rustc_flags<S: AsRef<str>, R: AsRef<str>>(
+    manifest_dir: PathBuf,
+    example_name: &str,
+    features: impl IntoIterator<Item = S> + Clone,
+    rustc_flags: impl IntoIterator<Item = R>,
+    init_config: &impl InitFileGenerator,
+) -> Result<Elf> {
     let pkg = get_package(&manifest_dir);
-    let guest_opts = GuestOptions::default().with_features(features.clone());
+    let guest_opts = GuestOptions::default()
+        .with_features(features.clone())
+        .with_rustc_flags(rustc_flags);
     let features = features
         .into_iter()
         .map(|x| x.as_ref().to_string())

--- a/crates/toolchain/tests/tests/rv64_bitmanip_transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/rv64_bitmanip_transpiler_tests.rs
@@ -1,0 +1,252 @@
+//! Transpiler tests for the RISC-V bit-manipulation (Zba/Zbb/Zbs) extension:
+//! word → OpenVM instruction mapping, and word ownership between the base
+//! RV64IM transpiler extensions and `Rv64BTranspilerExtension`.
+
+use openvm_circuit::{arch::VmExecutor, utils::air_test};
+use openvm_instructions::{
+    exe::VmExe, instruction::Instruction, program::Program, riscv::RV64_REGISTER_NUM_LIMBS,
+    LocalOpcode, SystemOpcode,
+};
+use openvm_riscv_circuit::{Rv64ImBConfig, Rv64ImBCpuBuilder};
+use openvm_riscv_transpiler::{
+    BitwiseInvOpcode, ByteUnaryOpcode, CountZerosOpcode, CountZerosWOpcode, CpopOpcode,
+    CpopWOpcode, MinMaxOpcode, RotateImmOpcode, RotateOpcode, RotateWImmOpcode, RotateWOpcode,
+    Rv64BTranspilerExtension, Rv64ITranspilerExtension, Rv64IoTranspilerExtension,
+    Rv64MTranspilerExtension, ShAddOpcode, SingleBitImmOpcode, SingleBitOpcode, SlliUwOpcode,
+};
+use openvm_stark_sdk::{openvm_stark_backend::p3_field::PrimeField32, p3_baby_bear::BabyBear};
+use openvm_transpiler::transpiler::Transpiler;
+
+type F = BabyBear;
+
+fn rv64im_transpiler() -> Transpiler<F> {
+    Transpiler::<F>::default()
+        .with_extension(Rv64ITranspilerExtension)
+        .with_extension(Rv64MTranspilerExtension)
+        .with_extension(Rv64IoTranspilerExtension)
+}
+
+fn rv64imb_transpiler() -> Transpiler<F> {
+    rv64im_transpiler().with_extension(Rv64BTranspilerExtension)
+}
+
+/// Expected operand layout of a transpiled bit-manipulation instruction.
+enum Operands {
+    /// Register-register: `c` = rs2 pointer, `e` = 1 (register address space).
+    Reg { rd: u32, rs1: u32, rs2: u32 },
+    /// Shift-immediate: `c` = shamt, `e` = 0 (immediate).
+    Shamt { rd: u32, rs1: u32, shamt: u32 },
+    /// Unary: `c` = 0, `e` = 0.
+    Unary { rd: u32, rs1: u32 },
+}
+
+/// Golden encodings generated with
+/// `llvm-mc -triple=riscv64 -mattr=+zba,+zbb,+zbs -show-encoding` (LLVM 22),
+/// i.e. the exact words the guest compiler emits.
+#[rustfmt::skip]
+fn golden_cases() -> Vec<(&'static str, u32, usize, Operands)> {
+    vec![
+        ("add.uw",    0x087302bb, ShAddOpcode::ADD_UW.global_opcode().as_usize(),        Operands::Reg { rd: 5, rs1: 6, rs2: 7 }),
+        ("sh1add",    0x20a4a433, ShAddOpcode::SH1ADD.global_opcode().as_usize(),        Operands::Reg { rd: 8, rs1: 9, rs2: 10 }),
+        ("sh2add",    0x20d645b3, ShAddOpcode::SH2ADD.global_opcode().as_usize(),        Operands::Reg { rd: 11, rs1: 12, rs2: 13 }),
+        ("sh3add",    0x2107e733, ShAddOpcode::SH3ADD.global_opcode().as_usize(),        Operands::Reg { rd: 14, rs1: 15, rs2: 16 }),
+        ("sh1add.uw", 0x213928bb, ShAddOpcode::SH1ADD_UW.global_opcode().as_usize(),     Operands::Reg { rd: 17, rs1: 18, rs2: 19 }),
+        ("sh2add.uw", 0x216aca3b, ShAddOpcode::SH2ADD_UW.global_opcode().as_usize(),     Operands::Reg { rd: 20, rs1: 21, rs2: 22 }),
+        ("sh3add.uw", 0x219c6bbb, ShAddOpcode::SH3ADD_UW.global_opcode().as_usize(),     Operands::Reg { rd: 23, rs1: 24, rs2: 25 }),
+        ("slli.uw",   0x0a5d9d1b, SlliUwOpcode::SLLI_UW.global_opcode().as_usize(),      Operands::Shamt { rd: 26, rs1: 27, shamt: 37 }),
+        ("andn",      0x407372b3, BitwiseInvOpcode::ANDN.global_opcode().as_usize(),     Operands::Reg { rd: 5, rs1: 6, rs2: 7 }),
+        ("orn",       0x40a4e433, BitwiseInvOpcode::ORN.global_opcode().as_usize(),      Operands::Reg { rd: 8, rs1: 9, rs2: 10 }),
+        ("xnor",      0x40d645b3, BitwiseInvOpcode::XNOR.global_opcode().as_usize(),     Operands::Reg { rd: 11, rs1: 12, rs2: 13 }),
+        ("clz",       0x60079713, CountZerosOpcode::CLZ.global_opcode().as_usize(),      Operands::Unary { rd: 14, rs1: 15 }),
+        ("ctz",       0x60189813, CountZerosOpcode::CTZ.global_opcode().as_usize(),      Operands::Unary { rd: 16, rs1: 17 }),
+        ("cpop",      0x60299913, CpopOpcode::CPOP.global_opcode().as_usize(),           Operands::Unary { rd: 18, rs1: 19 }),
+        ("clzw",      0x600a9a1b, CountZerosWOpcode::CLZW.global_opcode().as_usize(),    Operands::Unary { rd: 20, rs1: 21 }),
+        ("ctzw",      0x601b9b1b, CountZerosWOpcode::CTZW.global_opcode().as_usize(),    Operands::Unary { rd: 22, rs1: 23 }),
+        ("cpopw",     0x602c9c1b, CpopWOpcode::CPOPW.global_opcode().as_usize(),         Operands::Unary { rd: 24, rs1: 25 }),
+        ("min",       0x0a7342b3, MinMaxOpcode::MIN.global_opcode().as_usize(),          Operands::Reg { rd: 5, rs1: 6, rs2: 7 }),
+        ("minu",      0x0aa4d433, MinMaxOpcode::MINU.global_opcode().as_usize(),         Operands::Reg { rd: 8, rs1: 9, rs2: 10 }),
+        ("max",       0x0ad665b3, MinMaxOpcode::MAX.global_opcode().as_usize(),          Operands::Reg { rd: 11, rs1: 12, rs2: 13 }),
+        ("maxu",      0x0b07f733, MinMaxOpcode::MAXU.global_opcode().as_usize(),         Operands::Reg { rd: 14, rs1: 15, rs2: 16 }),
+        ("sext.b",    0x60491893, ByteUnaryOpcode::SEXT_B.global_opcode().as_usize(),    Operands::Unary { rd: 17, rs1: 18 }),
+        ("sext.h",    0x605a1993, ByteUnaryOpcode::SEXT_H.global_opcode().as_usize(),    Operands::Unary { rd: 19, rs1: 20 }),
+        ("zext.h",    0x080b4abb, ByteUnaryOpcode::ZEXT_H.global_opcode().as_usize(),    Operands::Unary { rd: 21, rs1: 22 }),
+        ("rol",       0x607312b3, RotateOpcode::ROL.global_opcode().as_usize(),          Operands::Reg { rd: 5, rs1: 6, rs2: 7 }),
+        ("ror",       0x60a4d433, RotateOpcode::ROR.global_opcode().as_usize(),          Operands::Reg { rd: 8, rs1: 9, rs2: 10 }),
+        ("rori",      0x62d65593, RotateImmOpcode::RORI.global_opcode().as_usize(),      Operands::Shamt { rd: 11, rs1: 12, shamt: 45 }),
+        ("rolw",      0x60f716bb, RotateWOpcode::ROLW.global_opcode().as_usize(),        Operands::Reg { rd: 13, rs1: 14, rs2: 15 }),
+        ("rorw",      0x6128d83b, RotateWOpcode::RORW.global_opcode().as_usize(),        Operands::Reg { rd: 16, rs1: 17, rs2: 18 }),
+        ("roriw",     0x615a599b, RotateWImmOpcode::RORIW.global_opcode().as_usize(),    Operands::Shamt { rd: 19, rs1: 20, shamt: 21 }),
+        ("orc.b",     0x287bdb13, ByteUnaryOpcode::ORC_B.global_opcode().as_usize(),     Operands::Unary { rd: 22, rs1: 23 }),
+        ("rev8",      0x6b8cdc13, ByteUnaryOpcode::REV8.global_opcode().as_usize(),      Operands::Unary { rd: 24, rs1: 25 }),
+        ("bclr",      0x487312b3, SingleBitOpcode::BCLR.global_opcode().as_usize(),      Operands::Reg { rd: 5, rs1: 6, rs2: 7 }),
+        ("bset",      0x28a49433, SingleBitOpcode::BSET.global_opcode().as_usize(),      Operands::Reg { rd: 8, rs1: 9, rs2: 10 }),
+        ("binv",      0x68d615b3, SingleBitOpcode::BINV.global_opcode().as_usize(),      Operands::Reg { rd: 11, rs1: 12, rs2: 13 }),
+        ("bext",      0x4907d733, SingleBitOpcode::BEXT.global_opcode().as_usize(),      Operands::Reg { rd: 14, rs1: 15, rs2: 16 }),
+        ("bclri",     0x4af91893, SingleBitImmOpcode::BCLRI.global_opcode().as_usize(),  Operands::Shamt { rd: 17, rs1: 18, shamt: 47 }),
+        ("bseti",     0x2b0a1993, SingleBitImmOpcode::BSETI.global_opcode().as_usize(),  Operands::Shamt { rd: 19, rs1: 20, shamt: 48 }),
+        ("binvi",     0x6b1b1a93, SingleBitImmOpcode::BINVI.global_opcode().as_usize(),  Operands::Shamt { rd: 21, rs1: 22, shamt: 49 }),
+        ("bexti",     0x4b2c5b93, SingleBitImmOpcode::BEXTI.global_opcode().as_usize(),  Operands::Shamt { rd: 23, rs1: 24, shamt: 50 }),
+    ]
+}
+
+#[test]
+fn transpiles_bitmanip_golden_words() {
+    let transpiler = rv64imb_transpiler();
+    for (name, word, expected_opcode, operands) in golden_cases() {
+        let program = transpiler
+            .transpile(&[word])
+            .unwrap_or_else(|e| panic!("{name}: transpilation failed: {e}"));
+        assert_eq!(program.len(), 1, "{name}: expected exactly one instruction");
+        let insn = program[0].as_ref().unwrap_or_else(|| panic!("{name}: gap"));
+
+        assert_eq!(
+            insn.opcode.as_usize(),
+            expected_opcode,
+            "{name}: wrong opcode"
+        );
+        let limbs = RV64_REGISTER_NUM_LIMBS as u32;
+        let (rd, rs1, c, e) = match operands {
+            Operands::Reg { rd, rs1, rs2 } => (rd, rs1, rs2 * limbs, 1),
+            Operands::Shamt { rd, rs1, shamt } => (rd, rs1, shamt, 0),
+            Operands::Unary { rd, rs1 } => (rd, rs1, 0, 0),
+        };
+        assert_eq!(insn.a.as_canonical_u32(), rd * limbs, "{name}: wrong a/rd");
+        assert_eq!(
+            insn.b.as_canonical_u32(),
+            rs1 * limbs,
+            "{name}: wrong b/rs1"
+        );
+        assert_eq!(insn.c.as_canonical_u32(), c, "{name}: wrong c operand");
+        assert_eq!(insn.d.as_canonical_u32(), 1, "{name}: wrong d operand");
+        assert_eq!(insn.e.as_canonical_u32(), e, "{name}: wrong e operand");
+    }
+}
+
+#[test]
+fn bitmanip_words_trap_without_b_extension() {
+    // Without `Rv64BTranspilerExtension`, the base RV64IM extensions must not
+    // claim bit-manipulation words (no misdecode into a base instruction);
+    // they become `unimp` (TERMINATE with exit code 2) like any other
+    // unsupported instruction.
+    let transpiler = rv64im_transpiler();
+    for (name, word, _, _) in golden_cases() {
+        let program = transpiler
+            .transpile(&[word])
+            .unwrap_or_else(|e| panic!("{name}: transpilation failed: {e}"));
+        let insn = program[0].as_ref().unwrap_or_else(|| panic!("{name}: gap"));
+        assert_eq!(
+            insn.opcode,
+            SystemOpcode::TERMINATE.global_opcode(),
+            "{name}: expected unimp without the B extension"
+        );
+        assert_eq!(insn.c.as_canonical_u32(), 2, "{name}: expected exit code 2");
+    }
+}
+
+#[test]
+fn base_words_unaffected_by_b_extension() {
+    // Base RV64IM words must transpile identically with and without the B
+    // extension registered (the ownership guard must not over-exclude).
+    let words = [
+        0x003100b3, // add x1, x2, x3
+        0x403100b3, // sub x1, x2, x3
+        0x0033a0b3, // slt x1, x7, x3
+        0x40335313, // srai x6, x6, 3
+        0x0023929b, // slliw x5, x7, 2
+        0x02310133, // mul x2, x2, x3
+    ];
+    let with_b = rv64imb_transpiler();
+    let without_b = rv64im_transpiler();
+    for word in words {
+        let a = with_b.transpile(&[word]).unwrap();
+        let b = without_b.transpile(&[word]).unwrap();
+        assert_eq!(a, b, "word {word:#010x} transpiles differently with B");
+        assert_ne!(
+            a[0].as_ref().unwrap().opcode,
+            SystemOpcode::TERMINATE.global_opcode(),
+            "word {word:#010x} unexpectedly unsupported"
+        );
+    }
+}
+
+#[test]
+fn bitmanip_rd_zero_transpiles_to_nop() {
+    // Writes to x0 are architectural nops; the B extension claims the word and
+    // emits the canonical nop (PHANTOM), exactly like the base extensions.
+    let transpiler = rv64imb_transpiler();
+    for (name, word, _, _) in golden_cases() {
+        let word_rd0 = word & !(0x1f << 7);
+        let program = transpiler
+            .transpile(&[word_rd0])
+            .unwrap_or_else(|e| panic!("{name} (rd=x0): transpilation failed: {e}"));
+        let insn = program[0]
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} (rd=x0): gap"));
+        assert_eq!(
+            insn.opcode,
+            SystemOpcode::PHANTOM.global_opcode(),
+            "{name} (rd=x0): expected nop"
+        );
+    }
+}
+
+#[test]
+fn mixed_base_and_bitmanip_program() {
+    // A program interleaving base and B words keeps 1:1 word→instruction
+    // alignment (PC mapping) and every word is claimed by exactly one
+    // extension (no AmbiguousNextInstruction).
+    let words = [
+        0x003100b3, // add x1, x2, x3
+        0x20a4a433, // sh1add x8, x9, x10
+        0x02310133, // mul x2, x2, x3
+        0x62d65593, // rori x11, x12, 45
+        0x60079713, // clz x14, x15
+        0x0033a0b3, // slt x1, x7, x3
+    ];
+    let program = rv64imb_transpiler().transpile(&words).unwrap();
+    assert_eq!(program.len(), words.len());
+    let expected = [
+        None, // base op, checked as "not terminate" below
+        Some(ShAddOpcode::SH1ADD.global_opcode()),
+        None,
+        Some(RotateImmOpcode::RORI.global_opcode()),
+        Some(CountZerosOpcode::CLZ.global_opcode()),
+        None,
+    ];
+    for (i, (insn, expected_opcode)) in program.iter().zip(expected).enumerate() {
+        let insn = insn.as_ref().unwrap();
+        if let Some(op) = expected_opcode {
+            assert_eq!(insn.opcode, op, "instruction {i}");
+        } else {
+            assert_ne!(
+                insn.opcode,
+                SystemOpcode::TERMINATE.global_opcode(),
+                "instruction {i} unexpectedly unsupported"
+            );
+        }
+    }
+}
+
+#[test]
+fn bitmanip_program_executes_and_proves_with_rv64imb_config() {
+    let words = golden_cases()
+        .into_iter()
+        .map(|(_, word, _, _)| word)
+        .collect::<Vec<_>>();
+    let mut instructions = rv64imb_transpiler().transpile(&words).unwrap();
+    instructions.push(Some(Instruction {
+        opcode: SystemOpcode::TERMINATE.global_opcode(),
+        ..Default::default()
+    }));
+    let exe = VmExe::new(Program::new_without_debug_infos_with_option(
+        &instructions,
+        0,
+    ));
+
+    let config = Rv64ImBConfig::default();
+    let executor = VmExecutor::new(config.clone()).unwrap();
+    let instance = executor.instance(&exe).unwrap();
+    instance.execute(vec![]).unwrap();
+
+    air_test(Rv64ImBCpuBuilder, config, exe);
+}

--- a/crates/toolchain/tests/tests/rv64_bitmanip_transpiler_tests.rs
+++ b/crates/toolchain/tests/tests/rv64_bitmanip_transpiler_tests.rs
@@ -7,7 +7,7 @@ use openvm_instructions::{
     exe::VmExe, instruction::Instruction, program::Program, riscv::RV64_REGISTER_NUM_LIMBS,
     LocalOpcode, SystemOpcode,
 };
-use openvm_riscv_circuit::{Rv64ImBConfig, Rv64ImBCpuBuilder};
+use openvm_riscv_circuit::{Rv64ImBBuilder, Rv64ImBConfig};
 use openvm_riscv_transpiler::{
     BitwiseInvOpcode, ByteUnaryOpcode, CountZerosOpcode, CountZerosWOpcode, CpopOpcode,
     CpopWOpcode, MinMaxOpcode, RotateImmOpcode, RotateOpcode, RotateWImmOpcode, RotateWOpcode,
@@ -248,5 +248,5 @@ fn bitmanip_program_executes_and_proves_with_rv64imb_config() {
     let instance = executor.instance(&exe).unwrap();
     instance.execute(vec![]).unwrap();
 
-    air_test(Rv64ImBCpuBuilder, config, exe);
+    air_test(Rv64ImBBuilder, config, exe);
 }

--- a/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
@@ -1,14 +1,16 @@
 #pragma once
 
 #include "primitives/constants.h"
+#include "primitives/histogram.cuh"
 #include "primitives/trace_access.h"
 
 using namespace riscv;
 
 constexpr size_t BITMANIP_NUM_LIMBS = BLOCK_FE_WIDTH;
 constexpr size_t BITMANIP_NUM_BITS = BITMANIP_NUM_LIMBS * U16_BITS;
-constexpr size_t BITMANIP_REG_OP_COUNT = 22;
-constexpr size_t BITMANIP_IMM_OP_COUNT = 18;
+constexpr size_t BITMANIP_SHADD_OP_COUNT = 7;
+constexpr size_t BITMANIP_REG_OP_COUNT = 15;
+constexpr size_t BITMANIP_IMM_OP_COUNT = 17;
 
 constexpr uint8_t SH1ADD = 0;
 constexpr uint8_t SH2ADD = 1;
@@ -51,15 +53,21 @@ constexpr uint8_t BSETI = 37;
 constexpr uint8_t BINVI = 38;
 constexpr uint8_t BEXTI = 39;
 
-__device__ __forceinline__ bool bitmanip_is_shadd(uint8_t op) {
-    return op == SH1ADD || op == SH2ADD || op == SH3ADD || op == ADD_UW || op == SH1ADD_UW ||
-           op == SH2ADD_UW || op == SH3ADD_UW;
+__device__ __forceinline__ int bitmanip_shadd_flag_pos(uint8_t op) {
+    constexpr uint8_t OPS[BITMANIP_SHADD_OP_COUNT] = {
+        SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW,
+    };
+    for (size_t i = 0; i < BITMANIP_SHADD_OP_COUNT; i++) {
+        if (OPS[i] == op) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
 }
 
 __device__ __forceinline__ int bitmanip_reg_flag_pos(uint8_t op) {
     constexpr uint8_t OPS[BITMANIP_REG_OP_COUNT] = {
-        SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW, ANDN, ORN, XNOR, ROL,
-        ROR, ROLW, RORW, OP_MIN, MINU, OP_MAX, MAXU, BCLR, BSET, BINV, BEXT,
+        ANDN, ORN, XNOR, ROL, ROR, ROLW, RORW, OP_MIN, MINU, OP_MAX, MAXU, BCLR, BSET, BINV, BEXT,
     };
     for (size_t i = 0; i < BITMANIP_REG_OP_COUNT; i++) {
         if (OPS[i] == op) {
@@ -71,8 +79,8 @@ __device__ __forceinline__ int bitmanip_reg_flag_pos(uint8_t op) {
 
 __device__ __forceinline__ int bitmanip_imm_flag_pos(uint8_t op) {
     constexpr uint8_t OPS[BITMANIP_IMM_OP_COUNT] = {
-        SLLI_UW, RORI, RORIW, CLZ, CTZ, CLZW, CTZW, CPOP, CPOPW, SEXT_B, SEXT_H, ZEXT_H,
-        ORC_B, REV8, BCLRI, BSETI, BINVI, BEXTI,
+        RORI, RORIW, CLZ, CTZ, CLZW, CTZW, CPOP, CPOPW, SEXT_B, SEXT_H, ZEXT_H, ORC_B,
+        REV8, BCLRI, BSETI, BINVI, BEXTI,
     };
     for (size_t i = 0; i < BITMANIP_IMM_OP_COUNT; i++) {
         if (OPS[i] == op) {
@@ -315,6 +323,180 @@ bitmanip_run_imm(uint8_t local_opcode, uint64_t rs1, uint32_t imm) {
     }
 }
 
+struct BitManipShAddCoreRecord {
+    uint16_t b[BITMANIP_NUM_LIMBS];
+    uint16_t c[BITMANIP_NUM_LIMBS];
+    uint8_t local_opcode;
+};
+
+static_assert(sizeof(BitManipShAddCoreRecord) == 18);
+
+template <typename T> struct BitManipShAddCoreCols {
+    T a[BITMANIP_NUM_LIMBS];
+    T b[BITMANIP_NUM_LIMBS];
+    T c[BITMANIP_NUM_LIMBS];
+    T opcode_flags[BITMANIP_SHADD_OP_COUNT];
+    T bit_shift_carry[BITMANIP_NUM_LIMBS];
+    T bit_shift_aux[BITMANIP_NUM_LIMBS];
+    T add_carry[BITMANIP_NUM_LIMBS + 1];
+};
+
+__device__ __forceinline__ void bitmanip_shadd_shift_uw(
+    uint8_t local_opcode,
+    uint32_t *shift,
+    bool *uw
+) {
+    *shift = 0;
+    *uw = false;
+    switch (local_opcode) {
+    case SH1ADD:
+        *shift = 1;
+        break;
+    case SH2ADD:
+        *shift = 2;
+        break;
+    case SH3ADD:
+        *shift = 3;
+        break;
+    case ADD_UW:
+        *uw = true;
+        break;
+    case SH1ADD_UW:
+        *shift = 1;
+        *uw = true;
+        break;
+    case SH2ADD_UW:
+        *shift = 2;
+        *uw = true;
+        break;
+    case SH3ADD_UW:
+        *shift = 3;
+        *uw = true;
+        break;
+    }
+}
+
+struct BitManipShAddCore {
+    VariableRangeChecker range_checker;
+
+    template <typename T> using Cols = BitManipShAddCoreCols<T>;
+
+    __device__ BitManipShAddCore(VariableRangeChecker rc) : range_checker(rc) {}
+
+    __device__ void fill_trace_row(RowSlice row, BitManipShAddCoreRecord record) {
+        uint64_t b_u64 = bitmanip_limbs_to_u64(record.b);
+        uint64_t c_u64 = bitmanip_limbs_to_u64(record.c);
+        uint64_t a_u64 = bitmanip_run_reg(record.local_opcode, b_u64, c_u64);
+
+        uint16_t a[BITMANIP_NUM_LIMBS];
+        uint8_t opcode_flags[BITMANIP_SHADD_OP_COUNT] = {0};
+        uint16_t bit_shift_carry[BITMANIP_NUM_LIMBS] = {0};
+        uint16_t bit_shift_aux[BITMANIP_NUM_LIMBS] = {0};
+        uint8_t add_carry[BITMANIP_NUM_LIMBS + 1] = {0};
+
+        bitmanip_u64_to_limbs(a_u64, a);
+
+        int flag_pos = bitmanip_shadd_flag_pos(record.local_opcode);
+        if (flag_pos >= 0) {
+            opcode_flags[flag_pos] = 1;
+        }
+
+        uint32_t shift;
+        bool uw;
+        bitmanip_shadd_shift_uw(record.local_opcode, &shift, &uw);
+        uint32_t carry_mask = (1u << shift) - 1;
+        uint32_t aux_mask = (1u << (U16_BITS - shift)) - 1;
+        for (size_t limb = 0; limb < BITMANIP_NUM_LIMBS; limb++) {
+            uint32_t source = (uw && limb >= 2) ? 0 : record.b[limb];
+            bit_shift_aux[limb] = source & aux_mask;
+            bit_shift_carry[limb] = (source >> (U16_BITS - shift)) & carry_mask;
+            range_checker.add_count(bit_shift_carry[limb], shift);
+            range_checker.add_count(bit_shift_aux[limb], U16_BITS - shift);
+        }
+
+        uint64_t shifted =
+            uw ? (static_cast<uint64_t>(static_cast<uint32_t>(b_u64)) << shift)
+               : (b_u64 << shift);
+        uint8_t carry = 0;
+        for (size_t bit = 0; bit < BITMANIP_NUM_BITS; bit++) {
+            if (bit % U16_BITS == 0) {
+                add_carry[bit / U16_BITS] = carry;
+            }
+            uint8_t total = static_cast<uint8_t>(
+                ((shifted >> bit) & 1ull) + ((c_u64 >> bit) & 1ull) + carry
+            );
+            carry = total >> 1;
+        }
+        add_carry[BITMANIP_NUM_LIMBS] = carry;
+
+        COL_WRITE_ARRAY(row, Cols, a, a);
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+        COL_WRITE_ARRAY(row, Cols, c, record.c);
+        COL_WRITE_ARRAY(row, Cols, opcode_flags, opcode_flags);
+        COL_WRITE_ARRAY(row, Cols, bit_shift_carry, bit_shift_carry);
+        COL_WRITE_ARRAY(row, Cols, bit_shift_aux, bit_shift_aux);
+        COL_WRITE_ARRAY(row, Cols, add_carry, add_carry);
+    }
+};
+
+struct BitManipSlliUwCoreRecord {
+    uint16_t b[BITMANIP_NUM_LIMBS];
+    uint8_t imm;
+};
+
+static_assert(sizeof(BitManipSlliUwCoreRecord) == 10);
+
+template <typename T> struct BitManipSlliUwCoreCols {
+    T a[BITMANIP_NUM_LIMBS];
+    T b[BITMANIP_NUM_LIMBS];
+    T bit_shift_marker[U16_BITS];
+    T limb_shift_marker[BITMANIP_NUM_LIMBS];
+    T bit_shift_carry[BITMANIP_NUM_LIMBS];
+    T bit_shift_aux[BITMANIP_NUM_LIMBS];
+};
+
+struct BitManipSlliUwCore {
+    VariableRangeChecker range_checker;
+
+    template <typename T> using Cols = BitManipSlliUwCoreCols<T>;
+
+    __device__ BitManipSlliUwCore(VariableRangeChecker rc) : range_checker(rc) {}
+
+    __device__ void fill_trace_row(RowSlice row, BitManipSlliUwCoreRecord record) {
+        uint64_t b_u64 = bitmanip_limbs_to_u64(record.b);
+        uint64_t a_u64 = bitmanip_run_imm(SLLI_UW, b_u64, record.imm);
+        uint32_t bit_shift = record.imm % U16_BITS;
+        uint32_t limb_shift = record.imm / U16_BITS;
+
+        uint16_t a[BITMANIP_NUM_LIMBS];
+        uint8_t bit_shift_marker[U16_BITS] = {0};
+        uint8_t limb_shift_marker[BITMANIP_NUM_LIMBS] = {0};
+        uint16_t bit_shift_carry[BITMANIP_NUM_LIMBS] = {0};
+        uint16_t bit_shift_aux[BITMANIP_NUM_LIMBS] = {0};
+
+        bitmanip_u64_to_limbs(a_u64, a);
+        bit_shift_marker[bit_shift] = 1;
+        limb_shift_marker[limb_shift] = 1;
+
+        uint32_t carry_mask = (1u << bit_shift) - 1;
+        uint32_t aux_mask = (1u << (U16_BITS - bit_shift)) - 1;
+        for (size_t limb = 0; limb < BITMANIP_NUM_LIMBS; limb++) {
+            uint32_t source = limb >= 2 ? 0 : record.b[limb];
+            bit_shift_aux[limb] = source & aux_mask;
+            bit_shift_carry[limb] = (source >> (U16_BITS - bit_shift)) & carry_mask;
+            range_checker.add_count(bit_shift_carry[limb], bit_shift);
+            range_checker.add_count(bit_shift_aux[limb], U16_BITS - bit_shift);
+        }
+
+        COL_WRITE_ARRAY(row, Cols, a, a);
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+        COL_WRITE_ARRAY(row, Cols, bit_shift_marker, bit_shift_marker);
+        COL_WRITE_ARRAY(row, Cols, limb_shift_marker, limb_shift_marker);
+        COL_WRITE_ARRAY(row, Cols, bit_shift_carry, bit_shift_carry);
+        COL_WRITE_ARRAY(row, Cols, bit_shift_aux, bit_shift_aux);
+    }
+};
+
 struct BitManipRegCoreRecord {
     uint16_t b[BITMANIP_NUM_LIMBS];
     uint16_t c[BITMANIP_NUM_LIMBS];
@@ -331,7 +513,6 @@ template <typename T> struct BitManipRegCoreCols {
     T b_bits[BITMANIP_NUM_BITS];
     T c_bits[BITMANIP_NUM_BITS];
     T opcode_flags[BITMANIP_REG_OP_COUNT];
-    T add_carry[BITMANIP_NUM_BITS + 1];
     T index_marker[BITMANIP_NUM_BITS];
     T minmax_lt;
     T minmax_diff_marker[BITMANIP_NUM_BITS];
@@ -350,7 +531,6 @@ struct BitManipRegCore {
         uint8_t b_bits[BITMANIP_NUM_BITS];
         uint8_t c_bits[BITMANIP_NUM_BITS];
         uint8_t opcode_flags[BITMANIP_REG_OP_COUNT] = {0};
-        uint8_t add_carry[BITMANIP_NUM_BITS + 1] = {0};
         uint8_t index_marker[BITMANIP_NUM_BITS] = {0};
         uint8_t minmax_diff_marker[BITMANIP_NUM_BITS] = {0};
         uint8_t minmax_lt = 0;
@@ -363,47 +543,6 @@ struct BitManipRegCore {
         int flag_pos = bitmanip_reg_flag_pos(record.local_opcode);
         if (flag_pos >= 0) {
             opcode_flags[flag_pos] = 1;
-        }
-
-        if (bitmanip_is_shadd(record.local_opcode)) {
-            uint32_t shift = 0;
-            bool uw = false;
-            switch (record.local_opcode) {
-            case SH1ADD:
-                shift = 1;
-                break;
-            case SH2ADD:
-                shift = 2;
-                break;
-            case SH3ADD:
-                shift = 3;
-                break;
-            case ADD_UW:
-                uw = true;
-                break;
-            case SH1ADD_UW:
-                shift = 1;
-                uw = true;
-                break;
-            case SH2ADD_UW:
-                shift = 2;
-                uw = true;
-                break;
-            case SH3ADD_UW:
-                shift = 3;
-                uw = true;
-                break;
-            }
-            uint64_t shifted =
-                uw ? (static_cast<uint64_t>(static_cast<uint32_t>(b_u64)) << shift)
-                   : (b_u64 << shift);
-            uint8_t carry = 0;
-            add_carry[0] = 0;
-            for (size_t i = 0; i < BITMANIP_NUM_BITS; i++) {
-                uint8_t total = static_cast<uint8_t>(((shifted >> i) & 1ull) + ((c_u64 >> i) & 1ull) + carry);
-                carry = total >> 1;
-                add_carry[i + 1] = carry;
-            }
         }
 
         if (record.local_opcode == ROL || record.local_opcode == ROR || record.local_opcode == BCLR ||
@@ -432,7 +571,6 @@ struct BitManipRegCore {
         COL_WRITE_ARRAY(row, Cols, b_bits, b_bits);
         COL_WRITE_ARRAY(row, Cols, c_bits, c_bits);
         COL_WRITE_ARRAY(row, Cols, opcode_flags, opcode_flags);
-        COL_WRITE_ARRAY(row, Cols, add_carry, add_carry);
         COL_WRITE_ARRAY(row, Cols, index_marker, index_marker);
         COL_WRITE_VALUE(row, Cols, minmax_lt, minmax_lt);
         COL_WRITE_ARRAY(row, Cols, minmax_diff_marker, minmax_diff_marker);
@@ -487,10 +625,9 @@ struct BitManipImmCore {
             opcode_flags[flag_pos] = 1;
         }
 
-        if (record.local_opcode == SLLI_UW || record.local_opcode == RORI ||
-            record.local_opcode == RORIW || record.local_opcode == BCLRI ||
-            record.local_opcode == BSETI || record.local_opcode == BINVI ||
-            record.local_opcode == BEXTI) {
+        if (record.local_opcode == RORI || record.local_opcode == RORIW ||
+            record.local_opcode == BCLRI || record.local_opcode == BSETI ||
+            record.local_opcode == BINVI || record.local_opcode == BEXTI) {
             index_marker[record.imm] = 1;
         }
 

--- a/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
@@ -3,6 +3,7 @@
 #include "primitives/constants.h"
 #include "primitives/histogram.cuh"
 #include "primitives/trace_access.h"
+#include "riscv/cores/less_than.cuh"
 
 using namespace riscv;
 
@@ -494,6 +495,159 @@ struct BitManipSlliUwCore {
         COL_WRITE_ARRAY(row, Cols, limb_shift_marker, limb_shift_marker);
         COL_WRITE_ARRAY(row, Cols, bit_shift_carry, bit_shift_carry);
         COL_WRITE_ARRAY(row, Cols, bit_shift_aux, bit_shift_aux);
+    }
+};
+
+struct BitManipBitwiseInvCoreRecord {
+    uint8_t b[RV64_REGISTER_NUM_LIMBS];
+    uint8_t c[RV64_REGISTER_NUM_LIMBS];
+    uint8_t local_opcode;
+};
+
+static_assert(sizeof(BitManipBitwiseInvCoreRecord) == 17);
+
+template <typename T> struct BitManipBitwiseInvCoreCols {
+    T a[RV64_REGISTER_NUM_LIMBS];
+    T b[RV64_REGISTER_NUM_LIMBS];
+    T c[RV64_REGISTER_NUM_LIMBS];
+    T opcode_andn_flag;
+    T opcode_orn_flag;
+    T opcode_xnor_flag;
+};
+
+struct BitManipBitwiseInvCore {
+    BitwiseOperationLookup bitwise_lookup;
+
+    template <typename T> using Cols = BitManipBitwiseInvCoreCols<T>;
+
+    __device__ BitManipBitwiseInvCore(BitwiseOperationLookup lookup) : bitwise_lookup(lookup) {}
+
+    __device__ void fill_trace_row(RowSlice row, BitManipBitwiseInvCoreRecord record) {
+        uint8_t a[RV64_REGISTER_NUM_LIMBS];
+
+#pragma unroll
+        for (size_t i = 0; i < RV64_REGISTER_NUM_LIMBS; i++) {
+            switch (record.local_opcode) {
+            case ANDN:
+                a[i] = record.b[i] & ~record.c[i];
+                break;
+            case ORN:
+                a[i] = record.b[i] | ~record.c[i];
+                break;
+            case XNOR:
+                a[i] = ~(record.b[i] ^ record.c[i]);
+                break;
+            default:
+                a[i] = 0;
+            }
+            // The second lookup input is ~c for ANDN/ORN and c for XNOR,
+            // matching the AIR's send_xor operands.
+            if (record.local_opcode == XNOR) {
+                bitwise_lookup.add_xor(record.b[i], record.c[i]);
+            } else {
+                bitwise_lookup.add_xor(record.b[i], 0xff - record.c[i]);
+            }
+        }
+
+        COL_WRITE_ARRAY(row, Cols, a, a);
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+        COL_WRITE_ARRAY(row, Cols, c, record.c);
+        COL_WRITE_VALUE(row, Cols, opcode_andn_flag, record.local_opcode == ANDN);
+        COL_WRITE_VALUE(row, Cols, opcode_orn_flag, record.local_opcode == ORN);
+        COL_WRITE_VALUE(row, Cols, opcode_xnor_flag, record.local_opcode == XNOR);
+    }
+};
+
+struct BitManipMinMaxCoreRecord {
+    uint16_t b[BITMANIP_NUM_LIMBS];
+    uint16_t c[BITMANIP_NUM_LIMBS];
+    uint8_t local_opcode;
+};
+
+static_assert(sizeof(BitManipMinMaxCoreRecord) == 18);
+
+template <typename T> struct BitManipMinMaxCoreCols {
+    T b[BITMANIP_NUM_LIMBS];
+    T c[BITMANIP_NUM_LIMBS];
+    T cmp_result;
+    T pick_b;
+    T opcode_min_flag;
+    T opcode_minu_flag;
+    T opcode_max_flag;
+    T opcode_maxu_flag;
+    T b_msb_f;
+    T c_msb_f;
+    T diff_marker[BITMANIP_NUM_LIMBS];
+    T diff_val;
+};
+
+struct BitManipMinMaxCore {
+    VariableRangeChecker range_checker;
+
+    template <typename T> using Cols = BitManipMinMaxCoreCols<T>;
+
+    __device__ BitManipMinMaxCore(VariableRangeChecker rc) : range_checker(rc) {}
+
+    __device__ void fill_trace_row(RowSlice row, BitManipMinMaxCoreRecord record) {
+        bool is_signed = record.local_opcode == OP_MIN || record.local_opcode == OP_MAX;
+        bool is_min = record.local_opcode == OP_MIN || record.local_opcode == MINU;
+        LessThanResult result =
+            run_less_than<BITMANIP_NUM_LIMBS, U16_BITS>(is_signed, record.b, record.c);
+        bool cmp_result = result.cmp_result;
+        size_t diff_idx = result.diff_idx;
+        bool b_sign = result.x_sign;
+        bool c_sign = result.y_sign;
+
+        uint32_t b_raw_msb = record.b[BITMANIP_NUM_LIMBS - 1];
+        uint32_t c_raw_msb = record.c[BITMANIP_NUM_LIMBS - 1];
+
+        uint32_t b_msb_f = b_sign ? (Fp::P - ((1u << U16_BITS) - b_raw_msb)) : b_raw_msb;
+        uint32_t c_msb_f = c_sign ? (Fp::P - ((1u << U16_BITS) - c_raw_msb)) : c_raw_msb;
+
+        // Shift signed MSBs into the same [0, 2^U16_BITS) range as unsigned MSBs.
+        uint32_t b_msb_range = b_sign
+                                   ? (b_raw_msb - (1u << (U16_BITS - 1)))
+                                   : (b_raw_msb + ((is_signed ? 1u : 0u) << (U16_BITS - 1)));
+        uint32_t c_msb_range = c_sign
+                                   ? (c_raw_msb - (1u << (U16_BITS - 1)))
+                                   : (c_raw_msb + ((is_signed ? 1u : 0u) << (U16_BITS - 1)));
+
+        uint32_t diff_val = 0;
+        if (diff_idx == BITMANIP_NUM_LIMBS) {
+            diff_val = 0;
+        } else if (diff_idx == (BITMANIP_NUM_LIMBS - 1) && is_signed) {
+            Fp fp_diff = cmp_result ? (Fp(c_msb_f) - Fp(b_msb_f)) : (Fp(b_msb_f) - Fp(c_msb_f));
+            diff_val = fp_diff.asUInt32();
+        } else if (cmp_result) {
+            diff_val = uint32_t(record.c[diff_idx] - record.b[diff_idx]);
+        } else {
+            diff_val = uint32_t(record.b[diff_idx] - record.c[diff_idx]);
+        }
+
+        range_checker.add_count(b_msb_range, U16_BITS);
+        range_checker.add_count(c_msb_range, U16_BITS);
+
+        uint16_t diff_marker[BITMANIP_NUM_LIMBS] = {0};
+        if (diff_idx != BITMANIP_NUM_LIMBS) {
+            // Range-check diff_val - 1 to prove the first differing limb is non-zero.
+            range_checker.add_count(diff_val - 1, U16_BITS);
+            diff_marker[diff_idx] = 1;
+        }
+
+        bool pick_b = is_min ? cmp_result : !cmp_result;
+
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+        COL_WRITE_ARRAY(row, Cols, c, record.c);
+        COL_WRITE_VALUE(row, Cols, cmp_result, cmp_result);
+        COL_WRITE_VALUE(row, Cols, pick_b, pick_b);
+        COL_WRITE_VALUE(row, Cols, opcode_min_flag, record.local_opcode == OP_MIN);
+        COL_WRITE_VALUE(row, Cols, opcode_minu_flag, record.local_opcode == MINU);
+        COL_WRITE_VALUE(row, Cols, opcode_max_flag, record.local_opcode == OP_MAX);
+        COL_WRITE_VALUE(row, Cols, opcode_maxu_flag, record.local_opcode == MAXU);
+        COL_WRITE_VALUE(row, Cols, b_msb_f, b_msb_f);
+        COL_WRITE_VALUE(row, Cols, c_msb_f, c_msb_f);
+        COL_WRITE_ARRAY(row, Cols, diff_marker, diff_marker);
+        COL_WRITE_VALUE(row, Cols, diff_val, diff_val);
     }
 };
 

--- a/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
@@ -1,0 +1,525 @@
+#pragma once
+
+#include "primitives/constants.h"
+#include "primitives/trace_access.h"
+
+using namespace riscv;
+
+constexpr size_t BITMANIP_NUM_LIMBS = BLOCK_FE_WIDTH;
+constexpr size_t BITMANIP_NUM_BITS = BITMANIP_NUM_LIMBS * U16_BITS;
+constexpr size_t BITMANIP_REG_OP_COUNT = 22;
+constexpr size_t BITMANIP_IMM_OP_COUNT = 18;
+
+constexpr uint8_t SH1ADD = 0;
+constexpr uint8_t SH2ADD = 1;
+constexpr uint8_t SH3ADD = 2;
+constexpr uint8_t ADD_UW = 3;
+constexpr uint8_t SH1ADD_UW = 4;
+constexpr uint8_t SH2ADD_UW = 5;
+constexpr uint8_t SH3ADD_UW = 6;
+constexpr uint8_t SLLI_UW = 7;
+constexpr uint8_t ANDN = 8;
+constexpr uint8_t ORN = 9;
+constexpr uint8_t XNOR = 10;
+constexpr uint8_t ROL = 11;
+constexpr uint8_t ROR = 12;
+constexpr uint8_t RORI = 13;
+constexpr uint8_t ROLW = 14;
+constexpr uint8_t RORW = 15;
+constexpr uint8_t RORIW = 16;
+constexpr uint8_t CLZ = 17;
+constexpr uint8_t CTZ = 18;
+constexpr uint8_t CLZW = 19;
+constexpr uint8_t CTZW = 20;
+constexpr uint8_t CPOP = 21;
+constexpr uint8_t CPOPW = 22;
+constexpr uint8_t OP_MIN = 23;
+constexpr uint8_t MINU = 24;
+constexpr uint8_t OP_MAX = 25;
+constexpr uint8_t MAXU = 26;
+constexpr uint8_t SEXT_B = 27;
+constexpr uint8_t SEXT_H = 28;
+constexpr uint8_t ZEXT_H = 29;
+constexpr uint8_t ORC_B = 30;
+constexpr uint8_t REV8 = 31;
+constexpr uint8_t BCLR = 32;
+constexpr uint8_t BSET = 33;
+constexpr uint8_t BINV = 34;
+constexpr uint8_t BEXT = 35;
+constexpr uint8_t BCLRI = 36;
+constexpr uint8_t BSETI = 37;
+constexpr uint8_t BINVI = 38;
+constexpr uint8_t BEXTI = 39;
+
+__device__ __forceinline__ bool bitmanip_is_shadd(uint8_t op) {
+    return op == SH1ADD || op == SH2ADD || op == SH3ADD || op == ADD_UW || op == SH1ADD_UW ||
+           op == SH2ADD_UW || op == SH3ADD_UW;
+}
+
+__device__ __forceinline__ int bitmanip_reg_flag_pos(uint8_t op) {
+    constexpr uint8_t OPS[BITMANIP_REG_OP_COUNT] = {
+        SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW, ANDN, ORN, XNOR, ROL,
+        ROR, ROLW, RORW, OP_MIN, MINU, OP_MAX, MAXU, BCLR, BSET, BINV, BEXT,
+    };
+    for (size_t i = 0; i < BITMANIP_REG_OP_COUNT; i++) {
+        if (OPS[i] == op) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+__device__ __forceinline__ int bitmanip_imm_flag_pos(uint8_t op) {
+    constexpr uint8_t OPS[BITMANIP_IMM_OP_COUNT] = {
+        SLLI_UW, RORI, RORIW, CLZ, CTZ, CLZW, CTZW, CPOP, CPOPW, SEXT_B, SEXT_H, ZEXT_H,
+        ORC_B, REV8, BCLRI, BSETI, BINVI, BEXTI,
+    };
+    for (size_t i = 0; i < BITMANIP_IMM_OP_COUNT; i++) {
+        if (OPS[i] == op) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+__device__ __forceinline__ uint64_t bitmanip_limbs_to_u64(const uint16_t limbs[BITMANIP_NUM_LIMBS]) {
+    uint64_t value = 0;
+    for (size_t i = 0; i < BITMANIP_NUM_LIMBS; i++) {
+        value |= static_cast<uint64_t>(limbs[i]) << (U16_BITS * i);
+    }
+    return value;
+}
+
+__device__ __forceinline__ void
+bitmanip_u64_to_limbs(uint64_t value, uint16_t limbs[BITMANIP_NUM_LIMBS]) {
+    for (size_t i = 0; i < BITMANIP_NUM_LIMBS; i++) {
+        limbs[i] = static_cast<uint16_t>((value >> (U16_BITS * i)) & 0xffffull);
+    }
+}
+
+__device__ __forceinline__ void bitmanip_bits_u64(uint64_t value, uint8_t bits[BITMANIP_NUM_BITS]) {
+    for (size_t i = 0; i < BITMANIP_NUM_BITS; i++) {
+        bits[i] = static_cast<uint8_t>((value >> i) & 1ull);
+    }
+}
+
+__device__ __forceinline__ uint64_t bitmanip_rol64(uint64_t value, uint32_t shamt) {
+    shamt &= 63u;
+    return shamt == 0 ? value : ((value << shamt) | (value >> (64u - shamt)));
+}
+
+__device__ __forceinline__ uint64_t bitmanip_ror64(uint64_t value, uint32_t shamt) {
+    shamt &= 63u;
+    return shamt == 0 ? value : ((value >> shamt) | (value << (64u - shamt)));
+}
+
+__device__ __forceinline__ uint32_t bitmanip_rol32(uint32_t value, uint32_t shamt) {
+    shamt &= 31u;
+    return shamt == 0 ? value : ((value << shamt) | (value >> (32u - shamt)));
+}
+
+__device__ __forceinline__ uint32_t bitmanip_ror32(uint32_t value, uint32_t shamt) {
+    shamt &= 31u;
+    return shamt == 0 ? value : ((value >> shamt) | (value << (32u - shamt)));
+}
+
+__device__ __forceinline__ uint64_t bitmanip_sext32(uint32_t value) {
+    return static_cast<uint64_t>(static_cast<int64_t>(static_cast<int32_t>(value)));
+}
+
+__device__ __forceinline__ uint64_t bitmanip_sext16(uint16_t value) {
+    return static_cast<uint64_t>(static_cast<int64_t>(static_cast<int16_t>(value)));
+}
+
+__device__ __forceinline__ uint64_t bitmanip_sext8(uint8_t value) {
+    return static_cast<uint64_t>(static_cast<int64_t>(static_cast<int8_t>(value)));
+}
+
+__device__ __forceinline__ bool bitmanip_signed_lt(uint64_t lhs, uint64_t rhs) {
+    return (lhs ^ (1ull << 63)) < (rhs ^ (1ull << 63));
+}
+
+__device__ __forceinline__ uint32_t bitmanip_clz64(uint64_t value) {
+    if (value == 0) {
+        return 64;
+    }
+    uint32_t count = 0;
+    for (int i = 63; i >= 0 && ((value >> i) & 1ull) == 0; i--) {
+        count++;
+    }
+    return count;
+}
+
+__device__ __forceinline__ uint32_t bitmanip_ctz64(uint64_t value) {
+    if (value == 0) {
+        return 64;
+    }
+    uint32_t count = 0;
+    for (size_t i = 0; i < 64 && ((value >> i) & 1ull) == 0; i++) {
+        count++;
+    }
+    return count;
+}
+
+__device__ __forceinline__ uint32_t bitmanip_clz32(uint32_t value) {
+    if (value == 0) {
+        return 32;
+    }
+    uint32_t count = 0;
+    for (int i = 31; i >= 0 && ((value >> i) & 1u) == 0; i--) {
+        count++;
+    }
+    return count;
+}
+
+__device__ __forceinline__ uint32_t bitmanip_ctz32(uint32_t value) {
+    if (value == 0) {
+        return 32;
+    }
+    uint32_t count = 0;
+    for (size_t i = 0; i < 32 && ((value >> i) & 1u) == 0; i++) {
+        count++;
+    }
+    return count;
+}
+
+__device__ __forceinline__ uint32_t bitmanip_cpop64(uint64_t value) {
+    uint32_t count = 0;
+    for (size_t i = 0; i < 64; i++) {
+        count += static_cast<uint32_t>((value >> i) & 1ull);
+    }
+    return count;
+}
+
+__device__ __forceinline__ uint32_t bitmanip_cpop32(uint32_t value) {
+    uint32_t count = 0;
+    for (size_t i = 0; i < 32; i++) {
+        count += (value >> i) & 1u;
+    }
+    return count;
+}
+
+__device__ __forceinline__ uint64_t bitmanip_orc_b(uint64_t value) {
+    uint64_t out = 0;
+    for (size_t byte = 0; byte < 8; byte++) {
+        if (((value >> (byte * 8)) & 0xffull) != 0) {
+            out |= 0xffull << (byte * 8);
+        }
+    }
+    return out;
+}
+
+__device__ __forceinline__ uint64_t bitmanip_rev8(uint64_t value) {
+    uint64_t out = 0;
+    for (size_t byte = 0; byte < 8; byte++) {
+        out |= ((value >> (byte * 8)) & 0xffull) << ((7 - byte) * 8);
+    }
+    return out;
+}
+
+__device__ __forceinline__ uint64_t
+bitmanip_run_reg(uint8_t local_opcode, uint64_t rs1, uint64_t rs2) {
+    uint32_t shamt64 = static_cast<uint32_t>(rs2 & 63ull);
+    uint32_t shamt32 = static_cast<uint32_t>(rs2 & 31ull);
+    switch (local_opcode) {
+    case SH1ADD:
+        return (rs1 << 1) + rs2;
+    case SH2ADD:
+        return (rs1 << 2) + rs2;
+    case SH3ADD:
+        return (rs1 << 3) + rs2;
+    case ADD_UW:
+        return static_cast<uint64_t>(static_cast<uint32_t>(rs1)) + rs2;
+    case SH1ADD_UW:
+        return (static_cast<uint64_t>(static_cast<uint32_t>(rs1)) << 1) + rs2;
+    case SH2ADD_UW:
+        return (static_cast<uint64_t>(static_cast<uint32_t>(rs1)) << 2) + rs2;
+    case SH3ADD_UW:
+        return (static_cast<uint64_t>(static_cast<uint32_t>(rs1)) << 3) + rs2;
+    case ANDN:
+        return rs1 & ~rs2;
+    case ORN:
+        return rs1 | ~rs2;
+    case XNOR:
+        return ~(rs1 ^ rs2);
+    case ROL:
+        return bitmanip_rol64(rs1, shamt64);
+    case ROR:
+        return bitmanip_ror64(rs1, shamt64);
+    case ROLW:
+        return bitmanip_sext32(bitmanip_rol32(static_cast<uint32_t>(rs1), shamt32));
+    case RORW:
+        return bitmanip_sext32(bitmanip_ror32(static_cast<uint32_t>(rs1), shamt32));
+    case OP_MIN:
+        return bitmanip_signed_lt(rs1, rs2) ? rs1 : rs2;
+    case MINU:
+        return rs1 < rs2 ? rs1 : rs2;
+    case OP_MAX:
+        return bitmanip_signed_lt(rs1, rs2) ? rs2 : rs1;
+    case MAXU:
+        return rs1 < rs2 ? rs2 : rs1;
+    case BCLR:
+        return rs1 & ~(1ull << shamt64);
+    case BSET:
+        return rs1 | (1ull << shamt64);
+    case BINV:
+        return rs1 ^ (1ull << shamt64);
+    case BEXT:
+        return (rs1 >> shamt64) & 1ull;
+    default:
+        return 0;
+    }
+}
+
+__device__ __forceinline__ uint64_t
+bitmanip_run_imm(uint8_t local_opcode, uint64_t rs1, uint32_t imm) {
+    switch (local_opcode) {
+    case SLLI_UW:
+        return static_cast<uint64_t>(static_cast<uint32_t>(rs1)) << imm;
+    case RORI:
+        return bitmanip_ror64(rs1, imm);
+    case RORIW:
+        return bitmanip_sext32(bitmanip_ror32(static_cast<uint32_t>(rs1), imm));
+    case CLZ:
+        return bitmanip_clz64(rs1);
+    case CTZ:
+        return bitmanip_ctz64(rs1);
+    case CLZW:
+        return bitmanip_clz32(static_cast<uint32_t>(rs1));
+    case CTZW:
+        return bitmanip_ctz32(static_cast<uint32_t>(rs1));
+    case CPOP:
+        return bitmanip_cpop64(rs1);
+    case CPOPW:
+        return bitmanip_cpop32(static_cast<uint32_t>(rs1));
+    case SEXT_B:
+        return bitmanip_sext8(static_cast<uint8_t>(rs1));
+    case SEXT_H:
+        return bitmanip_sext16(static_cast<uint16_t>(rs1));
+    case ZEXT_H:
+        return static_cast<uint64_t>(static_cast<uint16_t>(rs1));
+    case ORC_B:
+        return bitmanip_orc_b(rs1);
+    case REV8:
+        return bitmanip_rev8(rs1);
+    case BCLRI:
+        return rs1 & ~(1ull << imm);
+    case BSETI:
+        return rs1 | (1ull << imm);
+    case BINVI:
+        return rs1 ^ (1ull << imm);
+    case BEXTI:
+        return (rs1 >> imm) & 1ull;
+    default:
+        return 0;
+    }
+}
+
+struct BitManipRegCoreRecord {
+    uint16_t b[BITMANIP_NUM_LIMBS];
+    uint16_t c[BITMANIP_NUM_LIMBS];
+    uint8_t local_opcode;
+};
+
+static_assert(sizeof(BitManipRegCoreRecord) == 18);
+
+template <typename T> struct BitManipRegCoreCols {
+    T a[BITMANIP_NUM_LIMBS];
+    T b[BITMANIP_NUM_LIMBS];
+    T c[BITMANIP_NUM_LIMBS];
+    T a_bits[BITMANIP_NUM_BITS];
+    T b_bits[BITMANIP_NUM_BITS];
+    T c_bits[BITMANIP_NUM_BITS];
+    T opcode_flags[BITMANIP_REG_OP_COUNT];
+    T add_carry[BITMANIP_NUM_BITS + 1];
+    T index_marker[BITMANIP_NUM_BITS];
+    T minmax_lt;
+    T minmax_diff_marker[BITMANIP_NUM_BITS];
+};
+
+struct BitManipRegCore {
+    template <typename T> using Cols = BitManipRegCoreCols<T>;
+
+    __device__ void fill_trace_row(RowSlice row, BitManipRegCoreRecord record) {
+        uint64_t b_u64 = bitmanip_limbs_to_u64(record.b);
+        uint64_t c_u64 = bitmanip_limbs_to_u64(record.c);
+        uint64_t a_u64 = bitmanip_run_reg(record.local_opcode, b_u64, c_u64);
+
+        uint16_t a[BITMANIP_NUM_LIMBS];
+        uint8_t a_bits[BITMANIP_NUM_BITS];
+        uint8_t b_bits[BITMANIP_NUM_BITS];
+        uint8_t c_bits[BITMANIP_NUM_BITS];
+        uint8_t opcode_flags[BITMANIP_REG_OP_COUNT] = {0};
+        uint8_t add_carry[BITMANIP_NUM_BITS + 1] = {0};
+        uint8_t index_marker[BITMANIP_NUM_BITS] = {0};
+        uint8_t minmax_diff_marker[BITMANIP_NUM_BITS] = {0};
+        uint8_t minmax_lt = 0;
+
+        bitmanip_u64_to_limbs(a_u64, a);
+        bitmanip_bits_u64(a_u64, a_bits);
+        bitmanip_bits_u64(b_u64, b_bits);
+        bitmanip_bits_u64(c_u64, c_bits);
+
+        int flag_pos = bitmanip_reg_flag_pos(record.local_opcode);
+        if (flag_pos >= 0) {
+            opcode_flags[flag_pos] = 1;
+        }
+
+        if (bitmanip_is_shadd(record.local_opcode)) {
+            uint32_t shift = 0;
+            bool uw = false;
+            switch (record.local_opcode) {
+            case SH1ADD:
+                shift = 1;
+                break;
+            case SH2ADD:
+                shift = 2;
+                break;
+            case SH3ADD:
+                shift = 3;
+                break;
+            case ADD_UW:
+                uw = true;
+                break;
+            case SH1ADD_UW:
+                shift = 1;
+                uw = true;
+                break;
+            case SH2ADD_UW:
+                shift = 2;
+                uw = true;
+                break;
+            case SH3ADD_UW:
+                shift = 3;
+                uw = true;
+                break;
+            }
+            uint64_t shifted =
+                uw ? (static_cast<uint64_t>(static_cast<uint32_t>(b_u64)) << shift)
+                   : (b_u64 << shift);
+            uint8_t carry = 0;
+            add_carry[0] = 0;
+            for (size_t i = 0; i < BITMANIP_NUM_BITS; i++) {
+                uint8_t total = static_cast<uint8_t>(((shifted >> i) & 1ull) + ((c_u64 >> i) & 1ull) + carry);
+                carry = total >> 1;
+                add_carry[i + 1] = carry;
+            }
+        }
+
+        if (record.local_opcode == ROL || record.local_opcode == ROR || record.local_opcode == BCLR ||
+            record.local_opcode == BSET || record.local_opcode == BINV || record.local_opcode == BEXT) {
+            index_marker[c_u64 & 63ull] = 1;
+        } else if (record.local_opcode == ROLW || record.local_opcode == RORW) {
+            index_marker[c_u64 & 31ull] = 1;
+        }
+
+        if (record.local_opcode == OP_MIN || record.local_opcode == MINU ||
+            record.local_opcode == OP_MAX || record.local_opcode == MAXU) {
+            bool lt = (record.local_opcode == OP_MIN || record.local_opcode == OP_MAX)
+                          ? bitmanip_signed_lt(b_u64, c_u64)
+                          : (b_u64 < c_u64);
+            minmax_lt = lt ? 1 : 0;
+            uint64_t diff = b_u64 ^ c_u64;
+            if (diff != 0) {
+                minmax_diff_marker[63 - bitmanip_clz64(diff)] = 1;
+            }
+        }
+
+        COL_WRITE_ARRAY(row, Cols, a, a);
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+        COL_WRITE_ARRAY(row, Cols, c, record.c);
+        COL_WRITE_ARRAY(row, Cols, a_bits, a_bits);
+        COL_WRITE_ARRAY(row, Cols, b_bits, b_bits);
+        COL_WRITE_ARRAY(row, Cols, c_bits, c_bits);
+        COL_WRITE_ARRAY(row, Cols, opcode_flags, opcode_flags);
+        COL_WRITE_ARRAY(row, Cols, add_carry, add_carry);
+        COL_WRITE_ARRAY(row, Cols, index_marker, index_marker);
+        COL_WRITE_VALUE(row, Cols, minmax_lt, minmax_lt);
+        COL_WRITE_ARRAY(row, Cols, minmax_diff_marker, minmax_diff_marker);
+    }
+};
+
+struct BitManipImmCoreRecord {
+    uint16_t b[BITMANIP_NUM_LIMBS];
+    uint8_t imm;
+    uint8_t local_opcode;
+};
+
+static_assert(sizeof(BitManipImmCoreRecord) == 10);
+
+template <typename T> struct BitManipImmCoreCols {
+    T a[BITMANIP_NUM_LIMBS];
+    T b[BITMANIP_NUM_LIMBS];
+    T a_bits[BITMANIP_NUM_BITS];
+    T b_bits[BITMANIP_NUM_BITS];
+    T opcode_flags[BITMANIP_IMM_OP_COUNT];
+    T index_marker[BITMANIP_NUM_BITS];
+    T count_marker[BITMANIP_NUM_BITS + 1];
+    T byte_nonzero[8];
+    T byte_nonzero_inv[8];
+};
+
+struct BitManipImmCore {
+    template <typename T> using Cols = BitManipImmCoreCols<T>;
+
+    __device__ void fill_trace_row(RowSlice row, BitManipImmCoreRecord record) {
+        uint64_t b_u64 = bitmanip_limbs_to_u64(record.b);
+        uint64_t a_u64 = bitmanip_run_imm(record.local_opcode, b_u64, record.imm);
+
+        uint16_t a[BITMANIP_NUM_LIMBS];
+        uint8_t a_bits[BITMANIP_NUM_BITS];
+        uint8_t b_bits[BITMANIP_NUM_BITS];
+        uint8_t opcode_flags[BITMANIP_IMM_OP_COUNT] = {0};
+        uint8_t index_marker[BITMANIP_NUM_BITS] = {0};
+        uint8_t count_marker[BITMANIP_NUM_BITS + 1] = {0};
+        uint8_t byte_nonzero[8] = {0};
+        Fp byte_nonzero_inv[8];
+        for (size_t byte = 0; byte < 8; byte++) {
+            byte_nonzero_inv[byte] = Fp::zero();
+        }
+
+        bitmanip_u64_to_limbs(a_u64, a);
+        bitmanip_bits_u64(a_u64, a_bits);
+        bitmanip_bits_u64(b_u64, b_bits);
+
+        int flag_pos = bitmanip_imm_flag_pos(record.local_opcode);
+        if (flag_pos >= 0) {
+            opcode_flags[flag_pos] = 1;
+        }
+
+        if (record.local_opcode == SLLI_UW || record.local_opcode == RORI ||
+            record.local_opcode == RORIW || record.local_opcode == BCLRI ||
+            record.local_opcode == BSETI || record.local_opcode == BINVI ||
+            record.local_opcode == BEXTI) {
+            index_marker[record.imm] = 1;
+        }
+
+        if (record.local_opcode == CLZ || record.local_opcode == CTZ ||
+            record.local_opcode == CLZW || record.local_opcode == CTZW) {
+            count_marker[a_u64] = 1;
+        }
+
+        if (record.local_opcode == ORC_B) {
+            for (size_t byte = 0; byte < 8; byte++) {
+                uint32_t count = 0;
+                for (size_t bit = 0; bit < 8; bit++) {
+                    count += b_bits[byte * 8 + bit];
+                }
+                if (count != 0) {
+                    byte_nonzero[byte] = 1;
+                    byte_nonzero_inv[byte] = inv(Fp(count));
+                }
+            }
+        }
+
+        COL_WRITE_ARRAY(row, Cols, a, a);
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+        COL_WRITE_ARRAY(row, Cols, a_bits, a_bits);
+        COL_WRITE_ARRAY(row, Cols, b_bits, b_bits);
+        COL_WRITE_ARRAY(row, Cols, opcode_flags, opcode_flags);
+        COL_WRITE_ARRAY(row, Cols, index_marker, index_marker);
+        COL_WRITE_ARRAY(row, Cols, count_marker, count_marker);
+        COL_WRITE_ARRAY(row, Cols, byte_nonzero, byte_nonzero);
+        COL_WRITE_ARRAY(row, Cols, byte_nonzero_inv, byte_nonzero_inv);
+    }
+};

--- a/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/bitmanip.cuh
@@ -558,6 +558,71 @@ struct BitManipBitwiseInvCore {
     }
 };
 
+struct BitManipByteUnaryCoreRecord {
+    uint8_t b[RV64_REGISTER_NUM_LIMBS];
+    uint8_t local_opcode;
+};
+
+static_assert(sizeof(BitManipByteUnaryCoreRecord) == 9);
+
+template <typename T> struct BitManipByteUnaryCoreCols {
+    T b[RV64_REGISTER_NUM_LIMBS];
+    T nz[RV64_REGISTER_NUM_LIMBS];
+    T inv[RV64_REGISTER_NUM_LIMBS];
+    T sext_bit;
+    T sext_low;
+    T opcode_sext_b_flag;
+    T opcode_sext_h_flag;
+    T opcode_zext_h_flag;
+    T opcode_orc_b_flag;
+    T opcode_rev8_flag;
+};
+
+struct BitManipByteUnaryCore {
+    BitwiseOperationLookup bitwise_lookup;
+
+    template <typename T> using Cols = BitManipByteUnaryCoreCols<T>;
+
+    __device__ BitManipByteUnaryCore(BitwiseOperationLookup lookup) : bitwise_lookup(lookup) {}
+
+    __device__ void fill_trace_row(RowSlice row, BitManipByteUnaryCoreRecord record) {
+        bool is_orc_b = record.local_opcode == ORC_B;
+
+#pragma unroll
+        for (size_t i = 0; i < RV64_REGISTER_NUM_LIMBS / 2; i++) {
+            bitwise_lookup.add_range(record.b[2 * i], record.b[2 * i + 1]);
+        }
+
+        uint32_t sext_bit = 0;
+        uint32_t sext_low = 0;
+        if (record.local_opcode == SEXT_B) {
+            sext_bit = record.b[0] >> 7;
+            sext_low = record.b[0] & 0x7f;
+        } else if (record.local_opcode == SEXT_H) {
+            sext_bit = record.b[1] >> 7;
+            sext_low = record.b[1] & 0x7f;
+        }
+        if (record.local_opcode == SEXT_B || record.local_opcode == SEXT_H) {
+            bitwise_lookup.add_range(2 * sext_low, 0);
+        }
+
+        COL_WRITE_ARRAY(row, Cols, b, record.b);
+#pragma unroll
+        for (size_t i = 0; i < RV64_REGISTER_NUM_LIMBS; i++) {
+            bool nz = is_orc_b && record.b[i] != 0;
+            COL_WRITE_VALUE(row, Cols, nz[i], nz);
+            COL_WRITE_VALUE(row, Cols, inv[i], nz ? inv(Fp(record.b[i])) : Fp(0u));
+        }
+        COL_WRITE_VALUE(row, Cols, sext_bit, sext_bit);
+        COL_WRITE_VALUE(row, Cols, sext_low, sext_low);
+        COL_WRITE_VALUE(row, Cols, opcode_sext_b_flag, record.local_opcode == SEXT_B);
+        COL_WRITE_VALUE(row, Cols, opcode_sext_h_flag, record.local_opcode == SEXT_H);
+        COL_WRITE_VALUE(row, Cols, opcode_zext_h_flag, record.local_opcode == ZEXT_H);
+        COL_WRITE_VALUE(row, Cols, opcode_orc_b_flag, is_orc_b);
+        COL_WRITE_VALUE(row, Cols, opcode_rev8_flag, record.local_opcode == REV8);
+    }
+};
+
 struct BitManipMinMaxCoreRecord {
     uint16_t b[BITMANIP_NUM_LIMBS];
     uint16_t c[BITMANIP_NUM_LIMBS];

--- a/extensions/riscv/circuit/cuda/src/bitmanip.cu
+++ b/extensions/riscv/circuit/cuda/src/bitmanip.cu
@@ -1,0 +1,132 @@
+#include "launcher.cuh"
+#include "primitives/buffer_view.cuh"
+#include "primitives/constants.h"
+#include "primitives/histogram.cuh"
+#include "primitives/trace_access.h"
+#include "riscv/adapters/alu_imm_u16.cuh"
+#include "riscv/adapters/alu_reg_u16.cuh"
+#include "riscv/cores/bitmanip.cuh"
+#include "system/memory/params.cuh"
+
+using namespace riscv;
+using namespace program;
+
+template <typename T> struct BitManipRegCols {
+    Rv64BaseAluRegU16AdapterCols<T> adapter;
+    BitManipRegCoreCols<T> core;
+};
+
+struct BitManipRegRecord {
+    Rv64BaseAluRegU16AdapterRecord adapter;
+    BitManipRegCoreRecord core;
+};
+
+static_assert(sizeof(BitManipRegRecord) == 60);
+static_assert(offsetof(BitManipRegRecord, core) == 40);
+
+__global__ void rv64_bitmanip_reg_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipRegRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluRegU16Adapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipRegCore().fill_trace_row(row.slice_from(COL_INDEX(BitManipRegCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_reg_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipRegRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipRegCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_reg_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}
+
+template <typename T> struct BitManipImmCols {
+    Rv64BaseAluImmU16AdapterCols<T> adapter;
+    BitManipImmCoreCols<T> core;
+};
+
+struct BitManipImmRecord {
+    Rv64BaseAluImmU16AdapterRecord adapter;
+    BitManipImmCoreRecord core;
+};
+
+static_assert(sizeof(BitManipImmRecord) == 44);
+static_assert(offsetof(BitManipImmRecord, core) == 32);
+
+__global__ void rv64_bitmanip_imm_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipImmRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluImmU16Adapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipImmCore().fill_trace_row(row.slice_from(COL_INDEX(BitManipImmCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_imm_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipImmRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipImmCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_imm_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}

--- a/extensions/riscv/circuit/cuda/src/bitmanip.cu
+++ b/extensions/riscv/circuit/cuda/src/bitmanip.cu
@@ -11,6 +11,128 @@
 using namespace riscv;
 using namespace program;
 
+template <typename T> struct BitManipShAddCols {
+    Rv64BaseAluRegU16AdapterCols<T> adapter;
+    BitManipShAddCoreCols<T> core;
+};
+
+struct BitManipShAddRecord {
+    Rv64BaseAluRegU16AdapterRecord adapter;
+    BitManipShAddCoreRecord core;
+};
+
+static_assert(sizeof(BitManipShAddRecord) == 60);
+static_assert(offsetof(BitManipShAddRecord, core) == 40);
+
+__global__ void rv64_bitmanip_shadd_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipShAddRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluRegU16Adapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipShAddCore(VariableRangeChecker(range_ptr, range_bins))
+            .fill_trace_row(row.slice_from(COL_INDEX(BitManipShAddCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_shadd_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipShAddRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipShAddCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_shadd_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}
+
+template <typename T> struct BitManipSlliUwCols {
+    Rv64BaseAluImmU16AdapterCols<T> adapter;
+    BitManipSlliUwCoreCols<T> core;
+};
+
+struct BitManipSlliUwRecord {
+    Rv64BaseAluImmU16AdapterRecord adapter;
+    BitManipSlliUwCoreRecord core;
+};
+
+static_assert(sizeof(BitManipSlliUwRecord) == 44);
+static_assert(offsetof(BitManipSlliUwRecord, core) == 32);
+
+__global__ void rv64_bitmanip_slli_uw_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipSlliUwRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluImmU16Adapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipSlliUwCore(VariableRangeChecker(range_ptr, range_bins))
+            .fill_trace_row(row.slice_from(COL_INDEX(BitManipSlliUwCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_slli_uw_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipSlliUwRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipSlliUwCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_slli_uw_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}
+
 template <typename T> struct BitManipRegCols {
     Rv64BaseAluRegU16AdapterCols<T> adapter;
     BitManipRegCoreCols<T> core;

--- a/extensions/riscv/circuit/cuda/src/bitmanip.cu
+++ b/extensions/riscv/circuit/cuda/src/bitmanip.cu
@@ -3,6 +3,7 @@
 #include "primitives/constants.h"
 #include "primitives/histogram.cuh"
 #include "primitives/trace_access.h"
+#include "riscv/adapters/alu_imm.cuh"
 #include "riscv/adapters/alu_imm_u16.cuh"
 #include "riscv/adapters/alu_reg.cuh"
 #include "riscv/adapters/alu_reg_u16.cuh"
@@ -251,6 +252,70 @@ extern "C" int _rv64_bitmanip_min_max_tracegen(
         d_records,
         d_range_checker,
         range_checker_num_bins,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}
+
+template <typename T> struct BitManipByteUnaryCols {
+    Rv64BaseAluImmAdapterCols<T> adapter;
+    BitManipByteUnaryCoreCols<T> core;
+};
+
+struct BitManipByteUnaryRecord {
+    Rv64BaseAluImmAdapterRecord adapter;
+    BitManipByteUnaryCoreRecord core;
+};
+
+static_assert(sizeof(BitManipByteUnaryRecord) == 44);
+static_assert(offsetof(BitManipByteUnaryRecord, core) == 32);
+
+__global__ void rv64_bitmanip_byte_unary_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipByteUnaryRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t *bitwise_lookup_ptr,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluImmAdapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipByteUnaryCore(BitwiseOperationLookup(bitwise_lookup_ptr))
+            .fill_trace_row(row.slice_from(COL_INDEX(BitManipByteUnaryCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_byte_unary_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipByteUnaryRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t *__restrict__ d_bitwise_lookup,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipByteUnaryCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_byte_unary_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        d_bitwise_lookup,
         timestamp_max_bits
     );
     return CHECK_KERNEL();

--- a/extensions/riscv/circuit/cuda/src/bitmanip.cu
+++ b/extensions/riscv/circuit/cuda/src/bitmanip.cu
@@ -4,6 +4,7 @@
 #include "primitives/histogram.cuh"
 #include "primitives/trace_access.h"
 #include "riscv/adapters/alu_imm_u16.cuh"
+#include "riscv/adapters/alu_reg.cuh"
 #include "riscv/adapters/alu_reg_u16.cuh"
 #include "riscv/cores/bitmanip.cuh"
 #include "system/memory/params.cuh"
@@ -122,6 +123,128 @@ extern "C" int _rv64_bitmanip_slli_uw_tracegen(
     auto [grid, block] = kernel_launch_params(height, 512);
 
     rv64_bitmanip_slli_uw_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}
+
+template <typename T> struct BitManipBitwiseInvCols {
+    Rv64BaseAluRegAdapterCols<T> adapter;
+    BitManipBitwiseInvCoreCols<T> core;
+};
+
+struct BitManipBitwiseInvRecord {
+    Rv64BaseAluRegAdapterRecord adapter;
+    BitManipBitwiseInvCoreRecord core;
+};
+
+__global__ void rv64_bitmanip_bitwise_inv_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipBitwiseInvRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t *bitwise_lookup_ptr,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluRegAdapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipBitwiseInvCore(BitwiseOperationLookup(bitwise_lookup_ptr))
+            .fill_trace_row(row.slice_from(COL_INDEX(BitManipBitwiseInvCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_bitwise_inv_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipBitwiseInvRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t *__restrict__ d_bitwise_lookup,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipBitwiseInvCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_bitwise_inv_tracegen<<<grid, block, 0, stream>>>(
+        d_trace,
+        height,
+        width,
+        d_records,
+        d_range_checker,
+        range_checker_num_bins,
+        d_bitwise_lookup,
+        timestamp_max_bits
+    );
+    return CHECK_KERNEL();
+}
+
+template <typename T> struct BitManipMinMaxCols {
+    Rv64BaseAluRegU16AdapterCols<T> adapter;
+    BitManipMinMaxCoreCols<T> core;
+};
+
+struct BitManipMinMaxRecord {
+    Rv64BaseAluRegU16AdapterRecord adapter;
+    BitManipMinMaxCoreRecord core;
+};
+
+static_assert(sizeof(BitManipMinMaxRecord) == 60);
+static_assert(offsetof(BitManipMinMaxRecord, core) == 40);
+
+__global__ void rv64_bitmanip_min_max_tracegen(
+    Fp *trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipMinMaxRecord> records,
+    uint32_t *range_ptr,
+    uint32_t range_bins,
+    uint32_t timestamp_max_bits
+) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    RowSlice row(trace + idx, height);
+    if (idx < records.len()) {
+        auto const &rec = records[idx];
+        auto adapter = Rv64BaseAluRegU16Adapter(
+            VariableRangeChecker(range_ptr, range_bins), timestamp_max_bits);
+        adapter.fill_trace_row(row, rec.adapter);
+        BitManipMinMaxCore(VariableRangeChecker(range_ptr, range_bins))
+            .fill_trace_row(row.slice_from(COL_INDEX(BitManipMinMaxCols, core)), rec.core);
+    } else {
+        row.fill_zero(0, width);
+    }
+}
+
+extern "C" int _rv64_bitmanip_min_max_tracegen(
+    Fp *__restrict__ d_trace,
+    size_t height,
+    size_t width,
+    DeviceBufferConstView<BitManipMinMaxRecord> d_records,
+    uint32_t *__restrict__ d_range_checker,
+    uint32_t range_checker_num_bins,
+    uint32_t timestamp_max_bits,
+    cudaStream_t stream
+) {
+    assert(width == sizeof(BitManipMinMaxCols<uint8_t>));
+    auto [grid, block] = kernel_launch_params(height, 512);
+
+    rv64_bitmanip_min_max_tracegen<<<grid, block, 0, stream>>>(
         d_trace,
         height,
         width,

--- a/extensions/riscv/circuit/src/bitmanip/bitwise_inv.rs
+++ b/extensions/riscv/circuit/src/bitmanip/bitwise_inv.rs
@@ -1,0 +1,231 @@
+use std::borrow::{Borrow, BorrowMut};
+
+use openvm_circuit::{
+    arch::*,
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
+use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::{
+    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV64_REGISTER_NUM_LIMBS,
+};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::BaseAir,
+    p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
+    BaseAirWithPublicValues,
+};
+
+use super::core::{is_bitwise_inv_opcode, run_bitmanip_reg, ANDN, BITMANIP_OFFSET, ORN, XNOR};
+use crate::adapters::RV64_BYTE_BITS;
+
+/// ANDN/ORN/XNOR over byte limbs via the bitwise XOR lookup, with the
+/// complement of `c` folded linearly into the lookup relation (`~c = 255 - c`
+/// per byte), mirroring `BitwiseLogicCoreAir`:
+///   ANDN: b ^ ~c = b + ~c - 2a
+///   ORN:  b ^ ~c = 2a - b - ~c
+///   XNOR: b ^ c  = 255 - a
+/// The lookup range checks its inputs, which bounds `c` (via `~c`) and `a`.
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipBitwiseInvCoreCols<T> {
+    pub a: [T; RV64_REGISTER_NUM_LIMBS],
+    pub b: [T; RV64_REGISTER_NUM_LIMBS],
+    pub c: [T; RV64_REGISTER_NUM_LIMBS],
+
+    pub opcode_andn_flag: T,
+    pub opcode_orn_flag: T,
+    pub opcode_xnor_flag: T,
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipBitwiseInvCoreCols<u8>)]
+pub struct BitManipBitwiseInvCoreAir {
+    pub bus: BitwiseOperationLookupBus,
+}
+
+impl<F: Field> BaseAir<F> for BitManipBitwiseInvCoreAir {
+    fn width(&self) -> usize {
+        BitManipBitwiseInvCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipBitwiseInvCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipBitwiseInvCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; RV64_REGISTER_NUM_LIMBS]; 2]>,
+    I::Writes: From<[[AB::Expr; RV64_REGISTER_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<MinimalInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipBitwiseInvCoreCols<_> = local_core.borrow();
+        let flags = [
+            (cols.opcode_andn_flag, ANDN),
+            (cols.opcode_orn_flag, ORN),
+            (cols.opcode_xnor_flag, XNOR),
+        ];
+
+        let is_valid = flags.iter().fold(AB::Expr::ZERO, |acc, &(flag, _)| {
+            builder.assert_bool(flag);
+            acc + flag.into()
+        });
+        builder.assert_bool(is_valid.clone());
+
+        let max_byte = AB::Expr::from_u8(u8::MAX);
+        for i in 0..RV64_REGISTER_NUM_LIMBS {
+            let a = cols.a[i];
+            let b = cols.b[i];
+            let c = cols.c[i];
+            let c_inv = max_byte.clone() - c;
+
+            // The second lookup input is ~c for ANDN/ORN and c for XNOR.
+            let y = (cols.opcode_andn_flag + cols.opcode_orn_flag) * c_inv.clone()
+                + cols.opcode_xnor_flag * c;
+            // The expected XOR of the two lookup inputs, encoded per opcode.
+            let x_xor_y = cols.opcode_andn_flag * (b + c_inv.clone() - AB::Expr::from_u8(2) * a)
+                + cols.opcode_orn_flag * (AB::Expr::from_u8(2) * a - b - c_inv)
+                + cols.opcode_xnor_flag * (max_byte.clone() - a);
+            self.bus
+                .send_xor(b.into(), y, x_xor_y)
+                .eval(builder, is_valid.clone());
+        }
+
+        let expected_local_opcode = flags
+            .iter()
+            .fold(AB::Expr::ZERO, |acc, &(flag, local_opcode)| {
+                acc + flag * AB::Expr::from_usize(local_opcode)
+            });
+        let expected_opcode = expected_local_opcode + AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: MinimalInstruction {
+                is_valid,
+                opcode: expected_opcode,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipBitwiseInvCoreRecord {
+    pub b: [u8; RV64_REGISTER_NUM_LIMBS],
+    pub c: [u8; RV64_REGISTER_NUM_LIMBS],
+    pub local_opcode: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipBitwiseInvExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipBitwiseInvFiller<A> {
+    adapter: A,
+    pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<{ RV64_BYTE_BITS }>,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipBitwiseInvExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u8; RV64_REGISTER_NUM_LIMBS]; 2]>,
+            WriteData: From<[[u8; RV64_REGISTER_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipBitwiseInvCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BBitwiseInv({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_bitwise_inv_opcode(local_opcode));
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b, core_record.c] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.local_opcode = local_opcode as u8;
+
+        let output = run_bitmanip_reg(
+            local_opcode,
+            u64::from_le_bytes(core_record.b),
+            u64::from_le_bytes(core_record.c),
+        );
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [output.to_le_bytes()].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipBitwiseInvFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipBitwiseInvCoreRecord =
+            unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let c = record.c;
+        let local_opcode = record.local_opcode as usize;
+        let a = run_bitmanip_reg(local_opcode, u64::from_le_bytes(b), u64::from_le_bytes(c))
+            .to_le_bytes();
+
+        for i in 0..RV64_REGISTER_NUM_LIMBS {
+            if local_opcode == XNOR {
+                self.bitwise_lookup_chip
+                    .request_xor(b[i] as u32, c[i] as u32);
+            } else {
+                self.bitwise_lookup_chip
+                    .request_xor(b[i] as u32, (u8::MAX - c[i]) as u32);
+            }
+        }
+
+        let core_row: &mut BitManipBitwiseInvCoreCols<F> = core_row.borrow_mut();
+        core_row.opcode_xnor_flag = F::from_bool(local_opcode == XNOR);
+        core_row.opcode_orn_flag = F::from_bool(local_opcode == ORN);
+        core_row.opcode_andn_flag = F::from_bool(local_opcode == ANDN);
+        core_row.c = c.map(F::from_u8);
+        core_row.b = b.map(F::from_u8);
+        core_row.a = a.map(F::from_u8);
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/byte_unary.rs
+++ b/extensions/riscv/circuit/src/bitmanip/byte_unary.rs
@@ -1,0 +1,288 @@
+use std::{
+    array,
+    borrow::{Borrow, BorrowMut},
+};
+
+use openvm_circuit::{
+    arch::*,
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::{BitwiseOperationLookupBus, SharedBitwiseOperationLookupChip},
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
+use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::{
+    instruction::Instruction, program::DEFAULT_PC_STEP, riscv::RV64_REGISTER_NUM_LIMBS,
+};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::BaseAir,
+    p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
+    BaseAirWithPublicValues,
+};
+
+use super::core::{
+    is_byte_unary_opcode, run_bitmanip_imm, BITMANIP_OFFSET, ORC_B, REV8, SEXT_B, SEXT_H, ZEXT_H,
+};
+use crate::adapters::RV64_BYTE_BITS;
+
+/// Unary byte ops (SEXT.B / SEXT.H / ZEXT.H / ORC.B / REV8) over byte limbs.
+///
+/// The written value is an expression over the operand bytes and a handful of
+/// witnesses, so there are no output columns:
+///   REV8:   out[i] = b[7 - i]                       (pure wiring)
+///   ORC.B:  out[i] = 255 * nz[i], with nz[i] = (b[i] != 0) proven via the
+///           standard inverse trick (b * inv = nz, b * (1 - nz) = 0)
+///   SEXT.B: b[0] = lo + 128 * t, out = [b[0], 255*t, ...]
+///   SEXT.H: b[1] = lo + 128 * t, out = [b[0], b[1], 255*t, ...]
+///   ZEXT.H: out = [b[0], b[1], 0, ...]
+/// The byte-limb adapter's u16 packing does not bound individual bytes, so the
+/// `b` bytes are range checked pairwise through the bitwise lookup; `lo < 128`
+/// is checked as `2 * lo < 256` on the same lookup.
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipByteUnaryCoreCols<T> {
+    pub b: [T; RV64_REGISTER_NUM_LIMBS],
+    /// ORC.B only: nz[i] = 1 iff b[i] != 0.
+    pub nz: [T; RV64_REGISTER_NUM_LIMBS],
+    /// ORC.B only: inverse of b[i] when b[i] != 0, else 0.
+    pub inv: [T; RV64_REGISTER_NUM_LIMBS],
+    /// SEXT.B/SEXT.H only: sign bit and low 7 bits of the extended byte.
+    pub sext_bit: T,
+    pub sext_low: T,
+    pub opcode_sext_b_flag: T,
+    pub opcode_sext_h_flag: T,
+    pub opcode_zext_h_flag: T,
+    pub opcode_orc_b_flag: T,
+    pub opcode_rev8_flag: T,
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipByteUnaryCoreCols<u8>)]
+pub struct BitManipByteUnaryCoreAir {
+    pub bus: BitwiseOperationLookupBus,
+}
+
+impl<F: Field> BaseAir<F> for BitManipByteUnaryCoreAir {
+    fn width(&self) -> usize {
+        BitManipByteUnaryCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipByteUnaryCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipByteUnaryCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; RV64_REGISTER_NUM_LIMBS]; 1]>,
+    I::Writes: From<[[AB::Expr; RV64_REGISTER_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<ImmInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipByteUnaryCoreCols<_> = local_core.borrow();
+        let flags = [
+            (cols.opcode_sext_b_flag, SEXT_B),
+            (cols.opcode_sext_h_flag, SEXT_H),
+            (cols.opcode_zext_h_flag, ZEXT_H),
+            (cols.opcode_orc_b_flag, ORC_B),
+            (cols.opcode_rev8_flag, REV8),
+        ];
+
+        let is_valid = flags.iter().fold(AB::Expr::ZERO, |acc, &(flag, _)| {
+            builder.assert_bool(flag);
+            acc + flag.into()
+        });
+        builder.assert_bool(is_valid.clone());
+
+        let max_byte = AB::Expr::from_u8(u8::MAX);
+
+        // The adapter packs byte pairs into u16 memory cells, which bounds the
+        // pairs but not the individual bytes; range check them here.
+        for i in 0..RV64_REGISTER_NUM_LIMBS / 2 {
+            self.bus
+                .send_range(cols.b[2 * i], cols.b[2 * i + 1])
+                .eval(builder, is_valid.clone());
+        }
+
+        // ORC.B witnesses: nz[i] boolean, and (gated on the flag) nz[i] = 1
+        // exactly when b[i] != 0.
+        for i in 0..RV64_REGISTER_NUM_LIMBS {
+            builder.assert_bool(cols.nz[i]);
+            builder.assert_zero(cols.opcode_orc_b_flag * (cols.b[i] * cols.inv[i] - cols.nz[i]));
+            builder.assert_zero(cols.opcode_orc_b_flag * cols.b[i] * (AB::Expr::ONE - cols.nz[i]));
+        }
+
+        // SEXT.B/SEXT.H witness: the extended byte decomposes as
+        // lo + 128 * t with t boolean and lo < 128 (checked as 2 * lo < 256).
+        builder.assert_bool(cols.sext_bit);
+        let sext_flags = cols.opcode_sext_b_flag + cols.opcode_sext_h_flag;
+        let selected_byte =
+            cols.opcode_sext_b_flag * cols.b[0] + cols.opcode_sext_h_flag * cols.b[1];
+        builder.assert_eq(
+            selected_byte,
+            sext_flags.clone() * (cols.sext_low + AB::Expr::from_u8(128) * cols.sext_bit),
+        );
+        self.bus
+            .send_range(cols.sext_low + cols.sext_low, AB::Expr::ZERO)
+            .eval(builder, sext_flags.clone());
+
+        let sign_fill = max_byte.clone() * cols.sext_bit;
+        let writes: [AB::Expr; RV64_REGISTER_NUM_LIMBS] = array::from_fn(|i| {
+            let mut out = cols.opcode_orc_b_flag * (max_byte.clone() * cols.nz[i])
+                + cols.opcode_rev8_flag * cols.b[RV64_REGISTER_NUM_LIMBS - 1 - i];
+            out += match i {
+                0 => (sext_flags.clone() + cols.opcode_zext_h_flag) * cols.b[0],
+                1 => {
+                    (cols.opcode_sext_h_flag + cols.opcode_zext_h_flag) * cols.b[1]
+                        + cols.opcode_sext_b_flag * sign_fill.clone()
+                }
+                _ => sext_flags.clone() * sign_fill.clone(),
+            };
+            out
+        });
+
+        let expected_local_opcode = flags
+            .iter()
+            .fold(AB::Expr::ZERO, |acc, &(flag, local_opcode)| {
+                acc + flag * AB::Expr::from_usize(local_opcode)
+            });
+        let expected_opcode = expected_local_opcode + AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into)].into(),
+            writes: [writes].into(),
+            instruction: ImmInstruction {
+                is_valid,
+                opcode: expected_opcode,
+                immediate: AB::Expr::ZERO,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipByteUnaryCoreRecord {
+    pub b: [u8; RV64_REGISTER_NUM_LIMBS],
+    pub local_opcode: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipByteUnaryExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipByteUnaryFiller<A> {
+    adapter: A,
+    pub bitwise_lookup_chip: SharedBitwiseOperationLookupChip<{ RV64_BYTE_BITS }>,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipByteUnaryExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u8; RV64_REGISTER_NUM_LIMBS]; 1]>,
+            WriteData: From<[[u8; RV64_REGISTER_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipByteUnaryCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BByteUnary({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_byte_unary_opcode(local_opcode));
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.local_opcode = local_opcode as u8;
+
+        let output = run_bitmanip_imm(local_opcode, u64::from_le_bytes(core_record.b), 0);
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [output.to_le_bytes()].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipByteUnaryFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipByteUnaryCoreRecord =
+            unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let local_opcode = record.local_opcode as usize;
+
+        for i in 0..RV64_REGISTER_NUM_LIMBS / 2 {
+            self.bitwise_lookup_chip
+                .request_range(b[2 * i] as u32, b[2 * i + 1] as u32);
+        }
+
+        let core_row: &mut BitManipByteUnaryCoreCols<F> = core_row.borrow_mut();
+        let is_orc_b = local_opcode == ORC_B;
+        let (sext_bit, sext_low) = match local_opcode {
+            SEXT_B => (b[0] >> 7, b[0] & 0x7f),
+            SEXT_H => (b[1] >> 7, b[1] & 0x7f),
+            _ => (0, 0),
+        };
+        if matches!(local_opcode, SEXT_B | SEXT_H) {
+            self.bitwise_lookup_chip
+                .request_range(2 * sext_low as u32, 0);
+        }
+
+        core_row.opcode_rev8_flag = F::from_bool(local_opcode == REV8);
+        core_row.opcode_orc_b_flag = F::from_bool(is_orc_b);
+        core_row.opcode_zext_h_flag = F::from_bool(local_opcode == ZEXT_H);
+        core_row.opcode_sext_h_flag = F::from_bool(local_opcode == SEXT_H);
+        core_row.opcode_sext_b_flag = F::from_bool(local_opcode == SEXT_B);
+        core_row.sext_low = F::from_u8(sext_low);
+        core_row.sext_bit = F::from_u8(sext_bit);
+        for i in (0..RV64_REGISTER_NUM_LIMBS).rev() {
+            let (nz, inv) = if is_orc_b && b[i] != 0 {
+                (F::ONE, F::from_u8(b[i]).inverse())
+            } else {
+                (F::ZERO, F::ZERO)
+            };
+            core_row.inv[i] = inv;
+            core_row.nz[i] = nz;
+        }
+        core_row.b = b.map(F::from_u8);
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/core.rs
+++ b/extensions/riscv/circuit/src/bitmanip/core.rs
@@ -8,6 +8,7 @@ use openvm_circuit::{
     system::memory::{online::TracingMemory, MemoryAuxColsFactory},
 };
 use openvm_circuit_primitives::{
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
     AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
@@ -24,7 +25,7 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues,
 };
 
-use super::{BITMANIP_NUM_BITS, BITMANIP_NUM_LIMBS};
+use super::{BITMANIP_LIMB_BITS, BITMANIP_NUM_BITS, BITMANIP_NUM_LIMBS};
 
 pub(crate) const BITMANIP_OFFSET: usize = ShAddOpcode::CLASS_OFFSET;
 
@@ -105,17 +106,20 @@ pub(crate) const BINVI: usize =
 pub(crate) const BEXTI: usize =
     local::<{ SingleBitImmOpcode::CLASS_OFFSET }>(SingleBitImmOpcode::BEXTI as usize);
 
+const SHADD_OPS: [usize; SHADD_OP_COUNT] = [
+    SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW,
+];
 const REG_OPS: [usize; REG_OP_COUNT] = [
-    SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW, ANDN, ORN, XNOR, ROL, ROR,
-    ROLW, RORW, MIN, MINU, MAX, MAXU, BCLR, BSET, BINV, BEXT,
+    ANDN, ORN, XNOR, ROL, ROR, ROLW, RORW, MIN, MINU, MAX, MAXU, BCLR, BSET, BINV, BEXT,
 ];
 const IMM_OPS: [usize; IMM_OP_COUNT] = [
-    SLLI_UW, RORI, RORIW, CLZ, CTZ, CLZW, CTZW, CPOP, CPOPW, SEXT_B, SEXT_H, ZEXT_H, ORC_B, REV8,
-    BCLRI, BSETI, BINVI, BEXTI,
+    RORI, RORIW, CLZ, CTZ, CLZW, CTZW, CPOP, CPOPW, SEXT_B, SEXT_H, ZEXT_H, ORC_B, REV8, BCLRI,
+    BSETI, BINVI, BEXTI,
 ];
 
-pub(crate) const REG_OP_COUNT: usize = 22;
-pub(crate) const IMM_OP_COUNT: usize = 18;
+pub(crate) const SHADD_OP_COUNT: usize = 7;
+pub(crate) const REG_OP_COUNT: usize = 15;
+pub(crate) const IMM_OP_COUNT: usize = 17;
 
 fn flag_pos(ops: &[usize], local_opcode: usize) -> usize {
     ops.iter()
@@ -127,8 +131,16 @@ pub(crate) fn is_reg_opcode(local_opcode: usize) -> bool {
     REG_OPS.contains(&local_opcode)
 }
 
+pub(crate) fn is_shadd_opcode(local_opcode: usize) -> bool {
+    SHADD_OPS.contains(&local_opcode)
+}
+
 pub(crate) fn is_imm_opcode(local_opcode: usize) -> bool {
     IMM_OPS.contains(&local_opcode)
+}
+
+pub(crate) fn is_slli_uw_opcode(local_opcode: usize) -> bool {
+    local_opcode == SLLI_UW
 }
 
 pub(crate) fn limbs_to_u64(limbs: &[u16; BITMANIP_NUM_LIMBS]) -> u64 {
@@ -227,6 +239,434 @@ pub(crate) fn run_bitmanip_imm(local_opcode: usize, rs1: u64, imm: u32) -> u64 {
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipShAddCoreCols<T> {
+    pub a: [T; BITMANIP_NUM_LIMBS],
+    pub b: [T; BITMANIP_NUM_LIMBS],
+    pub c: [T; BITMANIP_NUM_LIMBS],
+    pub opcode_flags: [T; SHADD_OP_COUNT],
+    pub bit_shift_carry: [T; BITMANIP_NUM_LIMBS],
+    pub bit_shift_aux: [T; BITMANIP_NUM_LIMBS],
+    pub add_carry: [T; BITMANIP_NUM_LIMBS + 1],
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipShAddCoreCols<u8>)]
+pub struct BitManipShAddCoreAir {
+    pub range_bus: VariableRangeCheckerBus,
+}
+
+impl<F: Field> BaseAir<F> for BitManipShAddCoreAir {
+    fn width(&self) -> usize {
+        BitManipShAddCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipShAddCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipShAddCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 2]>,
+    I::Writes: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<MinimalInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipShAddCoreCols<_> = local_core.borrow();
+        let mut is_valid = AB::Expr::ZERO;
+        let mut expected_local_opcode = AB::Expr::ZERO;
+        let mut bit_shift = AB::Expr::ZERO;
+        let mut bit_multiplier = AB::Expr::ZERO;
+        let mut carry_multiplier = AB::Expr::ZERO;
+        let mut uw_flag = AB::Expr::ZERO;
+
+        for (flag, local_opcode) in cols.opcode_flags.iter().zip(SHADD_OPS) {
+            builder.assert_bool(*flag);
+            let flag: AB::Expr = (*flag).into();
+            let (shift, is_uw) = shadd_shift_uw(local_opcode);
+            is_valid += flag.clone();
+            expected_local_opcode += flag.clone() * AB::Expr::from_usize(local_opcode);
+            bit_shift += flag.clone() * AB::Expr::from_usize(shift);
+            bit_multiplier += flag.clone() * AB::Expr::from_usize(1 << shift);
+            carry_multiplier +=
+                flag.clone() * AB::Expr::from_usize(1 << (BITMANIP_LIMB_BITS - shift));
+            uw_flag += flag * if is_uw { AB::Expr::ONE } else { AB::Expr::ZERO };
+        }
+        builder.assert_bool(is_valid.clone());
+
+        builder
+            .when(is_valid.clone())
+            .assert_zero(cols.add_carry[0]);
+        for carry in &cols.add_carry[1..] {
+            let carry: AB::Expr = (*carry).into();
+            builder.assert_zero(is_valid.clone() * carry.clone() * (AB::Expr::ONE - carry));
+        }
+
+        let aux_bits = AB::Expr::from_usize(BITMANIP_LIMB_BITS) - bit_shift.clone();
+        for limb in 0..BITMANIP_NUM_LIMBS {
+            let source_active = if limb < 2 {
+                is_valid.clone()
+            } else {
+                is_valid.clone() - uw_flag.clone()
+            };
+            let source = cols.b[limb] * source_active;
+            builder.assert_eq(
+                source,
+                cols.bit_shift_aux[limb] + cols.bit_shift_carry[limb] * carry_multiplier.clone(),
+            );
+            self.range_bus
+                .send(cols.bit_shift_carry[limb], bit_shift.clone())
+                .eval(builder, is_valid.clone());
+            self.range_bus
+                .send(cols.bit_shift_aux[limb], aux_bits.clone())
+                .eval(builder, is_valid.clone());
+        }
+
+        for limb in 0..BITMANIP_NUM_LIMBS {
+            let carry_in = if limb == 0 {
+                AB::Expr::ZERO
+            } else {
+                cols.bit_shift_carry[limb - 1].into()
+            };
+            let shifted = cols.bit_shift_aux[limb] * bit_multiplier.clone() + carry_in;
+            builder.assert_zero(
+                shifted + cols.c[limb] + cols.add_carry[limb]
+                    - cols.a[limb]
+                    - AB::Expr::from_usize(1 << BITMANIP_LIMB_BITS) * cols.add_carry[limb + 1],
+            );
+        }
+
+        let expected_opcode = expected_local_opcode + AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: MinimalInstruction {
+                is_valid,
+                opcode: expected_opcode,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipShAddCoreRecord {
+    pub b: [u16; BITMANIP_NUM_LIMBS],
+    pub c: [u16; BITMANIP_NUM_LIMBS],
+    pub local_opcode: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipShAddExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipShAddFiller<A> {
+    adapter: A,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipShAddExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; BITMANIP_NUM_LIMBS]; 2]>,
+            WriteData: From<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipShAddCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BShAdd({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_shadd_opcode(local_opcode));
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b, core_record.c] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.local_opcode = local_opcode as u8;
+
+        let output = run_bitmanip_reg(
+            local_opcode,
+            limbs_to_u64(&core_record.b),
+            limbs_to_u64(&core_record.c),
+        );
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [u64_to_limbs(output)].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipShAddFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipShAddCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let c = record.c;
+        let local_opcode = record.local_opcode as usize;
+        let b_u64 = limbs_to_u64(&b);
+        let c_u64 = limbs_to_u64(&c);
+        let a_u64 = run_bitmanip_reg(local_opcode, b_u64, c_u64);
+        let a = u64_to_limbs(a_u64);
+
+        let core_row: &mut BitManipShAddCoreCols<F> = core_row.borrow_mut();
+        core_row.opcode_flags = [F::ZERO; SHADD_OP_COUNT];
+        core_row.opcode_flags[flag_pos(&SHADD_OPS, local_opcode)] = F::ONE;
+        core_row.a = a.map(F::from_u16);
+        core_row.b = b.map(F::from_u16);
+        core_row.c = c.map(F::from_u16);
+        fill_shadd_aux(core_row, local_opcode, b, c, &self.range_checker_chip);
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipSlliUwCoreCols<T> {
+    pub a: [T; BITMANIP_NUM_LIMBS],
+    pub b: [T; BITMANIP_NUM_LIMBS],
+    pub bit_shift_marker: [T; BITMANIP_LIMB_BITS],
+    pub limb_shift_marker: [T; BITMANIP_NUM_LIMBS],
+    pub bit_shift_carry: [T; BITMANIP_NUM_LIMBS],
+    pub bit_shift_aux: [T; BITMANIP_NUM_LIMBS],
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipSlliUwCoreCols<u8>)]
+pub struct BitManipSlliUwCoreAir {
+    pub range_bus: VariableRangeCheckerBus,
+}
+
+impl<F: Field> BaseAir<F> for BitManipSlliUwCoreAir {
+    fn width(&self) -> usize {
+        BitManipSlliUwCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipSlliUwCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipSlliUwCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::Writes: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<ImmInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipSlliUwCoreCols<_> = local_core.borrow();
+
+        let mut bit_marker_sum = AB::Expr::ZERO;
+        let mut bit_shift = AB::Expr::ZERO;
+        let mut bit_multiplier = AB::Expr::ZERO;
+        let mut carry_multiplier = AB::Expr::ZERO;
+        for bit in 0..BITMANIP_LIMB_BITS {
+            builder.assert_bool(cols.bit_shift_marker[bit]);
+            let marker: AB::Expr = cols.bit_shift_marker[bit].into();
+            bit_marker_sum += marker.clone();
+            bit_shift += AB::Expr::from_usize(bit) * marker.clone();
+            bit_multiplier += AB::Expr::from_usize(1 << bit) * marker.clone();
+            carry_multiplier += AB::Expr::from_usize(1 << (BITMANIP_LIMB_BITS - bit)) * marker;
+        }
+        builder.assert_bool(bit_marker_sum.clone());
+        let is_valid = bit_marker_sum;
+
+        let aux_bits = AB::Expr::from_usize(BITMANIP_LIMB_BITS) - bit_shift.clone();
+        for limb in 0..BITMANIP_NUM_LIMBS {
+            let source = if limb < 2 {
+                cols.b[limb].into()
+            } else {
+                AB::Expr::ZERO
+            };
+            builder.assert_eq(
+                source * is_valid.clone(),
+                cols.bit_shift_aux[limb] + cols.bit_shift_carry[limb] * carry_multiplier.clone(),
+            );
+            self.range_bus
+                .send(cols.bit_shift_carry[limb], bit_shift.clone())
+                .eval(builder, is_valid.clone());
+            self.range_bus
+                .send(cols.bit_shift_aux[limb], aux_bits.clone())
+                .eval(builder, is_valid.clone());
+        }
+
+        let mut limb_marker_sum = AB::Expr::ZERO;
+        let mut limb_shift = AB::Expr::ZERO;
+        for limb_shift_idx in 0..BITMANIP_NUM_LIMBS {
+            builder.assert_bool(cols.limb_shift_marker[limb_shift_idx]);
+            limb_marker_sum += cols.limb_shift_marker[limb_shift_idx].into();
+            limb_shift +=
+                AB::Expr::from_usize(limb_shift_idx) * cols.limb_shift_marker[limb_shift_idx];
+
+            let mut when_limb_shift = builder.when(cols.limb_shift_marker[limb_shift_idx]);
+            for out_limb in 0..BITMANIP_NUM_LIMBS {
+                if out_limb < limb_shift_idx {
+                    when_limb_shift.assert_zero(cols.a[out_limb]);
+                } else {
+                    let src_limb = out_limb - limb_shift_idx;
+                    let carry_in = if src_limb == 0 {
+                        AB::Expr::ZERO
+                    } else {
+                        cols.bit_shift_carry[src_limb - 1].into()
+                    };
+                    when_limb_shift.assert_eq(
+                        cols.a[out_limb],
+                        cols.bit_shift_aux[src_limb] * bit_multiplier.clone() + carry_in,
+                    );
+                }
+            }
+        }
+        builder.assert_eq(limb_marker_sum, is_valid.clone());
+
+        let immediate = limb_shift * AB::Expr::from_usize(BITMANIP_LIMB_BITS) + bit_shift;
+        let expected_opcode = AB::Expr::from_usize(BITMANIP_OFFSET + SLLI_UW);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: ImmInstruction {
+                is_valid,
+                opcode: expected_opcode,
+                immediate,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipSlliUwCoreRecord {
+    pub b: [u16; BITMANIP_NUM_LIMBS],
+    pub imm: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipSlliUwExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipSlliUwFiller<A> {
+    adapter: A,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipSlliUwExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+            WriteData: From<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipSlliUwCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BSlliUw({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_slli_uw_opcode(local_opcode));
+        let imm = instruction.c.as_canonical_u32();
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.imm = imm as u8;
+
+        let output = run_bitmanip_imm(local_opcode, limbs_to_u64(&core_record.b), imm);
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [u64_to_limbs(output)].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipSlliUwFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipSlliUwCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let imm = record.imm as u32;
+        let a = u64_to_limbs(run_bitmanip_imm(SLLI_UW, limbs_to_u64(&b), imm));
+
+        let core_row: &mut BitManipSlliUwCoreCols<F> = core_row.borrow_mut();
+        core_row.a = a.map(F::from_u16);
+        core_row.b = b.map(F::from_u16);
+        fill_slli_uw_aux(core_row, b, imm as usize, &self.range_checker_chip);
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
 pub struct BitManipRegCoreCols<T> {
     pub a: [T; BITMANIP_NUM_LIMBS],
     pub b: [T; BITMANIP_NUM_LIMBS],
@@ -235,7 +675,6 @@ pub struct BitManipRegCoreCols<T> {
     pub b_bits: [T; BITMANIP_NUM_BITS],
     pub c_bits: [T; BITMANIP_NUM_BITS],
     pub opcode_flags: [T; REG_OP_COUNT],
-    pub add_carry: [T; BITMANIP_NUM_BITS + 1],
     pub index_marker: [T; BITMANIP_NUM_BITS],
     pub minmax_lt: T,
     pub minmax_diff_marker: [T; BITMANIP_NUM_BITS],
@@ -281,11 +720,6 @@ where
         constrain_bits_and_limbs(builder, is_valid.clone(), &cols.c_bits, &cols.c);
 
         let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
-        let shadd_valid = [
-            SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW,
-        ]
-        .into_iter()
-        .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
         let bitwise_valid = [ANDN, ORN, XNOR]
             .into_iter()
             .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
@@ -303,7 +737,6 @@ where
             .into_iter()
             .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
 
-        self.eval_shadd(builder, cols, shadd_valid.clone());
         self.eval_bitwise_inv(builder, cols, bitwise_valid);
         self.eval_index_markers(
             builder,
@@ -335,38 +768,6 @@ where
 }
 
 impl BitManipRegCoreAir {
-    fn eval_shadd<AB: InteractionBuilder>(
-        &self,
-        builder: &mut AB,
-        cols: &BitManipRegCoreCols<AB::Var>,
-        shadd_valid: AB::Expr,
-    ) {
-        builder
-            .when(shadd_valid.clone())
-            .assert_zero(cols.add_carry[0]);
-        for carry in &cols.add_carry[1..] {
-            let carry: AB::Expr = (*carry).into();
-            builder.assert_zero(shadd_valid.clone() * carry.clone() * (AB::Expr::ONE - carry));
-        }
-
-        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
-        for i in 0..BITMANIP_NUM_BITS {
-            let shifted_bit = shifted_rs1_bit::<AB>(&cols.b_bits, i, 1, false) * flag(SH1ADD)
-                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 2, false) * flag(SH2ADD)
-                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 3, false) * flag(SH3ADD)
-                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 0, true) * flag(ADD_UW)
-                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 1, true) * flag(SH1ADD_UW)
-                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 2, true) * flag(SH2ADD_UW)
-                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 3, true) * flag(SH3ADD_UW);
-            builder.assert_zero(
-                shadd_valid.clone()
-                    * (shifted_bit + cols.c_bits[i] + cols.add_carry[i]
-                        - cols.a_bits[i]
-                        - AB::Expr::from_u8(2) * cols.add_carry[i + 1]),
-            );
-        }
-    }
-
     fn eval_bitwise_inv<AB: InteractionBuilder>(
         &self,
         builder: &mut AB,
@@ -617,13 +1018,6 @@ where
         let core_row: &mut BitManipRegCoreCols<F> = core_row.borrow_mut();
         core_row.opcode_flags = [F::ZERO; REG_OP_COUNT];
         core_row.opcode_flags[flag_pos(&REG_OPS, local_opcode)] = F::ONE;
-        core_row.add_carry = [F::ZERO; BITMANIP_NUM_BITS + 1];
-        if matches!(
-            local_opcode,
-            SH1ADD | SH2ADD | SH3ADD | ADD_UW | SH1ADD_UW | SH2ADD_UW | SH3ADD_UW
-        ) {
-            fill_add_carries(core_row, local_opcode, b_u64, c_u64);
-        }
         core_row.index_marker = [F::ZERO; BITMANIP_NUM_BITS];
         if matches!(local_opcode, ROL | ROR | BCLR | BSET | BINV | BEXT) {
             core_row.index_marker[(c_u64 & 63) as usize] = F::ONE;
@@ -706,7 +1100,7 @@ where
         constrain_bits_and_limbs(builder, is_valid.clone(), &cols.b_bits, &cols.b);
 
         let flag = |op| cols.opcode_flags[flag_pos(&IMM_OPS, op)];
-        let index_valid = [SLLI_UW, RORI, RORIW, BCLRI, BSETI, BINVI, BEXTI]
+        let index_valid = [RORI, RORIW, BCLRI, BSETI, BINVI, BEXTI]
             .into_iter()
             .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
         let count_valid = [CLZ, CTZ, CLZW, CTZW]
@@ -721,7 +1115,6 @@ where
             .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
 
         let immediate = self.eval_index_markers(builder, cols, index_valid.clone());
-        self.eval_slli_uw(builder, cols, flag(SLLI_UW));
         self.eval_rori(builder, cols, flag(RORI), flag(RORIW));
         self.eval_count_zeros(builder, cols, count_valid);
         self.eval_cpop(builder, cols, cpop_valid);
@@ -764,23 +1157,6 @@ impl BitManipImmCoreAir {
         }
         builder.assert_eq(marker_sum, index_valid);
         index
-    }
-
-    fn eval_slli_uw<AB: InteractionBuilder>(
-        &self,
-        builder: &mut AB,
-        cols: &BitManipImmCoreCols<AB::Var>,
-        slli_flag: AB::Var,
-    ) {
-        for i in 0..BITMANIP_NUM_BITS {
-            let mut expected = AB::Expr::ZERO;
-            for s in 0..BITMANIP_NUM_BITS {
-                if i >= s && i - s < 32 {
-                    expected += slli_flag * cols.index_marker[s] * cols.b_bits[i - s];
-                }
-            }
-            builder.assert_zero(slli_flag * cols.a_bits[i] - expected);
-        }
     }
 
     fn eval_rori<AB: InteractionBuilder>(
@@ -1017,10 +1393,7 @@ where
         core_row.opcode_flags = [F::ZERO; IMM_OP_COUNT];
         core_row.opcode_flags[flag_pos(&IMM_OPS, local_opcode)] = F::ONE;
         core_row.index_marker = [F::ZERO; BITMANIP_NUM_BITS];
-        if matches!(
-            local_opcode,
-            SLLI_UW | RORI | RORIW | BCLRI | BSETI | BINVI | BEXTI
-        ) {
+        if matches!(local_opcode, RORI | RORIW | BCLRI | BSETI | BINVI | BEXTI) {
             core_row.index_marker[imm as usize] = F::ONE;
         }
         core_row.count_marker = [F::ZERO; BITMANIP_NUM_BITS + 1];
@@ -1066,29 +1439,25 @@ fn constrain_bits_and_limbs<AB: InteractionBuilder>(
     }
 }
 
-fn shifted_rs1_bit<AB: InteractionBuilder>(
-    bits: &[AB::Var; BITMANIP_NUM_BITS],
-    out_idx: usize,
-    shift: usize,
-    uw: bool,
-) -> AB::Expr {
-    if out_idx >= shift {
-        let in_idx = out_idx - shift;
-        if in_idx < if uw { 32 } else { BITMANIP_NUM_BITS } {
-            bits[in_idx].into()
-        } else {
-            AB::Expr::ZERO
-        }
-    } else {
-        AB::Expr::ZERO
+fn shadd_shift_uw(local_opcode: usize) -> (usize, bool) {
+    match local_opcode {
+        SH1ADD => (1, false),
+        SH2ADD => (2, false),
+        SH3ADD => (3, false),
+        ADD_UW => (0, true),
+        SH1ADD_UW => (1, true),
+        SH2ADD_UW => (2, true),
+        SH3ADD_UW => (3, true),
+        _ => unreachable!("unsupported shadd opcode {local_opcode}"),
     }
 }
 
-fn fill_add_carries<F: PrimeField32>(
-    row: &mut BitManipRegCoreCols<F>,
+fn fill_shadd_aux<F: PrimeField32>(
+    row: &mut BitManipShAddCoreCols<F>,
     local_opcode: usize,
-    rs1: u64,
-    rs2: u64,
+    rs1: [u16; BITMANIP_NUM_LIMBS],
+    rs2: [u16; BITMANIP_NUM_LIMBS],
+    range_checker: &SharedVariableRangeCheckerChip,
 ) {
     let (shift, uw) = match local_opcode {
         SH1ADD => (1, false),
@@ -1100,17 +1469,63 @@ fn fill_add_carries<F: PrimeField32>(
         SH3ADD_UW => (3, true),
         _ => unreachable!(),
     };
+    row.bit_shift_carry = [F::ZERO; BITMANIP_NUM_LIMBS];
+    row.bit_shift_aux = [F::ZERO; BITMANIP_NUM_LIMBS];
+    let carry_mask = (1u32 << shift) - 1;
+    let aux_mask = (1u32 << (BITMANIP_LIMB_BITS - shift)) - 1;
+    for (limb, &rs1_limb) in rs1.iter().enumerate() {
+        let source = if uw && limb >= 2 { 0 } else { rs1_limb as u32 };
+        let aux = source & aux_mask;
+        let carry = (source >> (BITMANIP_LIMB_BITS - shift)) & carry_mask;
+        row.bit_shift_aux[limb] = F::from_u32(aux);
+        row.bit_shift_carry[limb] = F::from_u32(carry);
+        range_checker.add_count(carry, shift);
+        range_checker.add_count(aux, BITMANIP_LIMB_BITS - shift);
+    }
+
     let shifted = if uw {
-        (rs1 as u32 as u64) << shift
+        (limbs_to_u64(&rs1) as u32 as u64) << shift
     } else {
-        rs1.wrapping_shl(shift)
+        limbs_to_u64(&rs1).wrapping_shl(shift as u32)
     };
-    let mut carry = 0u8;
+    let rs2 = limbs_to_u64(&rs2);
+    let mut add_carry = 0u8;
     row.add_carry[0] = F::ZERO;
     for i in 0..BITMANIP_NUM_BITS {
-        let total = ((shifted >> i) & 1) as u8 + ((rs2 >> i) & 1) as u8 + carry;
-        carry = total >> 1;
-        row.add_carry[i + 1] = F::from_u8(carry);
+        if i % BITMANIP_LIMB_BITS == 0 {
+            row.add_carry[i / BITMANIP_LIMB_BITS] = F::from_u8(add_carry);
+        }
+        let total = ((shifted >> i) & 1) as u8 + ((rs2 >> i) & 1) as u8 + add_carry;
+        add_carry = total >> 1;
+    }
+    row.add_carry[BITMANIP_NUM_LIMBS] = F::from_u8(add_carry);
+}
+
+fn fill_slli_uw_aux<F: PrimeField32>(
+    row: &mut BitManipSlliUwCoreCols<F>,
+    rs1: [u16; BITMANIP_NUM_LIMBS],
+    imm: usize,
+    range_checker: &SharedVariableRangeCheckerChip,
+) {
+    let bit_shift = imm % BITMANIP_LIMB_BITS;
+    let limb_shift = imm / BITMANIP_LIMB_BITS;
+    row.bit_shift_marker = [F::ZERO; BITMANIP_LIMB_BITS];
+    row.bit_shift_marker[bit_shift] = F::ONE;
+    row.limb_shift_marker = [F::ZERO; BITMANIP_NUM_LIMBS];
+    row.limb_shift_marker[limb_shift] = F::ONE;
+    row.bit_shift_carry = [F::ZERO; BITMANIP_NUM_LIMBS];
+    row.bit_shift_aux = [F::ZERO; BITMANIP_NUM_LIMBS];
+
+    let carry_mask = (1u32 << bit_shift) - 1;
+    let aux_mask = (1u32 << (BITMANIP_LIMB_BITS - bit_shift)) - 1;
+    for (limb, &rs1_limb) in rs1.iter().enumerate() {
+        let source = if limb >= 2 { 0 } else { rs1_limb as u32 };
+        let aux = source & aux_mask;
+        let carry = (source >> (BITMANIP_LIMB_BITS - bit_shift)) & carry_mask;
+        row.bit_shift_aux[limb] = F::from_u32(aux);
+        row.bit_shift_carry[limb] = F::from_u32(carry);
+        range_checker.add_count(carry, bit_shift);
+        range_checker.add_count(aux, BITMANIP_LIMB_BITS - bit_shift);
     }
 }
 

--- a/extensions/riscv/circuit/src/bitmanip/core.rs
+++ b/extensions/riscv/circuit/src/bitmanip/core.rs
@@ -131,6 +131,14 @@ pub(crate) fn is_reg_opcode(local_opcode: usize) -> bool {
     REG_OPS.contains(&local_opcode)
 }
 
+pub(crate) fn is_bitwise_inv_opcode(local_opcode: usize) -> bool {
+    matches!(local_opcode, ANDN | ORN | XNOR)
+}
+
+pub(crate) fn is_min_max_opcode(local_opcode: usize) -> bool {
+    matches!(local_opcode, MIN | MINU | MAX | MAXU)
+}
+
 pub(crate) fn is_shadd_opcode(local_opcode: usize) -> bool {
     SHADD_OPS.contains(&local_opcode)
 }

--- a/extensions/riscv/circuit/src/bitmanip/core.rs
+++ b/extensions/riscv/circuit/src/bitmanip/core.rs
@@ -139,6 +139,10 @@ pub(crate) fn is_min_max_opcode(local_opcode: usize) -> bool {
     matches!(local_opcode, MIN | MINU | MAX | MAXU)
 }
 
+pub(crate) fn is_byte_unary_opcode(local_opcode: usize) -> bool {
+    matches!(local_opcode, SEXT_B | SEXT_H | ZEXT_H | ORC_B | REV8)
+}
+
 pub(crate) fn is_shadd_opcode(local_opcode: usize) -> bool {
     SHADD_OPS.contains(&local_opcode)
 }

--- a/extensions/riscv/circuit/src/bitmanip/core.rs
+++ b/extensions/riscv/circuit/src/bitmanip/core.rs
@@ -1,0 +1,1153 @@
+use std::{
+    array,
+    borrow::{Borrow, BorrowMut},
+};
+
+use openvm_circuit::{
+    arch::*,
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+};
+use openvm_circuit_primitives::{
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
+use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP, LocalOpcode};
+use openvm_riscv_transpiler::{
+    BitwiseInvOpcode, ByteUnaryOpcode, CountZerosOpcode, CountZerosWOpcode, CpopOpcode,
+    CpopWOpcode, MinMaxOpcode, RotateImmOpcode, RotateOpcode, RotateWImmOpcode, RotateWOpcode,
+    ShAddOpcode, SingleBitImmOpcode, SingleBitOpcode, SlliUwOpcode,
+};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::{AirBuilder, BaseAir},
+    p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
+    BaseAirWithPublicValues,
+};
+
+use super::{BITMANIP_NUM_BITS, BITMANIP_NUM_LIMBS};
+
+pub(crate) const BITMANIP_OFFSET: usize = ShAddOpcode::CLASS_OFFSET;
+
+const fn local<const CLASS_OFFSET: usize>(opcode: usize) -> usize {
+    CLASS_OFFSET - BITMANIP_OFFSET + opcode
+}
+
+pub(crate) const SH1ADD: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::SH1ADD as usize);
+pub(crate) const SH2ADD: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::SH2ADD as usize);
+pub(crate) const SH3ADD: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::SH3ADD as usize);
+pub(crate) const ADD_UW: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::ADD_UW as usize);
+pub(crate) const SH1ADD_UW: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::SH1ADD_UW as usize);
+pub(crate) const SH2ADD_UW: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::SH2ADD_UW as usize);
+pub(crate) const SH3ADD_UW: usize =
+    local::<{ ShAddOpcode::CLASS_OFFSET }>(ShAddOpcode::SH3ADD_UW as usize);
+pub(crate) const SLLI_UW: usize =
+    local::<{ SlliUwOpcode::CLASS_OFFSET }>(SlliUwOpcode::SLLI_UW as usize);
+pub(crate) const ANDN: usize =
+    local::<{ BitwiseInvOpcode::CLASS_OFFSET }>(BitwiseInvOpcode::ANDN as usize);
+pub(crate) const ORN: usize =
+    local::<{ BitwiseInvOpcode::CLASS_OFFSET }>(BitwiseInvOpcode::ORN as usize);
+pub(crate) const XNOR: usize =
+    local::<{ BitwiseInvOpcode::CLASS_OFFSET }>(BitwiseInvOpcode::XNOR as usize);
+pub(crate) const ROL: usize = local::<{ RotateOpcode::CLASS_OFFSET }>(RotateOpcode::ROL as usize);
+pub(crate) const ROR: usize = local::<{ RotateOpcode::CLASS_OFFSET }>(RotateOpcode::ROR as usize);
+pub(crate) const RORI: usize =
+    local::<{ RotateImmOpcode::CLASS_OFFSET }>(RotateImmOpcode::RORI as usize);
+pub(crate) const ROLW: usize =
+    local::<{ RotateWOpcode::CLASS_OFFSET }>(RotateWOpcode::ROLW as usize);
+pub(crate) const RORW: usize =
+    local::<{ RotateWOpcode::CLASS_OFFSET }>(RotateWOpcode::RORW as usize);
+pub(crate) const RORIW: usize =
+    local::<{ RotateWImmOpcode::CLASS_OFFSET }>(RotateWImmOpcode::RORIW as usize);
+pub(crate) const CLZ: usize =
+    local::<{ CountZerosOpcode::CLASS_OFFSET }>(CountZerosOpcode::CLZ as usize);
+pub(crate) const CTZ: usize =
+    local::<{ CountZerosOpcode::CLASS_OFFSET }>(CountZerosOpcode::CTZ as usize);
+pub(crate) const CLZW: usize =
+    local::<{ CountZerosWOpcode::CLASS_OFFSET }>(CountZerosWOpcode::CLZW as usize);
+pub(crate) const CTZW: usize =
+    local::<{ CountZerosWOpcode::CLASS_OFFSET }>(CountZerosWOpcode::CTZW as usize);
+pub(crate) const CPOP: usize = local::<{ CpopOpcode::CLASS_OFFSET }>(CpopOpcode::CPOP as usize);
+pub(crate) const CPOPW: usize = local::<{ CpopWOpcode::CLASS_OFFSET }>(CpopWOpcode::CPOPW as usize);
+pub(crate) const MIN: usize = local::<{ MinMaxOpcode::CLASS_OFFSET }>(MinMaxOpcode::MIN as usize);
+pub(crate) const MINU: usize = local::<{ MinMaxOpcode::CLASS_OFFSET }>(MinMaxOpcode::MINU as usize);
+pub(crate) const MAX: usize = local::<{ MinMaxOpcode::CLASS_OFFSET }>(MinMaxOpcode::MAX as usize);
+pub(crate) const MAXU: usize = local::<{ MinMaxOpcode::CLASS_OFFSET }>(MinMaxOpcode::MAXU as usize);
+pub(crate) const SEXT_B: usize =
+    local::<{ ByteUnaryOpcode::CLASS_OFFSET }>(ByteUnaryOpcode::SEXT_B as usize);
+pub(crate) const SEXT_H: usize =
+    local::<{ ByteUnaryOpcode::CLASS_OFFSET }>(ByteUnaryOpcode::SEXT_H as usize);
+pub(crate) const ZEXT_H: usize =
+    local::<{ ByteUnaryOpcode::CLASS_OFFSET }>(ByteUnaryOpcode::ZEXT_H as usize);
+pub(crate) const ORC_B: usize =
+    local::<{ ByteUnaryOpcode::CLASS_OFFSET }>(ByteUnaryOpcode::ORC_B as usize);
+pub(crate) const REV8: usize =
+    local::<{ ByteUnaryOpcode::CLASS_OFFSET }>(ByteUnaryOpcode::REV8 as usize);
+pub(crate) const BCLR: usize =
+    local::<{ SingleBitOpcode::CLASS_OFFSET }>(SingleBitOpcode::BCLR as usize);
+pub(crate) const BSET: usize =
+    local::<{ SingleBitOpcode::CLASS_OFFSET }>(SingleBitOpcode::BSET as usize);
+pub(crate) const BINV: usize =
+    local::<{ SingleBitOpcode::CLASS_OFFSET }>(SingleBitOpcode::BINV as usize);
+pub(crate) const BEXT: usize =
+    local::<{ SingleBitOpcode::CLASS_OFFSET }>(SingleBitOpcode::BEXT as usize);
+pub(crate) const BCLRI: usize =
+    local::<{ SingleBitImmOpcode::CLASS_OFFSET }>(SingleBitImmOpcode::BCLRI as usize);
+pub(crate) const BSETI: usize =
+    local::<{ SingleBitImmOpcode::CLASS_OFFSET }>(SingleBitImmOpcode::BSETI as usize);
+pub(crate) const BINVI: usize =
+    local::<{ SingleBitImmOpcode::CLASS_OFFSET }>(SingleBitImmOpcode::BINVI as usize);
+pub(crate) const BEXTI: usize =
+    local::<{ SingleBitImmOpcode::CLASS_OFFSET }>(SingleBitImmOpcode::BEXTI as usize);
+
+const REG_OPS: [usize; REG_OP_COUNT] = [
+    SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW, ANDN, ORN, XNOR, ROL, ROR,
+    ROLW, RORW, MIN, MINU, MAX, MAXU, BCLR, BSET, BINV, BEXT,
+];
+const IMM_OPS: [usize; IMM_OP_COUNT] = [
+    SLLI_UW, RORI, RORIW, CLZ, CTZ, CLZW, CTZW, CPOP, CPOPW, SEXT_B, SEXT_H, ZEXT_H, ORC_B, REV8,
+    BCLRI, BSETI, BINVI, BEXTI,
+];
+
+pub(crate) const REG_OP_COUNT: usize = 22;
+pub(crate) const IMM_OP_COUNT: usize = 18;
+
+fn flag_pos(ops: &[usize], local_opcode: usize) -> usize {
+    ops.iter()
+        .position(|&op| op == local_opcode)
+        .unwrap_or_else(|| panic!("unsupported bitmanip local opcode {local_opcode}"))
+}
+
+pub(crate) fn is_reg_opcode(local_opcode: usize) -> bool {
+    REG_OPS.contains(&local_opcode)
+}
+
+pub(crate) fn is_imm_opcode(local_opcode: usize) -> bool {
+    IMM_OPS.contains(&local_opcode)
+}
+
+pub(crate) fn limbs_to_u64(limbs: &[u16; BITMANIP_NUM_LIMBS]) -> u64 {
+    limbs
+        .iter()
+        .enumerate()
+        .fold(0u64, |acc, (i, limb)| acc | ((*limb as u64) << (16 * i)))
+}
+
+pub(crate) fn u64_to_limbs(value: u64) -> [u16; BITMANIP_NUM_LIMBS] {
+    array::from_fn(|i| ((value >> (16 * i)) & 0xffff) as u16)
+}
+
+fn bits_u64(value: u64) -> [u8; BITMANIP_NUM_BITS] {
+    array::from_fn(|i| ((value >> i) & 1) as u8)
+}
+
+fn highest_diff_bit(x: u64, y: u64) -> Option<usize> {
+    let diff = x ^ y;
+    if diff == 0 {
+        None
+    } else {
+        Some(63 - diff.leading_zeros() as usize)
+    }
+}
+
+pub(crate) fn run_bitmanip_reg(local_opcode: usize, rs1: u64, rs2: u64) -> u64 {
+    match local_opcode {
+        SH1ADD => rs1.wrapping_shl(1).wrapping_add(rs2),
+        SH2ADD => rs1.wrapping_shl(2).wrapping_add(rs2),
+        SH3ADD => rs1.wrapping_shl(3).wrapping_add(rs2),
+        ADD_UW => (rs1 as u32 as u64).wrapping_add(rs2),
+        SH1ADD_UW => ((rs1 as u32 as u64) << 1).wrapping_add(rs2),
+        SH2ADD_UW => ((rs1 as u32 as u64) << 2).wrapping_add(rs2),
+        SH3ADD_UW => ((rs1 as u32 as u64) << 3).wrapping_add(rs2),
+        ANDN => rs1 & !rs2,
+        ORN => rs1 | !rs2,
+        XNOR => !(rs1 ^ rs2),
+        ROL => rs1.rotate_left((rs2 & 63) as u32),
+        ROR => rs1.rotate_right((rs2 & 63) as u32),
+        ROLW => {
+            let value = (rs1 as u32).rotate_left((rs2 & 31) as u32);
+            (value as i32 as i64) as u64
+        }
+        RORW => {
+            let value = (rs1 as u32).rotate_right((rs2 & 31) as u32);
+            (value as i32 as i64) as u64
+        }
+        MIN => (rs1 as i64).min(rs2 as i64) as u64,
+        MINU => rs1.min(rs2),
+        MAX => (rs1 as i64).max(rs2 as i64) as u64,
+        MAXU => rs1.max(rs2),
+        BCLR => rs1 & !(1u64 << (rs2 & 63)),
+        BSET => rs1 | (1u64 << (rs2 & 63)),
+        BINV => rs1 ^ (1u64 << (rs2 & 63)),
+        BEXT => (rs1 >> (rs2 & 63)) & 1,
+        _ => unreachable!("unsupported bitmanip register opcode {local_opcode}"),
+    }
+}
+
+pub(crate) fn run_bitmanip_imm(local_opcode: usize, rs1: u64, imm: u32) -> u64 {
+    match local_opcode {
+        SLLI_UW => (rs1 as u32 as u64) << imm,
+        RORI => rs1.rotate_right(imm),
+        RORIW => {
+            let value = (rs1 as u32).rotate_right(imm);
+            (value as i32 as i64) as u64
+        }
+        CLZ => rs1.leading_zeros() as u64,
+        CTZ => rs1.trailing_zeros() as u64,
+        CLZW => (rs1 as u32).leading_zeros() as u64,
+        CTZW => (rs1 as u32).trailing_zeros() as u64,
+        CPOP => rs1.count_ones() as u64,
+        CPOPW => (rs1 as u32).count_ones() as u64,
+        SEXT_B => (rs1 as u8 as i8 as i64) as u64,
+        SEXT_H => (rs1 as u16 as i16 as i64) as u64,
+        ZEXT_H => rs1 as u16 as u64,
+        ORC_B => {
+            let mut out = 0u64;
+            for i in 0..8 {
+                let byte = ((rs1 >> (8 * i)) & 0xff) as u8;
+                if byte != 0 {
+                    out |= 0xffu64 << (8 * i);
+                }
+            }
+            out
+        }
+        REV8 => rs1.swap_bytes(),
+        BCLRI => rs1 & !(1u64 << imm),
+        BSETI => rs1 | (1u64 << imm),
+        BINVI => rs1 ^ (1u64 << imm),
+        BEXTI => (rs1 >> imm) & 1,
+        _ => unreachable!("unsupported bitmanip immediate opcode {local_opcode}"),
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipRegCoreCols<T> {
+    pub a: [T; BITMANIP_NUM_LIMBS],
+    pub b: [T; BITMANIP_NUM_LIMBS],
+    pub c: [T; BITMANIP_NUM_LIMBS],
+    pub a_bits: [T; BITMANIP_NUM_BITS],
+    pub b_bits: [T; BITMANIP_NUM_BITS],
+    pub c_bits: [T; BITMANIP_NUM_BITS],
+    pub opcode_flags: [T; REG_OP_COUNT],
+    pub add_carry: [T; BITMANIP_NUM_BITS + 1],
+    pub index_marker: [T; BITMANIP_NUM_BITS],
+    pub minmax_lt: T,
+    pub minmax_diff_marker: [T; BITMANIP_NUM_BITS],
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipRegCoreCols<u8>)]
+pub struct BitManipRegCoreAir;
+
+impl<F: Field> BaseAir<F> for BitManipRegCoreAir {
+    fn width(&self) -> usize {
+        BitManipRegCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipRegCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipRegCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 2]>,
+    I::Writes: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<MinimalInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipRegCoreCols<_> = local_core.borrow();
+        let mut is_valid = AB::Expr::ZERO;
+        let mut expected_local_opcode = AB::Expr::ZERO;
+        for (flag, local_opcode) in cols.opcode_flags.iter().zip(REG_OPS) {
+            builder.assert_bool(*flag);
+            is_valid += (*flag).into();
+            expected_local_opcode += (*flag).into() * AB::Expr::from_usize(local_opcode);
+        }
+        builder.assert_bool(is_valid.clone());
+
+        constrain_bits_and_limbs(builder, is_valid.clone(), &cols.a_bits, &cols.a);
+        constrain_bits_and_limbs(builder, is_valid.clone(), &cols.b_bits, &cols.b);
+        constrain_bits_and_limbs(builder, is_valid.clone(), &cols.c_bits, &cols.c);
+
+        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
+        let shadd_valid = [
+            SH1ADD, SH2ADD, SH3ADD, ADD_UW, SH1ADD_UW, SH2ADD_UW, SH3ADD_UW,
+        ]
+        .into_iter()
+        .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let bitwise_valid = [ANDN, ORN, XNOR]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let rotate64_valid = [ROL, ROR]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let rotatew_valid = [ROLW, RORW]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let rotate_valid = rotate64_valid.clone() + rotatew_valid.clone();
+        let minmax_valid = [MIN, MINU, MAX, MAXU]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let single_valid = [BCLR, BSET, BINV, BEXT]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+
+        self.eval_shadd(builder, cols, shadd_valid.clone());
+        self.eval_bitwise_inv(builder, cols, bitwise_valid);
+        self.eval_index_markers(
+            builder,
+            cols,
+            rotate64_valid.clone() + single_valid.clone(),
+            rotatew_valid.clone(),
+        );
+        self.eval_rotate(builder, cols, rotate_valid);
+        self.eval_minmax(builder, cols, minmax_valid);
+        self.eval_single_bit(builder, cols, single_valid);
+
+        let expected_opcode = expected_local_opcode + AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: MinimalInstruction {
+                is_valid,
+                opcode: expected_opcode,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+impl BitManipRegCoreAir {
+    fn eval_shadd<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipRegCoreCols<AB::Var>,
+        shadd_valid: AB::Expr,
+    ) {
+        builder
+            .when(shadd_valid.clone())
+            .assert_zero(cols.add_carry[0]);
+        for carry in &cols.add_carry[1..] {
+            let carry: AB::Expr = (*carry).into();
+            builder.assert_zero(shadd_valid.clone() * carry.clone() * (AB::Expr::ONE - carry));
+        }
+
+        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
+        for i in 0..BITMANIP_NUM_BITS {
+            let shifted_bit = shifted_rs1_bit::<AB>(&cols.b_bits, i, 1, false) * flag(SH1ADD)
+                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 2, false) * flag(SH2ADD)
+                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 3, false) * flag(SH3ADD)
+                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 0, true) * flag(ADD_UW)
+                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 1, true) * flag(SH1ADD_UW)
+                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 2, true) * flag(SH2ADD_UW)
+                + shifted_rs1_bit::<AB>(&cols.b_bits, i, 3, true) * flag(SH3ADD_UW);
+            builder.assert_zero(
+                shadd_valid.clone()
+                    * (shifted_bit + cols.c_bits[i] + cols.add_carry[i]
+                        - cols.a_bits[i]
+                        - AB::Expr::from_u8(2) * cols.add_carry[i + 1]),
+            );
+        }
+    }
+
+    fn eval_bitwise_inv<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipRegCoreCols<AB::Var>,
+        bitwise_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
+        for i in 0..BITMANIP_NUM_BITS {
+            let b: AB::Expr = cols.b_bits[i].into();
+            let c: AB::Expr = cols.c_bits[i].into();
+            let a: AB::Expr = cols.a_bits[i].into();
+            let expected = flag(ANDN) * b.clone() * (AB::Expr::ONE - c.clone())
+                + flag(ORN) * (AB::Expr::ONE - (AB::Expr::ONE - b.clone()) * c.clone())
+                + flag(XNOR)
+                    * (AB::Expr::ONE - b.clone() - c.clone() + AB::Expr::from_u8(2) * b * c);
+            builder.assert_zero(bitwise_valid.clone() * a - expected);
+        }
+    }
+
+    fn eval_index_markers<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipRegCoreCols<AB::Var>,
+        full_index_valid: AB::Expr,
+        word_index_valid: AB::Expr,
+    ) {
+        let mut marker_sum = AB::Expr::ZERO;
+        let mut index = AB::Expr::ZERO;
+        for (i, marker) in cols.index_marker.iter().enumerate() {
+            builder.assert_bool(*marker);
+            marker_sum += (*marker).into();
+            index += (*marker).into() * AB::Expr::from_usize(i);
+        }
+        builder.assert_eq(
+            marker_sum,
+            full_index_valid.clone() + word_index_valid.clone(),
+        );
+
+        let c_low6 = (0..6).fold(AB::Expr::ZERO, |acc, i| {
+            acc + cols.c_bits[i] * AB::Expr::from_usize(1 << i)
+        });
+        let c_low5 = (0..5).fold(AB::Expr::ZERO, |acc, i| {
+            acc + cols.c_bits[i] * AB::Expr::from_usize(1 << i)
+        });
+        builder.assert_zero(full_index_valid * (index.clone() - c_low6));
+        builder.assert_zero(word_index_valid * (index - c_low5));
+    }
+
+    fn eval_rotate<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipRegCoreCols<AB::Var>,
+        rotate_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
+        for i in 0..BITMANIP_NUM_BITS {
+            let mut expected64 = AB::Expr::ZERO;
+            let mut expectedw = AB::Expr::ZERO;
+            for s in 0..BITMANIP_NUM_BITS {
+                let marker = cols.index_marker[s];
+                expected64 += flag(ROL)
+                    * marker
+                    * cols.b_bits[(i + BITMANIP_NUM_BITS - s) % BITMANIP_NUM_BITS];
+                expected64 += flag(ROR) * marker * cols.b_bits[(i + s) % BITMANIP_NUM_BITS];
+                let w_bit = if i < 32 { i } else { 31 };
+                expectedw += flag(ROLW) * marker * cols.b_bits[(w_bit + 32 - (s % 32)) % 32];
+                expectedw += flag(RORW) * marker * cols.b_bits[(w_bit + s) % 32];
+            }
+            builder.assert_zero(rotate_valid.clone() * cols.a_bits[i] - expected64 - expectedw);
+        }
+    }
+
+    fn eval_minmax<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipRegCoreCols<AB::Var>,
+        minmax_valid: AB::Expr,
+    ) {
+        let minmax_lt: AB::Expr = cols.minmax_lt.into();
+        builder.assert_zero(
+            minmax_valid.clone() * minmax_lt.clone() * (AB::Expr::ONE - minmax_lt.clone()),
+        );
+
+        let mut diff_marker_sum = AB::Expr::ZERO;
+        let mut prefix_sum = AB::Expr::ZERO;
+        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
+        let signed_flag = flag(MIN) + flag(MAX);
+        let unsigned_flag = flag(MINU) + flag(MAXU);
+        for i in (0..BITMANIP_NUM_BITS).rev() {
+            let marker = cols.minmax_diff_marker[i];
+            builder.assert_bool(marker);
+            let marker_expr: AB::Expr = marker.into();
+            diff_marker_sum += marker_expr.clone();
+            prefix_sum += marker_expr.clone();
+            let b: AB::Expr = cols.b_bits[i].into();
+            let c: AB::Expr = cols.c_bits[i].into();
+            builder.assert_zero(
+                minmax_valid.clone()
+                    * (AB::Expr::ONE - prefix_sum.clone())
+                    * (b.clone() - c.clone()),
+            );
+            builder.assert_zero(marker_expr.clone() * (b.clone() + c.clone() - AB::Expr::ONE));
+            let signed_here = if i == BITMANIP_NUM_BITS - 1 {
+                b
+            } else {
+                c.clone()
+            };
+            builder.assert_zero(
+                marker_expr.clone()
+                    * (signed_flag.clone() * (minmax_lt.clone() - signed_here)
+                        + unsigned_flag.clone() * (minmax_lt.clone() - c)),
+            );
+        }
+        builder.assert_bool(diff_marker_sum.clone());
+        builder.assert_zero((minmax_valid.clone() - diff_marker_sum.clone()) * minmax_lt.clone());
+        builder.assert_zero((AB::Expr::ONE - minmax_valid.clone()) * diff_marker_sum);
+
+        let min_flag = flag(MIN) + flag(MINU);
+        let max_flag = flag(MAX) + flag(MAXU);
+        for i in 0..BITMANIP_NUM_BITS {
+            let b: AB::Expr = cols.b_bits[i].into();
+            let c: AB::Expr = cols.c_bits[i].into();
+            let min_expected = c.clone() + minmax_lt.clone() * (b.clone() - c.clone());
+            let max_expected = b.clone() + minmax_lt.clone() * (c - b);
+            builder.assert_zero(
+                min_flag.clone() * (cols.a_bits[i] - min_expected)
+                    + max_flag.clone() * (cols.a_bits[i] - max_expected),
+            );
+        }
+    }
+
+    fn eval_single_bit<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipRegCoreCols<AB::Var>,
+        single_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&REG_OPS, op)];
+        let selected = (0..BITMANIP_NUM_BITS).fold(AB::Expr::ZERO, |acc, i| {
+            acc + cols.index_marker[i] * cols.b_bits[i]
+        });
+        for i in 0..BITMANIP_NUM_BITS {
+            let marker: AB::Expr = cols.index_marker[i].into();
+            let b: AB::Expr = cols.b_bits[i].into();
+            let expected = flag(BCLR) * b.clone() * (AB::Expr::ONE - marker.clone())
+                + flag(BSET) * (b.clone() + marker.clone() * (AB::Expr::ONE - b.clone()))
+                + flag(BINV) * (b.clone() + marker * (AB::Expr::ONE - AB::Expr::from_u8(2) * b))
+                + flag(BEXT)
+                    * if i == 0 {
+                        selected.clone()
+                    } else {
+                        AB::Expr::ZERO
+                    };
+            builder.assert_zero(single_valid.clone() * cols.a_bits[i] - expected);
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipRegCoreRecord {
+    pub b: [u16; BITMANIP_NUM_LIMBS],
+    pub c: [u16; BITMANIP_NUM_LIMBS],
+    pub local_opcode: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipRegExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipRegFiller<A> {
+    adapter: A,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipRegExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; BITMANIP_NUM_LIMBS]; 2]>,
+            WriteData: From<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipRegCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BReg({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_reg_opcode(local_opcode));
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b, core_record.c] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.local_opcode = local_opcode as u8;
+
+        let output = run_bitmanip_reg(
+            local_opcode,
+            limbs_to_u64(&core_record.b),
+            limbs_to_u64(&core_record.c),
+        );
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [u64_to_limbs(output)].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipRegFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipRegCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let c = record.c;
+        let local_opcode = record.local_opcode as usize;
+        let b_u64 = limbs_to_u64(&b);
+        let c_u64 = limbs_to_u64(&c);
+        let a_u64 = run_bitmanip_reg(local_opcode, b_u64, c_u64);
+        let a = u64_to_limbs(a_u64);
+        let b_bits = bits_u64(b_u64);
+        let c_bits = bits_u64(c_u64);
+        let a_bits = bits_u64(a_u64);
+
+        let core_row: &mut BitManipRegCoreCols<F> = core_row.borrow_mut();
+        core_row.opcode_flags = [F::ZERO; REG_OP_COUNT];
+        core_row.opcode_flags[flag_pos(&REG_OPS, local_opcode)] = F::ONE;
+        core_row.add_carry = [F::ZERO; BITMANIP_NUM_BITS + 1];
+        if matches!(
+            local_opcode,
+            SH1ADD | SH2ADD | SH3ADD | ADD_UW | SH1ADD_UW | SH2ADD_UW | SH3ADD_UW
+        ) {
+            fill_add_carries(core_row, local_opcode, b_u64, c_u64);
+        }
+        core_row.index_marker = [F::ZERO; BITMANIP_NUM_BITS];
+        if matches!(local_opcode, ROL | ROR | BCLR | BSET | BINV | BEXT) {
+            core_row.index_marker[(c_u64 & 63) as usize] = F::ONE;
+        } else if matches!(local_opcode, ROLW | RORW) {
+            core_row.index_marker[(c_u64 & 31) as usize] = F::ONE;
+        }
+        core_row.minmax_diff_marker = [F::ZERO; BITMANIP_NUM_BITS];
+        core_row.minmax_lt = F::ZERO;
+        if matches!(local_opcode, MIN | MINU | MAX | MAXU) {
+            let signed = matches!(local_opcode, MIN | MAX);
+            let lt = if signed {
+                (b_u64 as i64) < (c_u64 as i64)
+            } else {
+                b_u64 < c_u64
+            };
+            core_row.minmax_lt = F::from_bool(lt);
+            if let Some(idx) = highest_diff_bit(b_u64, c_u64) {
+                core_row.minmax_diff_marker[idx] = F::ONE;
+            }
+        }
+        core_row.a_bits = a_bits.map(F::from_u8);
+        core_row.b_bits = b_bits.map(F::from_u8);
+        core_row.c_bits = c_bits.map(F::from_u8);
+        core_row.a = a.map(F::from_u16);
+        core_row.b = b.map(F::from_u16);
+        core_row.c = c.map(F::from_u16);
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipImmCoreCols<T> {
+    pub a: [T; BITMANIP_NUM_LIMBS],
+    pub b: [T; BITMANIP_NUM_LIMBS],
+    pub a_bits: [T; BITMANIP_NUM_BITS],
+    pub b_bits: [T; BITMANIP_NUM_BITS],
+    pub opcode_flags: [T; IMM_OP_COUNT],
+    pub index_marker: [T; BITMANIP_NUM_BITS],
+    pub count_marker: [T; BITMANIP_NUM_BITS + 1],
+    pub byte_nonzero: [T; 8],
+    pub byte_nonzero_inv: [T; 8],
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipImmCoreCols<u8>)]
+pub struct BitManipImmCoreAir;
+
+impl<F: Field> BaseAir<F> for BitManipImmCoreAir {
+    fn width(&self) -> usize {
+        BitManipImmCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipImmCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipImmCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::Writes: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<ImmInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipImmCoreCols<_> = local_core.borrow();
+        let mut is_valid = AB::Expr::ZERO;
+        let mut expected_local_opcode = AB::Expr::ZERO;
+        for (flag, local_opcode) in cols.opcode_flags.iter().zip(IMM_OPS) {
+            builder.assert_bool(*flag);
+            is_valid += (*flag).into();
+            expected_local_opcode += (*flag).into() * AB::Expr::from_usize(local_opcode);
+        }
+        builder.assert_bool(is_valid.clone());
+
+        constrain_bits_and_limbs(builder, is_valid.clone(), &cols.a_bits, &cols.a);
+        constrain_bits_and_limbs(builder, is_valid.clone(), &cols.b_bits, &cols.b);
+
+        let flag = |op| cols.opcode_flags[flag_pos(&IMM_OPS, op)];
+        let index_valid = [SLLI_UW, RORI, RORIW, BCLRI, BSETI, BINVI, BEXTI]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let count_valid = [CLZ, CTZ, CLZW, CTZW]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let cpop_valid = flag(CPOP) + flag(CPOPW);
+        let byte_valid = [SEXT_B, SEXT_H, ZEXT_H, ORC_B, REV8]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+        let single_valid = [BCLRI, BSETI, BINVI, BEXTI]
+            .into_iter()
+            .fold(AB::Expr::ZERO, |acc, op| acc + flag(op));
+
+        let immediate = self.eval_index_markers(builder, cols, index_valid.clone());
+        self.eval_slli_uw(builder, cols, flag(SLLI_UW));
+        self.eval_rori(builder, cols, flag(RORI), flag(RORIW));
+        self.eval_count_zeros(builder, cols, count_valid);
+        self.eval_cpop(builder, cols, cpop_valid);
+        self.eval_byte_unary(builder, cols, byte_valid);
+        self.eval_single_bit_imm(builder, cols, single_valid);
+
+        let expected_opcode = expected_local_opcode + AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: ImmInstruction {
+                is_valid,
+                opcode: expected_opcode,
+                immediate,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+impl BitManipImmCoreAir {
+    fn eval_index_markers<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        index_valid: AB::Expr,
+    ) -> AB::Expr {
+        let mut marker_sum = AB::Expr::ZERO;
+        let mut index = AB::Expr::ZERO;
+        for (i, marker) in cols.index_marker.iter().enumerate() {
+            builder.assert_bool(*marker);
+            marker_sum += (*marker).into();
+            index += (*marker).into() * AB::Expr::from_usize(i);
+        }
+        builder.assert_eq(marker_sum, index_valid);
+        index
+    }
+
+    fn eval_slli_uw<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        slli_flag: AB::Var,
+    ) {
+        for i in 0..BITMANIP_NUM_BITS {
+            let mut expected = AB::Expr::ZERO;
+            for s in 0..BITMANIP_NUM_BITS {
+                if i >= s && i - s < 32 {
+                    expected += slli_flag * cols.index_marker[s] * cols.b_bits[i - s];
+                }
+            }
+            builder.assert_zero(slli_flag * cols.a_bits[i] - expected);
+        }
+    }
+
+    fn eval_rori<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        rori_flag: AB::Var,
+        roriw_flag: AB::Var,
+    ) {
+        let rotate_valid: AB::Expr = rori_flag.into() + roriw_flag.into();
+        for i in 0..BITMANIP_NUM_BITS {
+            let mut expected64 = AB::Expr::ZERO;
+            let mut expectedw = AB::Expr::ZERO;
+            for s in 0..BITMANIP_NUM_BITS {
+                expected64 += rori_flag * cols.index_marker[s] * cols.b_bits[(i + s) % 64];
+                let w_bit = if i < 32 { i } else { 31 };
+                expectedw += roriw_flag * cols.index_marker[s] * cols.b_bits[(w_bit + s) % 32];
+            }
+            builder.assert_zero(rotate_valid.clone() * cols.a_bits[i] - expected64 - expectedw);
+        }
+    }
+
+    fn eval_count_zeros<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        count_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&IMM_OPS, op)];
+        let clz64 = flag(CLZ);
+        let ctz64 = flag(CTZ);
+        let clz32 = flag(CLZW);
+        let ctz32 = flag(CTZW);
+        let mut marker_sum = AB::Expr::ZERO;
+        let mut count_value = AB::Expr::ZERO;
+        for (k, marker) in cols.count_marker.iter().enumerate() {
+            builder.assert_bool(*marker);
+            let marker_expr: AB::Expr = (*marker).into();
+            marker_sum += marker_expr.clone();
+            count_value += marker_expr.clone() * AB::Expr::from_usize(k);
+            if k > 32 {
+                builder.assert_zero((clz32 + ctz32) * marker_expr.clone());
+            }
+            constrain_clz_marker(builder, &cols.b_bits, marker_expr.clone() * clz64, k, 64);
+            constrain_ctz_marker(builder, &cols.b_bits, marker_expr.clone() * ctz64, k, 64);
+            if k <= 32 {
+                constrain_clz_marker(builder, &cols.b_bits, marker_expr.clone() * clz32, k, 32);
+                constrain_ctz_marker(builder, &cols.b_bits, marker_expr * ctz32, k, 32);
+            }
+        }
+        builder.assert_eq(marker_sum, count_valid.clone());
+        builder.assert_zero(count_valid.clone() * (cols.a[0] - count_value));
+        for limb in cols.a.iter().skip(1) {
+            builder.assert_zero(count_valid.clone() * *limb);
+        }
+    }
+
+    fn eval_cpop<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        cpop_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&IMM_OPS, op)];
+        let sum64 = cols
+            .b_bits
+            .iter()
+            .fold(AB::Expr::ZERO, |acc, bit| acc + *bit);
+        let sum32 = cols.b_bits[..32]
+            .iter()
+            .fold(AB::Expr::ZERO, |acc, bit| acc + *bit);
+        let value = flag(CPOP) * sum64 + flag(CPOPW) * sum32;
+        builder.assert_zero(cpop_valid.clone() * (cols.a[0] - value));
+        for limb in cols.a.iter().skip(1) {
+            builder.assert_zero(cpop_valid.clone() * *limb);
+        }
+    }
+
+    fn eval_byte_unary<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        byte_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&IMM_OPS, op)];
+        for byte in 0..8 {
+            builder.assert_bool(cols.byte_nonzero[byte]);
+            let sum = (0..8).fold(AB::Expr::ZERO, |acc, bit| acc + cols.b_bits[byte * 8 + bit]);
+            builder.assert_zero(
+                flag(ORC_B) * (sum.clone() * cols.byte_nonzero_inv[byte] - cols.byte_nonzero[byte]),
+            );
+            builder.assert_zero(
+                flag(ORC_B) * sum * (AB::Expr::ONE - AB::Expr::from(cols.byte_nonzero[byte])),
+            );
+        }
+        for i in 0..BITMANIP_NUM_BITS {
+            let expected = flag(SEXT_B)
+                * if i < 8 {
+                    cols.b_bits[i].into()
+                } else {
+                    cols.b_bits[7].into()
+                }
+                + flag(SEXT_H)
+                    * if i < 16 {
+                        cols.b_bits[i].into()
+                    } else {
+                        cols.b_bits[15].into()
+                    }
+                + flag(ZEXT_H)
+                    * if i < 16 {
+                        cols.b_bits[i].into()
+                    } else {
+                        AB::Expr::ZERO
+                    }
+                + flag(ORC_B) * cols.byte_nonzero[i / 8]
+                + flag(REV8) * cols.b_bits[(7 - (i / 8)) * 8 + (i % 8)];
+            builder.assert_zero(byte_valid.clone() * cols.a_bits[i] - expected);
+        }
+    }
+
+    fn eval_single_bit_imm<AB: InteractionBuilder>(
+        &self,
+        builder: &mut AB,
+        cols: &BitManipImmCoreCols<AB::Var>,
+        single_valid: AB::Expr,
+    ) {
+        let flag = |op| cols.opcode_flags[flag_pos(&IMM_OPS, op)];
+        let selected = (0..BITMANIP_NUM_BITS).fold(AB::Expr::ZERO, |acc, i| {
+            acc + cols.index_marker[i] * cols.b_bits[i]
+        });
+        for i in 0..BITMANIP_NUM_BITS {
+            let marker: AB::Expr = cols.index_marker[i].into();
+            let b: AB::Expr = cols.b_bits[i].into();
+            let expected = flag(BCLRI) * b.clone() * (AB::Expr::ONE - marker.clone())
+                + flag(BSETI) * (b.clone() + marker.clone() * (AB::Expr::ONE - b.clone()))
+                + flag(BINVI) * (b.clone() + marker * (AB::Expr::ONE - AB::Expr::from_u8(2) * b))
+                + flag(BEXTI)
+                    * if i == 0 {
+                        selected.clone()
+                    } else {
+                        AB::Expr::ZERO
+                    };
+            builder.assert_zero(single_valid.clone() * cols.a_bits[i] - expected);
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipImmCoreRecord {
+    pub b: [u16; BITMANIP_NUM_LIMBS],
+    pub imm: u8,
+    pub local_opcode: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipImmExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipImmFiller<A> {
+    adapter: A,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipImmExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+            WriteData: From<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipImmCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BImm({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_imm_opcode(local_opcode));
+        let imm = instruction.c.as_canonical_u32();
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.imm = imm as u8;
+        core_record.local_opcode = local_opcode as u8;
+
+        let output = run_bitmanip_imm(local_opcode, limbs_to_u64(&core_record.b), imm);
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [u64_to_limbs(output)].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipImmFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipImmCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let imm = record.imm as u32;
+        let local_opcode = record.local_opcode as usize;
+        let b_u64 = limbs_to_u64(&b);
+        let a_u64 = run_bitmanip_imm(local_opcode, b_u64, imm);
+        let a = u64_to_limbs(a_u64);
+        let b_bits = bits_u64(b_u64);
+        let a_bits = bits_u64(a_u64);
+
+        let core_row: &mut BitManipImmCoreCols<F> = core_row.borrow_mut();
+        core_row.opcode_flags = [F::ZERO; IMM_OP_COUNT];
+        core_row.opcode_flags[flag_pos(&IMM_OPS, local_opcode)] = F::ONE;
+        core_row.index_marker = [F::ZERO; BITMANIP_NUM_BITS];
+        if matches!(
+            local_opcode,
+            SLLI_UW | RORI | RORIW | BCLRI | BSETI | BINVI | BEXTI
+        ) {
+            core_row.index_marker[imm as usize] = F::ONE;
+        }
+        core_row.count_marker = [F::ZERO; BITMANIP_NUM_BITS + 1];
+        if matches!(local_opcode, CLZ | CTZ | CLZW | CTZW) {
+            core_row.count_marker[a_u64 as usize] = F::ONE;
+        }
+        core_row.byte_nonzero = [F::ZERO; 8];
+        core_row.byte_nonzero_inv = [F::ZERO; 8];
+        if local_opcode == ORC_B {
+            for byte in 0..8 {
+                let count = b_bits[byte * 8..byte * 8 + 8]
+                    .iter()
+                    .map(|bit| *bit as u32)
+                    .sum::<u32>();
+                if count != 0 {
+                    core_row.byte_nonzero[byte] = F::ONE;
+                    core_row.byte_nonzero_inv[byte] = F::from_u32(count).inverse();
+                }
+            }
+        }
+        core_row.a_bits = a_bits.map(F::from_u8);
+        core_row.b_bits = b_bits.map(F::from_u8);
+        core_row.a = a.map(F::from_u16);
+        core_row.b = b.map(F::from_u16);
+    }
+}
+
+fn constrain_bits_and_limbs<AB: InteractionBuilder>(
+    builder: &mut AB,
+    is_valid: AB::Expr,
+    bits: &[AB::Var; BITMANIP_NUM_BITS],
+    limbs: &[AB::Var; BITMANIP_NUM_LIMBS],
+) {
+    for bit in bits {
+        let bit_expr: AB::Expr = (*bit).into();
+        builder.assert_zero(is_valid.clone() * bit_expr.clone() * (AB::Expr::ONE - bit_expr));
+    }
+    for limb in 0..BITMANIP_NUM_LIMBS {
+        let value = (0..16).fold(AB::Expr::ZERO, |acc, bit| {
+            acc + bits[16 * limb + bit] * AB::Expr::from_usize(1 << bit)
+        });
+        builder.assert_zero(is_valid.clone() * (limbs[limb] - value));
+    }
+}
+
+fn shifted_rs1_bit<AB: InteractionBuilder>(
+    bits: &[AB::Var; BITMANIP_NUM_BITS],
+    out_idx: usize,
+    shift: usize,
+    uw: bool,
+) -> AB::Expr {
+    if out_idx >= shift {
+        let in_idx = out_idx - shift;
+        if in_idx < if uw { 32 } else { BITMANIP_NUM_BITS } {
+            bits[in_idx].into()
+        } else {
+            AB::Expr::ZERO
+        }
+    } else {
+        AB::Expr::ZERO
+    }
+}
+
+fn fill_add_carries<F: PrimeField32>(
+    row: &mut BitManipRegCoreCols<F>,
+    local_opcode: usize,
+    rs1: u64,
+    rs2: u64,
+) {
+    let (shift, uw) = match local_opcode {
+        SH1ADD => (1, false),
+        SH2ADD => (2, false),
+        SH3ADD => (3, false),
+        ADD_UW => (0, true),
+        SH1ADD_UW => (1, true),
+        SH2ADD_UW => (2, true),
+        SH3ADD_UW => (3, true),
+        _ => unreachable!(),
+    };
+    let shifted = if uw {
+        (rs1 as u32 as u64) << shift
+    } else {
+        rs1.wrapping_shl(shift)
+    };
+    let mut carry = 0u8;
+    row.add_carry[0] = F::ZERO;
+    for i in 0..BITMANIP_NUM_BITS {
+        let total = ((shifted >> i) & 1) as u8 + ((rs2 >> i) & 1) as u8 + carry;
+        carry = total >> 1;
+        row.add_carry[i + 1] = F::from_u8(carry);
+    }
+}
+
+fn constrain_clz_marker<AB: InteractionBuilder>(
+    builder: &mut AB,
+    bits: &[AB::Var; BITMANIP_NUM_BITS],
+    active_marker: AB::Expr,
+    count: usize,
+    width: usize,
+) {
+    if count == width {
+        for bit in bits.iter().take(width) {
+            builder.assert_zero(active_marker.clone() * *bit);
+        }
+    } else if count < width {
+        for bit in bits.iter().take(width).skip(width - count) {
+            builder.assert_zero(active_marker.clone() * *bit);
+        }
+        builder.assert_zero(active_marker * (bits[width - count - 1] - AB::Expr::ONE));
+    }
+}
+
+fn constrain_ctz_marker<AB: InteractionBuilder>(
+    builder: &mut AB,
+    bits: &[AB::Var; BITMANIP_NUM_BITS],
+    active_marker: AB::Expr,
+    count: usize,
+    width: usize,
+) {
+    if count == width {
+        for bit in bits.iter().take(width) {
+            builder.assert_zero(active_marker.clone() * *bit);
+        }
+    } else if count < width {
+        for bit in bits.iter().take(count) {
+            builder.assert_zero(active_marker.clone() * *bit);
+        }
+        builder.assert_zero(active_marker * (bits[count] - AB::Expr::ONE));
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/cuda.rs
+++ b/extensions/riscv/circuit/src/bitmanip/cuda.rs
@@ -10,20 +10,21 @@ use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use super::{
-    BitManipBitwiseInvCoreCols, BitManipBitwiseInvCoreRecord, BitManipImmCoreCols,
-    BitManipImmCoreRecord, BitManipMinMaxCoreCols, BitManipMinMaxCoreRecord, BitManipRegCoreCols,
-    BitManipRegCoreRecord, BitManipShAddCoreCols, BitManipShAddCoreRecord, BitManipSlliUwCoreCols,
+    BitManipBitwiseInvCoreCols, BitManipBitwiseInvCoreRecord, BitManipByteUnaryCoreCols,
+    BitManipByteUnaryCoreRecord, BitManipImmCoreCols, BitManipImmCoreRecord,
+    BitManipMinMaxCoreCols, BitManipMinMaxCoreRecord, BitManipRegCoreCols, BitManipRegCoreRecord,
+    BitManipShAddCoreCols, BitManipShAddCoreRecord, BitManipSlliUwCoreCols,
     BitManipSlliUwCoreRecord,
 };
 use crate::{
     adapters::{
-        Rv64BaseAluImmU16AdapterCols, Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegAdapterCols,
-        Rv64BaseAluRegAdapterRecord, Rv64BaseAluRegU16AdapterCols, Rv64BaseAluRegU16AdapterRecord,
-        RV64_BYTE_BITS,
+        Rv64BaseAluImmAdapterCols, Rv64BaseAluImmAdapterRecord, Rv64BaseAluImmU16AdapterCols,
+        Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegAdapterCols, Rv64BaseAluRegAdapterRecord,
+        Rv64BaseAluRegU16AdapterCols, Rv64BaseAluRegU16AdapterRecord, RV64_BYTE_BITS,
     },
     cuda_abi::{
-        bitmanip_bitwise_inv_cuda, bitmanip_imm_cuda, bitmanip_min_max_cuda, bitmanip_reg_cuda,
-        bitmanip_shadd_cuda, bitmanip_slli_uw_cuda,
+        bitmanip_bitwise_inv_cuda, bitmanip_byte_unary_cuda, bitmanip_imm_cuda,
+        bitmanip_min_max_cuda, bitmanip_reg_cuda, bitmanip_shadd_cuda, bitmanip_slli_uw_cuda,
     },
 };
 
@@ -140,6 +141,50 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipBitwiseInvChipGpu {
 
         unsafe {
             bitmanip_bitwise_inv_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                &self.bitwise_lookup.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}
+
+#[derive(new)]
+pub struct Rv64BitManipByteUnaryChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV64_BYTE_BITS>>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipByteUnaryChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluImmAdapterRecord, BitManipByteUnaryCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluImmAdapterCols::<F>::width() + BitManipByteUnaryCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_byte_unary_cuda::tracegen(
                 d_trace.buffer(),
                 trace_height,
                 &d_records,

--- a/extensions/riscv/circuit/src/bitmanip/cuda.rs
+++ b/extensions/riscv/circuit/src/bitmanip/cuda.rs
@@ -1,0 +1,103 @@
+use std::{mem::size_of, sync::Arc};
+
+use derive_new::new;
+use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
+use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
+use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
+use openvm_cuda_common::copy::MemCopyH2D;
+use openvm_stark_backend::prover::AirProvingContext;
+
+use super::{
+    BitManipImmCoreCols, BitManipImmCoreRecord, BitManipRegCoreCols, BitManipRegCoreRecord,
+};
+use crate::{
+    adapters::{
+        Rv64BaseAluImmU16AdapterCols, Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegU16AdapterCols,
+        Rv64BaseAluRegU16AdapterRecord,
+    },
+    cuda_abi::{bitmanip_imm_cuda, bitmanip_reg_cuda},
+};
+
+#[derive(new)]
+pub struct Rv64BitManipRegChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipRegChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluRegU16AdapterRecord, BitManipRegCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluRegU16AdapterCols::<F>::width() + BitManipRegCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_reg_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}
+
+#[derive(new)]
+pub struct Rv64BitManipImmChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipImmChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluImmU16AdapterRecord, BitManipImmCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluImmU16AdapterCols::<F>::width() + BitManipImmCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_imm_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/cuda.rs
+++ b/extensions/riscv/circuit/src/bitmanip/cuda.rs
@@ -2,22 +2,29 @@ use std::{mem::size_of, sync::Arc};
 
 use derive_new::new;
 use openvm_circuit::{arch::DenseRecordArena, utils::next_power_of_two_or_zero};
-use openvm_circuit_primitives::{var_range::VariableRangeCheckerChipGPU, Chip};
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::BitwiseOperationLookupChipGPU, var_range::VariableRangeCheckerChipGPU, Chip,
+};
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
 use openvm_cuda_common::copy::MemCopyH2D;
 use openvm_stark_backend::prover::AirProvingContext;
 
 use super::{
-    BitManipImmCoreCols, BitManipImmCoreRecord, BitManipRegCoreCols, BitManipRegCoreRecord,
-    BitManipShAddCoreCols, BitManipShAddCoreRecord, BitManipSlliUwCoreCols,
+    BitManipBitwiseInvCoreCols, BitManipBitwiseInvCoreRecord, BitManipImmCoreCols,
+    BitManipImmCoreRecord, BitManipMinMaxCoreCols, BitManipMinMaxCoreRecord, BitManipRegCoreCols,
+    BitManipRegCoreRecord, BitManipShAddCoreCols, BitManipShAddCoreRecord, BitManipSlliUwCoreCols,
     BitManipSlliUwCoreRecord,
 };
 use crate::{
     adapters::{
-        Rv64BaseAluImmU16AdapterCols, Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegU16AdapterCols,
-        Rv64BaseAluRegU16AdapterRecord,
+        Rv64BaseAluImmU16AdapterCols, Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegAdapterCols,
+        Rv64BaseAluRegAdapterRecord, Rv64BaseAluRegU16AdapterCols, Rv64BaseAluRegU16AdapterRecord,
+        RV64_BYTE_BITS,
     },
-    cuda_abi::{bitmanip_imm_cuda, bitmanip_reg_cuda, bitmanip_shadd_cuda, bitmanip_slli_uw_cuda},
+    cuda_abi::{
+        bitmanip_bitwise_inv_cuda, bitmanip_imm_cuda, bitmanip_min_max_cuda, bitmanip_reg_cuda,
+        bitmanip_shadd_cuda, bitmanip_slli_uw_cuda,
+    },
 };
 
 #[derive(new)]
@@ -90,6 +97,92 @@ impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipSlliUwChipGpu {
 
         unsafe {
             bitmanip_slli_uw_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}
+
+#[derive(new)]
+pub struct Rv64BitManipBitwiseInvChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub bitwise_lookup: Arc<BitwiseOperationLookupChipGPU<RV64_BYTE_BITS>>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipBitwiseInvChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluRegAdapterRecord, BitManipBitwiseInvCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluRegAdapterCols::<F>::width() + BitManipBitwiseInvCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_bitwise_inv_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                &self.bitwise_lookup.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}
+
+#[derive(new)]
+pub struct Rv64BitManipMinMaxChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipMinMaxChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluRegU16AdapterRecord, BitManipMinMaxCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluRegU16AdapterCols::<F>::width() + BitManipMinMaxCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_min_max_cuda::tracegen(
                 d_trace.buffer(),
                 trace_height,
                 &d_records,

--- a/extensions/riscv/circuit/src/bitmanip/cuda.rs
+++ b/extensions/riscv/circuit/src/bitmanip/cuda.rs
@@ -9,14 +9,100 @@ use openvm_stark_backend::prover::AirProvingContext;
 
 use super::{
     BitManipImmCoreCols, BitManipImmCoreRecord, BitManipRegCoreCols, BitManipRegCoreRecord,
+    BitManipShAddCoreCols, BitManipShAddCoreRecord, BitManipSlliUwCoreCols,
+    BitManipSlliUwCoreRecord,
 };
 use crate::{
     adapters::{
         Rv64BaseAluImmU16AdapterCols, Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegU16AdapterCols,
         Rv64BaseAluRegU16AdapterRecord,
     },
-    cuda_abi::{bitmanip_imm_cuda, bitmanip_reg_cuda},
+    cuda_abi::{bitmanip_imm_cuda, bitmanip_reg_cuda, bitmanip_shadd_cuda, bitmanip_slli_uw_cuda},
 };
+
+#[derive(new)]
+pub struct Rv64BitManipShAddChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipShAddChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluRegU16AdapterRecord, BitManipShAddCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluRegU16AdapterCols::<F>::width() + BitManipShAddCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_shadd_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}
+
+#[derive(new)]
+pub struct Rv64BitManipSlliUwChipGpu {
+    pub range_checker: Arc<VariableRangeCheckerChipGPU>,
+    pub timestamp_max_bits: usize,
+}
+
+impl Chip<DenseRecordArena, GpuBackend> for Rv64BitManipSlliUwChipGpu {
+    fn generate_proving_ctx(&self, arena: DenseRecordArena) -> AirProvingContext<GpuBackend> {
+        const RECORD_SIZE: usize =
+            size_of::<(Rv64BaseAluImmU16AdapterRecord, BitManipSlliUwCoreRecord)>();
+        let records = arena.allocated();
+        if records.is_empty() {
+            return AirProvingContext::simple_no_pis(DeviceMatrix::dummy());
+        }
+        debug_assert_eq!(records.len() % RECORD_SIZE, 0);
+
+        let trace_width =
+            Rv64BaseAluImmU16AdapterCols::<F>::width() + BitManipSlliUwCoreCols::<F>::width();
+        let trace_height = next_power_of_two_or_zero(records.len() / RECORD_SIZE);
+        let device_ctx = &self.range_checker.device_ctx;
+
+        let d_records = tracing::info_span!("trace_gen.h2d_records")
+            .in_scope(|| records.to_device_on(device_ctx))
+            .unwrap();
+        let d_trace = DeviceMatrix::<F>::with_capacity_on(trace_height, trace_width, device_ctx);
+
+        unsafe {
+            bitmanip_slli_uw_cuda::tracegen(
+                d_trace.buffer(),
+                trace_height,
+                &d_records,
+                &self.range_checker.count,
+                self.timestamp_max_bits as u32,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+        }
+
+        AirProvingContext::simple_no_pis(d_trace)
+    }
+}
 
 #[derive(new)]
 pub struct Rv64BitManipRegChipGpu {

--- a/extensions/riscv/circuit/src/bitmanip/execution.rs
+++ b/extensions/riscv/circuit/src/bitmanip/execution.rs
@@ -1,0 +1,366 @@
+use std::{
+    borrow::{Borrow, BorrowMut},
+    mem::size_of,
+};
+
+use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
+use openvm_circuit_primitives_derive::AlignedBytesBorrow;
+use openvm_instructions::{
+    instruction::Instruction,
+    program::DEFAULT_PC_STEP,
+    riscv::{RV64_IMM_AS, RV64_REGISTER_AS, RV64_REGISTER_NUM_LIMBS},
+};
+use openvm_stark_backend::p3_field::PrimeField32;
+
+use super::{
+    core::{is_imm_opcode, is_reg_opcode, run_bitmanip_imm, run_bitmanip_reg, BITMANIP_OFFSET},
+    BitManipImmExecutor, BitManipRegExecutor,
+};
+
+#[derive(AlignedBytesBorrow, Clone)]
+#[repr(C)]
+struct BitManipRegPreCompute {
+    rs2_ptr: u8,
+    rd_ptr: u8,
+    rs1_ptr: u8,
+    local_opcode: u8,
+}
+
+impl<A> BitManipRegExecutor<A> {
+    #[inline(always)]
+    fn pre_compute_impl<F: PrimeField32>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut BitManipRegPreCompute,
+    ) -> Result<(), StaticProgramError> {
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c,
+            d,
+            e,
+            ..
+        } = inst;
+        if d.as_canonical_u32() != RV64_REGISTER_AS || e.as_canonical_u32() != RV64_REGISTER_AS {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        let local_opcode = opcode.local_opcode_idx(BITMANIP_OFFSET);
+        if !is_reg_opcode(local_opcode) {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        *data = BitManipRegPreCompute {
+            rs2_ptr: c.as_canonical_u32() as u8,
+            rd_ptr: a.as_canonical_u32() as u8,
+            rs1_ptr: b.as_canonical_u32() as u8,
+            local_opcode: local_opcode as u8,
+        };
+        Ok(())
+    }
+}
+
+impl<F, A> InterpreterExecutor<F> for BitManipRegExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn pre_compute_size(&self) -> usize {
+        size_of::<BitManipRegPreCompute>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn pre_compute<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipRegPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_reg_e1_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn handler<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipRegPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_reg_e1_handler)
+    }
+}
+
+impl<F, A> InterpreterMeteredExecutor<F> for BitManipRegExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn metered_pre_compute_size(&self) -> usize {
+        size_of::<E2PreCompute<BitManipRegPreCompute>>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn metered_pre_compute<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipRegPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_reg_e2_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn metered_handler<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipRegPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_reg_e2_handler)
+    }
+}
+
+#[inline(always)]
+unsafe fn execute_reg_e12_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: &BitManipRegPreCompute,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let rs1 = exec_state
+        .vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.rs1_ptr as u32);
+    let rs2 = exec_state
+        .vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.rs2_ptr as u32);
+    let rd = run_bitmanip_reg(
+        pre_compute.local_opcode as usize,
+        u64::from_le_bytes(rs1),
+        u64::from_le_bytes(rs2),
+    )
+    .to_le_bytes();
+    exec_state.vm_write_bytes(RV64_REGISTER_AS, pre_compute.rd_ptr as u32, &rd);
+    let pc = exec_state.pc();
+    exec_state.set_pc(pc.wrapping_add(DEFAULT_PC_STEP));
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_reg_e1_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &BitManipRegPreCompute =
+        std::slice::from_raw_parts(pre_compute, size_of::<BitManipRegPreCompute>()).borrow();
+    execute_reg_e12_impl::<CTX>(pre_compute, exec_state);
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_reg_e2_impl<CTX: MeteredExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &E2PreCompute<BitManipRegPreCompute> = std::slice::from_raw_parts(
+        pre_compute,
+        size_of::<E2PreCompute<BitManipRegPreCompute>>(),
+    )
+    .borrow();
+    exec_state
+        .ctx
+        .on_height_change(pre_compute.chip_idx as usize, 1);
+    execute_reg_e12_impl::<CTX>(&pre_compute.data, exec_state);
+}
+
+#[derive(AlignedBytesBorrow, Clone)]
+#[repr(C)]
+struct BitManipImmPreCompute {
+    imm: u8,
+    rd_ptr: u8,
+    rs1_ptr: u8,
+    local_opcode: u8,
+}
+
+impl<A> BitManipImmExecutor<A> {
+    #[inline(always)]
+    fn pre_compute_impl<F: PrimeField32>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut BitManipImmPreCompute,
+    ) -> Result<(), StaticProgramError> {
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c,
+            d,
+            e,
+            ..
+        } = inst;
+        if d.as_canonical_u32() != RV64_REGISTER_AS || e.as_canonical_u32() != RV64_IMM_AS {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        let local_opcode = opcode.local_opcode_idx(BITMANIP_OFFSET);
+        if !is_imm_opcode(local_opcode) {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        *data = BitManipImmPreCompute {
+            imm: c.as_canonical_u32() as u8,
+            rd_ptr: a.as_canonical_u32() as u8,
+            rs1_ptr: b.as_canonical_u32() as u8,
+            local_opcode: local_opcode as u8,
+        };
+        Ok(())
+    }
+}
+
+impl<F, A> InterpreterExecutor<F> for BitManipImmExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn pre_compute_size(&self) -> usize {
+        size_of::<BitManipImmPreCompute>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn pre_compute<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipImmPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_imm_e1_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn handler<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipImmPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_imm_e1_handler)
+    }
+}
+
+impl<F, A> InterpreterMeteredExecutor<F> for BitManipImmExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn metered_pre_compute_size(&self) -> usize {
+        size_of::<E2PreCompute<BitManipImmPreCompute>>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn metered_pre_compute<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipImmPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_imm_e2_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn metered_handler<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipImmPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_imm_e2_handler)
+    }
+}
+
+#[inline(always)]
+unsafe fn execute_imm_e12_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: &BitManipImmPreCompute,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let rs1 = exec_state
+        .vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.rs1_ptr as u32);
+    let rd = run_bitmanip_imm(
+        pre_compute.local_opcode as usize,
+        u64::from_le_bytes(rs1),
+        pre_compute.imm as u32,
+    )
+    .to_le_bytes();
+    exec_state.vm_write_bytes(RV64_REGISTER_AS, pre_compute.rd_ptr as u32, &rd);
+    let pc = exec_state.pc();
+    exec_state.set_pc(pc.wrapping_add(DEFAULT_PC_STEP));
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_imm_e1_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &BitManipImmPreCompute =
+        std::slice::from_raw_parts(pre_compute, size_of::<BitManipImmPreCompute>()).borrow();
+    execute_imm_e12_impl::<CTX>(pre_compute, exec_state);
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_imm_e2_impl<CTX: MeteredExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &E2PreCompute<BitManipImmPreCompute> = std::slice::from_raw_parts(
+        pre_compute,
+        size_of::<E2PreCompute<BitManipImmPreCompute>>(),
+    )
+    .borrow();
+    exec_state
+        .ctx
+        .on_height_change(pre_compute.chip_idx as usize, 1);
+    execute_imm_e12_impl::<CTX>(&pre_compute.data, exec_state);
+}

--- a/extensions/riscv/circuit/src/bitmanip/execution.rs
+++ b/extensions/riscv/circuit/src/bitmanip/execution.rs
@@ -14,10 +14,11 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::{
     core::{
-        is_imm_opcode, is_reg_opcode, is_shadd_opcode, is_slli_uw_opcode, run_bitmanip_imm,
-        run_bitmanip_reg, BITMANIP_OFFSET, SLLI_UW,
+        is_bitwise_inv_opcode, is_imm_opcode, is_min_max_opcode, is_reg_opcode, is_shadd_opcode,
+        is_slli_uw_opcode, run_bitmanip_imm, run_bitmanip_reg, BITMANIP_OFFSET, SLLI_UW,
     },
-    BitManipImmExecutor, BitManipRegExecutor, BitManipShAddExecutor, BitManipSlliUwExecutor,
+    BitManipBitwiseInvExecutor, BitManipImmExecutor, BitManipMinMaxExecutor, BitManipRegExecutor,
+    BitManipShAddExecutor, BitManipSlliUwExecutor,
 };
 
 #[derive(AlignedBytesBorrow, Clone)]
@@ -536,6 +537,137 @@ unsafe fn execute_reg_e2_impl<CTX: MeteredExecutionCtxTrait>(
         .on_height_change(pre_compute.chip_idx as usize, 1);
     execute_reg_e12_impl::<CTX>(&pre_compute.data, exec_state);
 }
+
+// The bitwise-inv and min-max executors run the same register-register
+// interpretation as the generic reg executor (the handlers dispatch on the
+// local opcode stored in the precompute); only the accepted opcode set and the
+// preflight record format differ.
+macro_rules! impl_reg_shaped_interpreter {
+    ($executor:ident, $is_opcode:ident) => {
+        impl<A> $executor<A> {
+            #[inline(always)]
+            fn pre_compute_impl<F: PrimeField32>(
+                &self,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut BitManipRegPreCompute,
+            ) -> Result<(), StaticProgramError> {
+                let Instruction {
+                    opcode,
+                    a,
+                    b,
+                    c,
+                    d,
+                    e,
+                    ..
+                } = inst;
+                if d.as_canonical_u32() != RV64_REGISTER_AS
+                    || e.as_canonical_u32() != RV64_REGISTER_AS
+                {
+                    return Err(StaticProgramError::InvalidInstruction(pc));
+                }
+                let local_opcode = opcode.local_opcode_idx(BITMANIP_OFFSET);
+                if !$is_opcode(local_opcode) {
+                    return Err(StaticProgramError::InvalidInstruction(pc));
+                }
+                *data = BitManipRegPreCompute {
+                    rs2_ptr: c.as_canonical_u32() as u8,
+                    rd_ptr: a.as_canonical_u32() as u8,
+                    rs1_ptr: b.as_canonical_u32() as u8,
+                    local_opcode: local_opcode as u8,
+                };
+                Ok(())
+            }
+        }
+
+        impl<F, A> InterpreterExecutor<F> for $executor<A>
+        where
+            F: PrimeField32,
+        {
+            #[inline(always)]
+            fn pre_compute_size(&self) -> usize {
+                size_of::<BitManipRegPreCompute>()
+            }
+
+            #[cfg(not(feature = "tco"))]
+            fn pre_compute<Ctx>(
+                &self,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+            where
+                Ctx: ExecutionCtxTrait,
+            {
+                let data: &mut BitManipRegPreCompute = data.borrow_mut();
+                self.pre_compute_impl(pc, inst, data)?;
+                Ok(execute_reg_e1_handler)
+            }
+
+            #[cfg(feature = "tco")]
+            fn handler<Ctx>(
+                &self,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<Handler<Ctx>, StaticProgramError>
+            where
+                Ctx: ExecutionCtxTrait,
+            {
+                let data: &mut BitManipRegPreCompute = data.borrow_mut();
+                self.pre_compute_impl(pc, inst, data)?;
+                Ok(execute_reg_e1_handler)
+            }
+        }
+
+        impl<F, A> InterpreterMeteredExecutor<F> for $executor<A>
+        where
+            F: PrimeField32,
+        {
+            #[inline(always)]
+            fn metered_pre_compute_size(&self) -> usize {
+                size_of::<E2PreCompute<BitManipRegPreCompute>>()
+            }
+
+            #[cfg(not(feature = "tco"))]
+            fn metered_pre_compute<Ctx>(
+                &self,
+                chip_idx: usize,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+            where
+                Ctx: MeteredExecutionCtxTrait,
+            {
+                let data: &mut E2PreCompute<BitManipRegPreCompute> = data.borrow_mut();
+                data.chip_idx = chip_idx as u32;
+                self.pre_compute_impl(pc, inst, &mut data.data)?;
+                Ok(execute_reg_e2_handler)
+            }
+
+            #[cfg(feature = "tco")]
+            fn metered_handler<Ctx>(
+                &self,
+                chip_idx: usize,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<Handler<Ctx>, StaticProgramError>
+            where
+                Ctx: MeteredExecutionCtxTrait,
+            {
+                let data: &mut E2PreCompute<BitManipRegPreCompute> = data.borrow_mut();
+                data.chip_idx = chip_idx as u32;
+                self.pre_compute_impl(pc, inst, &mut data.data)?;
+                Ok(execute_reg_e2_handler)
+            }
+        }
+    };
+}
+
+impl_reg_shaped_interpreter!(BitManipBitwiseInvExecutor, is_bitwise_inv_opcode);
+impl_reg_shaped_interpreter!(BitManipMinMaxExecutor, is_min_max_opcode);
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]

--- a/extensions/riscv/circuit/src/bitmanip/execution.rs
+++ b/extensions/riscv/circuit/src/bitmanip/execution.rs
@@ -14,11 +14,12 @@ use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::{
     core::{
-        is_bitwise_inv_opcode, is_imm_opcode, is_min_max_opcode, is_reg_opcode, is_shadd_opcode,
-        is_slli_uw_opcode, run_bitmanip_imm, run_bitmanip_reg, BITMANIP_OFFSET, SLLI_UW,
+        is_bitwise_inv_opcode, is_byte_unary_opcode, is_imm_opcode, is_min_max_opcode,
+        is_reg_opcode, is_shadd_opcode, is_slli_uw_opcode, run_bitmanip_imm, run_bitmanip_reg,
+        BITMANIP_OFFSET, SLLI_UW,
     },
-    BitManipBitwiseInvExecutor, BitManipImmExecutor, BitManipMinMaxExecutor, BitManipRegExecutor,
-    BitManipShAddExecutor, BitManipSlliUwExecutor,
+    BitManipBitwiseInvExecutor, BitManipByteUnaryExecutor, BitManipImmExecutor,
+    BitManipMinMaxExecutor, BitManipRegExecutor, BitManipShAddExecutor, BitManipSlliUwExecutor,
 };
 
 #[derive(AlignedBytesBorrow, Clone)]
@@ -668,6 +669,133 @@ macro_rules! impl_reg_shaped_interpreter {
 
 impl_reg_shaped_interpreter!(BitManipBitwiseInvExecutor, is_bitwise_inv_opcode);
 impl_reg_shaped_interpreter!(BitManipMinMaxExecutor, is_min_max_opcode);
+
+// Immediate-shaped executors reuse the generic imm interpretation (the
+// handlers dispatch on the local opcode stored in the precompute); only the
+// accepted opcode set and the preflight record format differ.
+macro_rules! impl_imm_shaped_interpreter {
+    ($executor:ident, $is_opcode:ident) => {
+        impl<A> $executor<A> {
+            #[inline(always)]
+            fn pre_compute_impl<F: PrimeField32>(
+                &self,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut BitManipImmPreCompute,
+            ) -> Result<(), StaticProgramError> {
+                let Instruction {
+                    opcode,
+                    a,
+                    b,
+                    c,
+                    d,
+                    e,
+                    ..
+                } = inst;
+                if d.as_canonical_u32() != RV64_REGISTER_AS || e.as_canonical_u32() != RV64_IMM_AS {
+                    return Err(StaticProgramError::InvalidInstruction(pc));
+                }
+                let local_opcode = opcode.local_opcode_idx(BITMANIP_OFFSET);
+                if !$is_opcode(local_opcode) {
+                    return Err(StaticProgramError::InvalidInstruction(pc));
+                }
+                *data = BitManipImmPreCompute {
+                    imm: c.as_canonical_u32() as u8,
+                    rd_ptr: a.as_canonical_u32() as u8,
+                    rs1_ptr: b.as_canonical_u32() as u8,
+                    local_opcode: local_opcode as u8,
+                };
+                Ok(())
+            }
+        }
+
+        impl<F, A> InterpreterExecutor<F> for $executor<A>
+        where
+            F: PrimeField32,
+        {
+            #[inline(always)]
+            fn pre_compute_size(&self) -> usize {
+                size_of::<BitManipImmPreCompute>()
+            }
+
+            #[cfg(not(feature = "tco"))]
+            fn pre_compute<Ctx>(
+                &self,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+            where
+                Ctx: ExecutionCtxTrait,
+            {
+                let data: &mut BitManipImmPreCompute = data.borrow_mut();
+                self.pre_compute_impl(pc, inst, data)?;
+                Ok(execute_imm_e1_handler)
+            }
+
+            #[cfg(feature = "tco")]
+            fn handler<Ctx>(
+                &self,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<Handler<Ctx>, StaticProgramError>
+            where
+                Ctx: ExecutionCtxTrait,
+            {
+                let data: &mut BitManipImmPreCompute = data.borrow_mut();
+                self.pre_compute_impl(pc, inst, data)?;
+                Ok(execute_imm_e1_handler)
+            }
+        }
+
+        impl<F, A> InterpreterMeteredExecutor<F> for $executor<A>
+        where
+            F: PrimeField32,
+        {
+            #[inline(always)]
+            fn metered_pre_compute_size(&self) -> usize {
+                size_of::<E2PreCompute<BitManipImmPreCompute>>()
+            }
+
+            #[cfg(not(feature = "tco"))]
+            fn metered_pre_compute<Ctx>(
+                &self,
+                chip_idx: usize,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+            where
+                Ctx: MeteredExecutionCtxTrait,
+            {
+                let data: &mut E2PreCompute<BitManipImmPreCompute> = data.borrow_mut();
+                data.chip_idx = chip_idx as u32;
+                self.pre_compute_impl(pc, inst, &mut data.data)?;
+                Ok(execute_imm_e2_handler)
+            }
+
+            #[cfg(feature = "tco")]
+            fn metered_handler<Ctx>(
+                &self,
+                chip_idx: usize,
+                pc: u32,
+                inst: &Instruction<F>,
+                data: &mut [u8],
+            ) -> Result<Handler<Ctx>, StaticProgramError>
+            where
+                Ctx: MeteredExecutionCtxTrait,
+            {
+                let data: &mut E2PreCompute<BitManipImmPreCompute> = data.borrow_mut();
+                data.chip_idx = chip_idx as u32;
+                self.pre_compute_impl(pc, inst, &mut data.data)?;
+                Ok(execute_imm_e2_handler)
+            }
+        }
+    };
+}
+
+impl_imm_shaped_interpreter!(BitManipByteUnaryExecutor, is_byte_unary_opcode);
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]

--- a/extensions/riscv/circuit/src/bitmanip/execution.rs
+++ b/extensions/riscv/circuit/src/bitmanip/execution.rs
@@ -13,9 +13,354 @@ use openvm_instructions::{
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::{
-    core::{is_imm_opcode, is_reg_opcode, run_bitmanip_imm, run_bitmanip_reg, BITMANIP_OFFSET},
-    BitManipImmExecutor, BitManipRegExecutor,
+    core::{
+        is_imm_opcode, is_reg_opcode, is_shadd_opcode, is_slli_uw_opcode, run_bitmanip_imm,
+        run_bitmanip_reg, BITMANIP_OFFSET, SLLI_UW,
+    },
+    BitManipImmExecutor, BitManipRegExecutor, BitManipShAddExecutor, BitManipSlliUwExecutor,
 };
+
+#[derive(AlignedBytesBorrow, Clone)]
+#[repr(C)]
+struct BitManipShAddPreCompute {
+    rs2_ptr: u8,
+    rd_ptr: u8,
+    rs1_ptr: u8,
+    local_opcode: u8,
+}
+
+impl<A> BitManipShAddExecutor<A> {
+    #[inline(always)]
+    fn pre_compute_impl<F: PrimeField32>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut BitManipShAddPreCompute,
+    ) -> Result<(), StaticProgramError> {
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c,
+            d,
+            e,
+            ..
+        } = inst;
+        if d.as_canonical_u32() != RV64_REGISTER_AS || e.as_canonical_u32() != RV64_REGISTER_AS {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        let local_opcode = opcode.local_opcode_idx(BITMANIP_OFFSET);
+        if !is_shadd_opcode(local_opcode) {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        *data = BitManipShAddPreCompute {
+            rs2_ptr: c.as_canonical_u32() as u8,
+            rd_ptr: a.as_canonical_u32() as u8,
+            rs1_ptr: b.as_canonical_u32() as u8,
+            local_opcode: local_opcode as u8,
+        };
+        Ok(())
+    }
+}
+
+impl<F, A> InterpreterExecutor<F> for BitManipShAddExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn pre_compute_size(&self) -> usize {
+        size_of::<BitManipShAddPreCompute>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn pre_compute<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipShAddPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_shadd_e1_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn handler<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipShAddPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_shadd_e1_handler)
+    }
+}
+
+impl<F, A> InterpreterMeteredExecutor<F> for BitManipShAddExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn metered_pre_compute_size(&self) -> usize {
+        size_of::<E2PreCompute<BitManipShAddPreCompute>>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn metered_pre_compute<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipShAddPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_shadd_e2_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn metered_handler<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipShAddPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_shadd_e2_handler)
+    }
+}
+
+#[inline(always)]
+unsafe fn execute_shadd_e12_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: &BitManipShAddPreCompute,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let rs1 = exec_state
+        .vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.rs1_ptr as u32);
+    let rs2 = exec_state
+        .vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.rs2_ptr as u32);
+    let rd = run_bitmanip_reg(
+        pre_compute.local_opcode as usize,
+        u64::from_le_bytes(rs1),
+        u64::from_le_bytes(rs2),
+    )
+    .to_le_bytes();
+    exec_state.vm_write_bytes(RV64_REGISTER_AS, pre_compute.rd_ptr as u32, &rd);
+    let pc = exec_state.pc();
+    exec_state.set_pc(pc.wrapping_add(DEFAULT_PC_STEP));
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_shadd_e1_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &BitManipShAddPreCompute =
+        std::slice::from_raw_parts(pre_compute, size_of::<BitManipShAddPreCompute>()).borrow();
+    execute_shadd_e12_impl::<CTX>(pre_compute, exec_state);
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_shadd_e2_impl<CTX: MeteredExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &E2PreCompute<BitManipShAddPreCompute> = std::slice::from_raw_parts(
+        pre_compute,
+        size_of::<E2PreCompute<BitManipShAddPreCompute>>(),
+    )
+    .borrow();
+    exec_state
+        .ctx
+        .on_height_change(pre_compute.chip_idx as usize, 1);
+    execute_shadd_e12_impl::<CTX>(&pre_compute.data, exec_state);
+}
+
+#[derive(AlignedBytesBorrow, Clone)]
+#[repr(C)]
+struct BitManipSlliUwPreCompute {
+    imm: u8,
+    rd_ptr: u8,
+    rs1_ptr: u8,
+}
+
+impl<A> BitManipSlliUwExecutor<A> {
+    #[inline(always)]
+    fn pre_compute_impl<F: PrimeField32>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut BitManipSlliUwPreCompute,
+    ) -> Result<(), StaticProgramError> {
+        let Instruction {
+            opcode,
+            a,
+            b,
+            c,
+            d,
+            e,
+            ..
+        } = inst;
+        if d.as_canonical_u32() != RV64_REGISTER_AS || e.as_canonical_u32() != RV64_IMM_AS {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        let local_opcode = opcode.local_opcode_idx(BITMANIP_OFFSET);
+        if !is_slli_uw_opcode(local_opcode) {
+            return Err(StaticProgramError::InvalidInstruction(pc));
+        }
+        *data = BitManipSlliUwPreCompute {
+            imm: c.as_canonical_u32() as u8,
+            rd_ptr: a.as_canonical_u32() as u8,
+            rs1_ptr: b.as_canonical_u32() as u8,
+        };
+        Ok(())
+    }
+}
+
+impl<F, A> InterpreterExecutor<F> for BitManipSlliUwExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn pre_compute_size(&self) -> usize {
+        size_of::<BitManipSlliUwPreCompute>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn pre_compute<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipSlliUwPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_slli_uw_e1_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn handler<Ctx>(
+        &self,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: ExecutionCtxTrait,
+    {
+        let data: &mut BitManipSlliUwPreCompute = data.borrow_mut();
+        self.pre_compute_impl(pc, inst, data)?;
+        Ok(execute_slli_uw_e1_handler)
+    }
+}
+
+impl<F, A> InterpreterMeteredExecutor<F> for BitManipSlliUwExecutor<A>
+where
+    F: PrimeField32,
+{
+    #[inline(always)]
+    fn metered_pre_compute_size(&self) -> usize {
+        size_of::<E2PreCompute<BitManipSlliUwPreCompute>>()
+    }
+
+    #[cfg(not(feature = "tco"))]
+    fn metered_pre_compute<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<ExecuteFunc<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipSlliUwPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_slli_uw_e2_handler)
+    }
+
+    #[cfg(feature = "tco")]
+    fn metered_handler<Ctx>(
+        &self,
+        chip_idx: usize,
+        pc: u32,
+        inst: &Instruction<F>,
+        data: &mut [u8],
+    ) -> Result<Handler<Ctx>, StaticProgramError>
+    where
+        Ctx: MeteredExecutionCtxTrait,
+    {
+        let data: &mut E2PreCompute<BitManipSlliUwPreCompute> = data.borrow_mut();
+        data.chip_idx = chip_idx as u32;
+        self.pre_compute_impl(pc, inst, &mut data.data)?;
+        Ok(execute_slli_uw_e2_handler)
+    }
+}
+
+#[inline(always)]
+unsafe fn execute_slli_uw_e12_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: &BitManipSlliUwPreCompute,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let rs1 = exec_state
+        .vm_read_bytes::<RV64_REGISTER_NUM_LIMBS>(RV64_REGISTER_AS, pre_compute.rs1_ptr as u32);
+    let rd =
+        run_bitmanip_imm(SLLI_UW, u64::from_le_bytes(rs1), pre_compute.imm as u32).to_le_bytes();
+    exec_state.vm_write_bytes(RV64_REGISTER_AS, pre_compute.rd_ptr as u32, &rd);
+    let pc = exec_state.pc();
+    exec_state.set_pc(pc.wrapping_add(DEFAULT_PC_STEP));
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_slli_uw_e1_impl<CTX: ExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &BitManipSlliUwPreCompute =
+        std::slice::from_raw_parts(pre_compute, size_of::<BitManipSlliUwPreCompute>()).borrow();
+    execute_slli_uw_e12_impl::<CTX>(pre_compute, exec_state);
+}
+
+#[create_handler]
+#[inline(always)]
+unsafe fn execute_slli_uw_e2_impl<CTX: MeteredExecutionCtxTrait>(
+    pre_compute: *const u8,
+    exec_state: &mut VmExecState<GuestMemory, CTX>,
+) {
+    let pre_compute: &E2PreCompute<BitManipSlliUwPreCompute> = std::slice::from_raw_parts(
+        pre_compute,
+        size_of::<E2PreCompute<BitManipSlliUwPreCompute>>(),
+    )
+    .borrow();
+    exec_state
+        .ctx
+        .on_height_change(pre_compute.chip_idx as usize, 1);
+    execute_slli_uw_e12_impl::<CTX>(&pre_compute.data, exec_state);
+}
 
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]

--- a/extensions/riscv/circuit/src/bitmanip/min_max.rs
+++ b/extensions/riscv/circuit/src/bitmanip/min_max.rs
@@ -1,0 +1,331 @@
+use std::{
+    array,
+    borrow::{Borrow, BorrowMut},
+};
+
+use openvm_circuit::{
+    arch::*,
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+};
+use openvm_circuit_primitives::{
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
+use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::{AirBuilder, BaseAir},
+    p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
+    BaseAirWithPublicValues,
+};
+
+use super::{
+    core::{
+        is_min_max_opcode, limbs_to_u64, run_bitmanip_reg, u64_to_limbs, BITMANIP_OFFSET, MAX,
+        MAXU, MIN, MINU,
+    },
+    BITMANIP_LIMB_BITS, BITMANIP_NUM_LIMBS,
+};
+use crate::less_than::run_less_than;
+
+/// MIN/MINU/MAX/MAXU: the `less_than` comparison gadget plus a `pick_b`
+/// selector; the written value is an expression over the operand limbs, so no
+/// output columns are needed.
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipMinMaxCoreCols<T> {
+    pub b: [T; BITMANIP_NUM_LIMBS],
+    pub c: [T; BITMANIP_NUM_LIMBS],
+    /// b < c (signed for MIN/MAX, unsigned for MINU/MAXU).
+    pub cmp_result: T,
+    /// 1 exactly when the written value is `b`.
+    pub pick_b: T,
+    pub opcode_min_flag: T,
+    pub opcode_minu_flag: T,
+    pub opcode_max_flag: T,
+    pub opcode_maxu_flag: T,
+    /// Most significant limb of b and c as a field element; range checked to
+    /// [-2^(LIMB_BITS-1), 2^(LIMB_BITS-1)) if signed, [0, 2^LIMB_BITS) if not.
+    pub b_msb_f: T,
+    pub c_msb_f: T,
+    /// 1 at the most significant index where b and c differ, otherwise 0.
+    pub diff_marker: [T; BITMANIP_NUM_LIMBS],
+    pub diff_val: T,
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipMinMaxCoreCols<u8>)]
+pub struct BitManipMinMaxCoreAir {
+    pub range_bus: VariableRangeCheckerBus,
+}
+
+impl<F: Field> BaseAir<F> for BitManipMinMaxCoreAir {
+    fn width(&self) -> usize {
+        BitManipMinMaxCoreCols::<F>::width()
+    }
+}
+impl<F: Field> BaseAirWithPublicValues<F> for BitManipMinMaxCoreAir {}
+
+impl<AB, I> VmCoreAir<AB, I> for BitManipMinMaxCoreAir
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 2]>,
+    I::Writes: From<[[AB::Expr; BITMANIP_NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<MinimalInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipMinMaxCoreCols<_> = local_core.borrow();
+        let flags = [
+            (cols.opcode_min_flag, MIN),
+            (cols.opcode_minu_flag, MINU),
+            (cols.opcode_max_flag, MAX),
+            (cols.opcode_maxu_flag, MAXU),
+        ];
+
+        let is_valid = flags.iter().fold(AB::Expr::ZERO, |acc, &(flag, _)| {
+            builder.assert_bool(flag);
+            acc + flag.into()
+        });
+        builder.assert_bool(is_valid.clone());
+        builder.assert_bool(cols.cmp_result);
+
+        // The comparison machinery below mirrors `LessThanCoreAir`: find the
+        // most significant differing limb via a one-hot marker with prefix sum
+        // and derive `cmp_result = (b < c)`, with the top limbs replaced by
+        // sign-adjusted field values when the comparison is signed.
+        let b = &cols.b;
+        let c = &cols.c;
+        let marker = &cols.diff_marker;
+        let mut prefix_sum = AB::Expr::ZERO;
+
+        let b_diff = b[BITMANIP_NUM_LIMBS - 1] - cols.b_msb_f;
+        let c_diff = c[BITMANIP_NUM_LIMBS - 1] - cols.c_msb_f;
+        builder
+            .assert_zero(b_diff.clone() * (AB::Expr::from_u32(1 << BITMANIP_LIMB_BITS) - b_diff));
+        builder
+            .assert_zero(c_diff.clone() * (AB::Expr::from_u32(1 << BITMANIP_LIMB_BITS) - c_diff));
+
+        for i in (0..BITMANIP_NUM_LIMBS).rev() {
+            let diff = (if i == BITMANIP_NUM_LIMBS - 1 {
+                cols.c_msb_f - cols.b_msb_f
+            } else {
+                c[i] - b[i]
+            }) * (AB::Expr::from_u8(2) * cols.cmp_result - AB::Expr::ONE);
+            prefix_sum += marker[i].into();
+            builder.assert_bool(marker[i]);
+            builder.assert_zero((AB::Expr::ONE - prefix_sum.clone()) * diff.clone());
+            builder.when(marker[i]).assert_eq(cols.diff_val, diff);
+        }
+
+        builder.assert_bool(prefix_sum.clone());
+        builder.assert_zero((AB::Expr::ONE - prefix_sum.clone()) * cols.cmp_result);
+
+        let signed_flag = cols.opcode_min_flag + cols.opcode_max_flag;
+        let sign_shift = AB::Expr::from_u32(1 << (BITMANIP_LIMB_BITS - 1)) * signed_flag;
+        self.range_bus
+            .range_check(cols.b_msb_f + sign_shift.clone(), BITMANIP_LIMB_BITS)
+            .eval(builder, is_valid.clone());
+        self.range_bus
+            .range_check(cols.c_msb_f + sign_shift, BITMANIP_LIMB_BITS)
+            .eval(builder, is_valid.clone());
+
+        // Ensures diff_val is non-zero at the marked limb.
+        self.range_bus
+            .range_check(cols.diff_val - AB::Expr::ONE, BITMANIP_LIMB_BITS)
+            .eval(builder, prefix_sum);
+
+        // pick_b selects the written operand: the smaller one for MIN/MINU,
+        // the larger one for MAX/MAXU. Zero on padding rows.
+        let min_flags = cols.opcode_min_flag + cols.opcode_minu_flag;
+        let max_flags = cols.opcode_max_flag + cols.opcode_maxu_flag;
+        builder.assert_eq(
+            cols.pick_b,
+            min_flags * cols.cmp_result + max_flags * (AB::Expr::ONE - cols.cmp_result),
+        );
+
+        let writes: [AB::Expr; BITMANIP_NUM_LIMBS] =
+            array::from_fn(|i| cols.pick_b * cols.b[i] + (AB::Expr::ONE - cols.pick_b) * cols.c[i]);
+
+        let expected_local_opcode = flags
+            .iter()
+            .fold(AB::Expr::ZERO, |acc, &(flag, local_opcode)| {
+                acc + flag * AB::Expr::from_usize(local_opcode)
+            });
+        let expected_opcode = expected_local_opcode + AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
+            writes: [writes].into(),
+            instruction: MinimalInstruction {
+                is_valid,
+                opcode: expected_opcode,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipMinMaxCoreRecord {
+    pub b: [u16; BITMANIP_NUM_LIMBS],
+    pub c: [u16; BITMANIP_NUM_LIMBS],
+    pub local_opcode: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipMinMaxExecutor<A> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipMinMaxFiller<A> {
+    adapter: A,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
+}
+
+impl<F, A, RA> PreflightExecutor<F, RA> for BitManipMinMaxExecutor<A>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; BITMANIP_NUM_LIMBS]; 2]>,
+            WriteData: From<[[u16; BITMANIP_NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (A::RecordMut<'buf>, &'buf mut BitManipMinMaxCoreRecord),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BMinMax({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_min_max_opcode(local_opcode));
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b, core_record.c] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.local_opcode = local_opcode as u8;
+
+        let output = run_bitmanip_reg(
+            local_opcode,
+            limbs_to_u64(&core_record.b),
+            limbs_to_u64(&core_record.c),
+        );
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [u64_to_limbs(output)].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A> TraceFiller<F> for BitManipMinMaxFiller<A>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipMinMaxCoreRecord = unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let c = record.c;
+        let local_opcode = record.local_opcode as usize;
+
+        let core_row: &mut BitManipMinMaxCoreCols<F> = core_row.borrow_mut();
+
+        let is_signed = matches!(local_opcode, MIN | MAX);
+        let is_min = matches!(local_opcode, MIN | MINU);
+        let (cmp_result, diff_idx, b_sign, c_sign) =
+            run_less_than::<BITMANIP_NUM_LIMBS, BITMANIP_LIMB_BITS>(is_signed, &b, &c);
+
+        // Range check (msb_f + 2^(LIMB_BITS-1)) if signed, msb_f if not.
+        let (b_msb_f, b_msb_range) = if b_sign {
+            (
+                -F::from_u16(b[BITMANIP_NUM_LIMBS - 1].wrapping_neg()),
+                b[BITMANIP_NUM_LIMBS - 1] as u32 - (1u32 << (BITMANIP_LIMB_BITS - 1)),
+            )
+        } else {
+            (
+                F::from_u16(b[BITMANIP_NUM_LIMBS - 1]),
+                b[BITMANIP_NUM_LIMBS - 1] as u32 + ((is_signed as u32) << (BITMANIP_LIMB_BITS - 1)),
+            )
+        };
+        let (c_msb_f, c_msb_range) = if c_sign {
+            (
+                -F::from_u16(c[BITMANIP_NUM_LIMBS - 1].wrapping_neg()),
+                c[BITMANIP_NUM_LIMBS - 1] as u32 - (1u32 << (BITMANIP_LIMB_BITS - 1)),
+            )
+        } else {
+            (
+                F::from_u16(c[BITMANIP_NUM_LIMBS - 1]),
+                c[BITMANIP_NUM_LIMBS - 1] as u32 + ((is_signed as u32) << (BITMANIP_LIMB_BITS - 1)),
+            )
+        };
+
+        core_row.diff_val = if diff_idx == BITMANIP_NUM_LIMBS {
+            F::ZERO
+        } else if diff_idx == BITMANIP_NUM_LIMBS - 1 {
+            if cmp_result {
+                c_msb_f - b_msb_f
+            } else {
+                b_msb_f - c_msb_f
+            }
+        } else if cmp_result {
+            F::from_u16((c[diff_idx] as u32 - b[diff_idx] as u32) as u16)
+        } else {
+            F::from_u16((b[diff_idx] as u32 - c[diff_idx] as u32) as u16)
+        };
+
+        self.range_checker_chip
+            .add_count(b_msb_range, BITMANIP_LIMB_BITS);
+        self.range_checker_chip
+            .add_count(c_msb_range, BITMANIP_LIMB_BITS);
+
+        core_row.diff_marker = [F::ZERO; BITMANIP_NUM_LIMBS];
+        if diff_idx != BITMANIP_NUM_LIMBS {
+            self.range_checker_chip
+                .add_count(core_row.diff_val.as_canonical_u32() - 1, BITMANIP_LIMB_BITS);
+            core_row.diff_marker[diff_idx] = F::ONE;
+        }
+
+        core_row.c_msb_f = c_msb_f;
+        core_row.b_msb_f = b_msb_f;
+        core_row.opcode_maxu_flag = F::from_bool(local_opcode == MAXU);
+        core_row.opcode_max_flag = F::from_bool(local_opcode == MAX);
+        core_row.opcode_minu_flag = F::from_bool(local_opcode == MINU);
+        core_row.opcode_min_flag = F::from_bool(local_opcode == MIN);
+        core_row.pick_b = F::from_bool(if is_min { cmp_result } else { !cmp_result });
+        core_row.cmp_result = F::from_bool(cmp_result);
+        core_row.c = c.map(F::from_u16);
+        core_row.b = b.map(F::from_u16);
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/mod.rs
+++ b/extensions/riscv/circuit/src/bitmanip/mod.rs
@@ -2,13 +2,19 @@ use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper, BLOCK_FE_WIDTH};
 
 use crate::adapters::{
     Rv64BaseAluImmU16AdapterAir, Rv64BaseAluImmU16AdapterExecutor, Rv64BaseAluImmU16AdapterFiller,
+    Rv64BaseAluRegAdapterAir, Rv64BaseAluRegAdapterExecutor, Rv64BaseAluRegAdapterFiller,
     Rv64BaseAluRegU16AdapterAir, Rv64BaseAluRegU16AdapterExecutor, Rv64BaseAluRegU16AdapterFiller,
     U16_BITS,
 };
 
+mod bitwise_inv;
 mod core;
 mod execution;
+mod min_max;
 pub use core::*;
+
+pub use bitwise_inv::*;
+pub use min_max::*;
 
 #[cfg(feature = "cuda")]
 mod cuda;
@@ -37,6 +43,17 @@ pub type Rv64BitManipImmAir = VmAirWrapper<Rv64BaseAluImmU16AdapterAir, BitManip
 pub type Rv64BitManipImmExecutor = BitManipImmExecutor<Rv64BaseAluImmU16AdapterExecutor>;
 pub type Rv64BitManipImmChip<F> =
     VmChipWrapper<F, BitManipImmFiller<Rv64BaseAluImmU16AdapterFiller>>;
+
+pub type Rv64BitManipBitwiseInvAir =
+    VmAirWrapper<Rv64BaseAluRegAdapterAir, BitManipBitwiseInvCoreAir>;
+pub type Rv64BitManipBitwiseInvExecutor = BitManipBitwiseInvExecutor<Rv64BaseAluRegAdapterExecutor>;
+pub type Rv64BitManipBitwiseInvChip<F> =
+    VmChipWrapper<F, BitManipBitwiseInvFiller<Rv64BaseAluRegAdapterFiller>>;
+
+pub type Rv64BitManipMinMaxAir = VmAirWrapper<Rv64BaseAluRegU16AdapterAir, BitManipMinMaxCoreAir>;
+pub type Rv64BitManipMinMaxExecutor = BitManipMinMaxExecutor<Rv64BaseAluRegU16AdapterExecutor>;
+pub type Rv64BitManipMinMaxChip<F> =
+    VmChipWrapper<F, BitManipMinMaxFiller<Rv64BaseAluRegU16AdapterFiller>>;
 
 pub(crate) const BITMANIP_NUM_LIMBS: usize = BLOCK_FE_WIDTH;
 pub(crate) const BITMANIP_LIMB_BITS: usize = U16_BITS;

--- a/extensions/riscv/circuit/src/bitmanip/mod.rs
+++ b/extensions/riscv/circuit/src/bitmanip/mod.rs
@@ -10,6 +10,11 @@ mod core;
 mod execution;
 pub use core::*;
 
+#[cfg(feature = "cuda")]
+mod cuda;
+#[cfg(feature = "cuda")]
+pub use cuda::*;
+
 #[cfg(test)]
 mod tests;
 

--- a/extensions/riscv/circuit/src/bitmanip/mod.rs
+++ b/extensions/riscv/circuit/src/bitmanip/mod.rs
@@ -18,6 +18,16 @@ pub use cuda::*;
 #[cfg(test)]
 mod tests;
 
+pub type Rv64BitManipShAddAir = VmAirWrapper<Rv64BaseAluRegU16AdapterAir, BitManipShAddCoreAir>;
+pub type Rv64BitManipShAddExecutor = BitManipShAddExecutor<Rv64BaseAluRegU16AdapterExecutor>;
+pub type Rv64BitManipShAddChip<F> =
+    VmChipWrapper<F, BitManipShAddFiller<Rv64BaseAluRegU16AdapterFiller>>;
+
+pub type Rv64BitManipSlliUwAir = VmAirWrapper<Rv64BaseAluImmU16AdapterAir, BitManipSlliUwCoreAir>;
+pub type Rv64BitManipSlliUwExecutor = BitManipSlliUwExecutor<Rv64BaseAluImmU16AdapterExecutor>;
+pub type Rv64BitManipSlliUwChip<F> =
+    VmChipWrapper<F, BitManipSlliUwFiller<Rv64BaseAluImmU16AdapterFiller>>;
+
 pub type Rv64BitManipRegAir = VmAirWrapper<Rv64BaseAluRegU16AdapterAir, BitManipRegCoreAir>;
 pub type Rv64BitManipRegExecutor = BitManipRegExecutor<Rv64BaseAluRegU16AdapterExecutor>;
 pub type Rv64BitManipRegChip<F> =

--- a/extensions/riscv/circuit/src/bitmanip/mod.rs
+++ b/extensions/riscv/circuit/src/bitmanip/mod.rs
@@ -1,0 +1,28 @@
+use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper, BLOCK_FE_WIDTH};
+
+use crate::adapters::{
+    Rv64BaseAluImmU16AdapterAir, Rv64BaseAluImmU16AdapterExecutor, Rv64BaseAluImmU16AdapterFiller,
+    Rv64BaseAluRegU16AdapterAir, Rv64BaseAluRegU16AdapterExecutor, Rv64BaseAluRegU16AdapterFiller,
+    U16_BITS,
+};
+
+mod core;
+mod execution;
+pub use core::*;
+
+#[cfg(test)]
+mod tests;
+
+pub type Rv64BitManipRegAir = VmAirWrapper<Rv64BaseAluRegU16AdapterAir, BitManipRegCoreAir>;
+pub type Rv64BitManipRegExecutor = BitManipRegExecutor<Rv64BaseAluRegU16AdapterExecutor>;
+pub type Rv64BitManipRegChip<F> =
+    VmChipWrapper<F, BitManipRegFiller<Rv64BaseAluRegU16AdapterFiller>>;
+
+pub type Rv64BitManipImmAir = VmAirWrapper<Rv64BaseAluImmU16AdapterAir, BitManipImmCoreAir>;
+pub type Rv64BitManipImmExecutor = BitManipImmExecutor<Rv64BaseAluImmU16AdapterExecutor>;
+pub type Rv64BitManipImmChip<F> =
+    VmChipWrapper<F, BitManipImmFiller<Rv64BaseAluImmU16AdapterFiller>>;
+
+pub(crate) const BITMANIP_NUM_LIMBS: usize = BLOCK_FE_WIDTH;
+pub(crate) const BITMANIP_LIMB_BITS: usize = U16_BITS;
+pub(crate) const BITMANIP_NUM_BITS: usize = BITMANIP_NUM_LIMBS * BITMANIP_LIMB_BITS;

--- a/extensions/riscv/circuit/src/bitmanip/mod.rs
+++ b/extensions/riscv/circuit/src/bitmanip/mod.rs
@@ -1,6 +1,7 @@
 use openvm_circuit::arch::{VmAirWrapper, VmChipWrapper, BLOCK_FE_WIDTH};
 
 use crate::adapters::{
+    Rv64BaseAluImmAdapterAir, Rv64BaseAluImmAdapterExecutor, Rv64BaseAluImmAdapterFiller,
     Rv64BaseAluImmU16AdapterAir, Rv64BaseAluImmU16AdapterExecutor, Rv64BaseAluImmU16AdapterFiller,
     Rv64BaseAluRegAdapterAir, Rv64BaseAluRegAdapterExecutor, Rv64BaseAluRegAdapterFiller,
     Rv64BaseAluRegU16AdapterAir, Rv64BaseAluRegU16AdapterExecutor, Rv64BaseAluRegU16AdapterFiller,
@@ -8,12 +9,14 @@ use crate::adapters::{
 };
 
 mod bitwise_inv;
+mod byte_unary;
 mod core;
 mod execution;
 mod min_max;
 pub use core::*;
 
 pub use bitwise_inv::*;
+pub use byte_unary::*;
 pub use min_max::*;
 
 #[cfg(feature = "cuda")]
@@ -54,6 +57,12 @@ pub type Rv64BitManipMinMaxAir = VmAirWrapper<Rv64BaseAluRegU16AdapterAir, BitMa
 pub type Rv64BitManipMinMaxExecutor = BitManipMinMaxExecutor<Rv64BaseAluRegU16AdapterExecutor>;
 pub type Rv64BitManipMinMaxChip<F> =
     VmChipWrapper<F, BitManipMinMaxFiller<Rv64BaseAluRegU16AdapterFiller>>;
+
+pub type Rv64BitManipByteUnaryAir =
+    VmAirWrapper<Rv64BaseAluImmAdapterAir, BitManipByteUnaryCoreAir>;
+pub type Rv64BitManipByteUnaryExecutor = BitManipByteUnaryExecutor<Rv64BaseAluImmAdapterExecutor>;
+pub type Rv64BitManipByteUnaryChip<F> =
+    VmChipWrapper<F, BitManipByteUnaryFiller<Rv64BaseAluImmAdapterFiller>>;
 
 pub(crate) const BITMANIP_NUM_LIMBS: usize = BLOCK_FE_WIDTH;
 pub(crate) const BITMANIP_LIMB_BITS: usize = U16_BITS;

--- a/extensions/riscv/circuit/src/bitmanip/rotate.rs
+++ b/extensions/riscv/circuit/src/bitmanip/rotate.rs
@@ -1,0 +1,362 @@
+use std::{
+    array,
+    borrow::{Borrow, BorrowMut},
+};
+
+use openvm_circuit::{
+    arch::*,
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+};
+use openvm_circuit_primitives::{
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
+use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::{AirBuilder, BaseAir},
+    p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
+    BaseAirWithPublicValues,
+};
+
+use super::{
+    core::{is_rotate_reg_opcode, BITMANIP_OFFSET, ROL, ROLW},
+    BITMANIP_LIMB_BITS,
+};
+
+/// Register-register rotates over `NUM_LIMBS` u16 limbs (ROL/ROR at 4 limbs,
+/// ROLW/RORW at 2 limbs behind the sign-extending W adapter).
+///
+/// The recombination machinery always computes a LEFT rotate by the
+/// marker-encoded amount `idx`; a right rotate by `s` is a left rotate by
+/// `(width - s) % width`, so the direction only changes how `idx` is bound to
+/// the rs2 amount:
+///   ROL: rs2_low ≡ idx  (mod width),  i.e. (c[0] - idx) / width is a small int
+///   ROR: rs2_low ≡ -idx (mod width),  i.e. (c[0] + idx) / width is a small int
+///
+/// Each `b` limb splits at bit `beta = idx % 16` into `aux` (low `16 - beta`
+/// bits) and `carry` (high `beta` bits); output limb `j` recombines
+/// `aux[(j - L) % N] * 2^beta + carry[(j - L - 1) % N]` where `L = idx / 16`.
+/// Unlike a shift, every output limb has a carry-in (the rotate wraps), and
+/// the additive recombination bounds each output limb below `2^16`.
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipRotateCoreCols<T, const NUM_LIMBS: usize> {
+    pub a: [T; NUM_LIMBS],
+    pub b: [T; NUM_LIMBS],
+    pub c: [T; NUM_LIMBS],
+    pub opcode_rol_flag: T,
+    pub opcode_ror_flag: T,
+    pub bit_shift_marker: [T; BITMANIP_LIMB_BITS],
+    pub limb_shift_marker: [T; NUM_LIMBS],
+    pub bit_shift_carry: [T; NUM_LIMBS],
+    pub bit_shift_aux: [T; NUM_LIMBS],
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipRotateCoreCols<u8, NUM_LIMBS>)]
+pub struct BitManipRotateCoreAir<const NUM_LIMBS: usize> {
+    pub range_bus: VariableRangeCheckerBus,
+    /// Local opcodes of the left/right rotate this instantiation serves.
+    pub rol_opcode: usize,
+    pub ror_opcode: usize,
+}
+
+impl<F: Field, const NUM_LIMBS: usize> BaseAir<F> for BitManipRotateCoreAir<NUM_LIMBS> {
+    fn width(&self) -> usize {
+        BitManipRotateCoreCols::<F, NUM_LIMBS>::width()
+    }
+}
+impl<F: Field, const NUM_LIMBS: usize> BaseAirWithPublicValues<F>
+    for BitManipRotateCoreAir<NUM_LIMBS>
+{
+}
+
+impl<AB, I, const NUM_LIMBS: usize> VmCoreAir<AB, I> for BitManipRotateCoreAir<NUM_LIMBS>
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; NUM_LIMBS]; 2]>,
+    I::Writes: From<[[AB::Expr; NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<MinimalInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipRotateCoreCols<_, NUM_LIMBS> = local_core.borrow();
+        let width_bits = NUM_LIMBS * BITMANIP_LIMB_BITS;
+
+        builder.assert_bool(cols.opcode_rol_flag);
+        builder.assert_bool(cols.opcode_ror_flag);
+        let is_valid: AB::Expr = cols.opcode_rol_flag + cols.opcode_ror_flag;
+        builder.assert_bool(is_valid.clone());
+
+        // One-hot markers encode the normalized left-rotate amount
+        // idx = 16 * limb_shift + bit_shift.
+        let mut bit_marker_sum = AB::Expr::ZERO;
+        let mut bit_shift = AB::Expr::ZERO;
+        let mut bit_multiplier = AB::Expr::ZERO;
+        let mut carry_multiplier = AB::Expr::ZERO;
+        for bit in 0..BITMANIP_LIMB_BITS {
+            builder.assert_bool(cols.bit_shift_marker[bit]);
+            let marker: AB::Expr = cols.bit_shift_marker[bit].into();
+            bit_marker_sum += marker.clone();
+            bit_shift += AB::Expr::from_usize(bit) * marker.clone();
+            bit_multiplier += AB::Expr::from_usize(1 << bit) * marker.clone();
+            carry_multiplier += AB::Expr::from_usize(1 << (BITMANIP_LIMB_BITS - bit)) * marker;
+        }
+        builder.assert_eq(bit_marker_sum, is_valid.clone());
+
+        let mut limb_marker_sum = AB::Expr::ZERO;
+        let mut limb_shift = AB::Expr::ZERO;
+        for limb in 0..NUM_LIMBS {
+            builder.assert_bool(cols.limb_shift_marker[limb]);
+            limb_marker_sum += cols.limb_shift_marker[limb].into();
+            limb_shift += AB::Expr::from_usize(limb) * cols.limb_shift_marker[limb];
+
+            let mut when_limb_shift = builder.when(cols.limb_shift_marker[limb]);
+            for out_limb in 0..NUM_LIMBS {
+                let src_limb = (out_limb + NUM_LIMBS - limb) % NUM_LIMBS;
+                let carry_src = (out_limb + NUM_LIMBS - limb - 1) % NUM_LIMBS;
+                when_limb_shift.assert_eq(
+                    cols.a[out_limb],
+                    cols.bit_shift_aux[src_limb] * bit_multiplier.clone()
+                        + cols.bit_shift_carry[carry_src],
+                );
+            }
+        }
+        builder.assert_eq(limb_marker_sum, is_valid.clone());
+
+        // Split each b limb at the bit shift; the recombination above is then
+        // exact. Vacuous on padding rows (all columns zero).
+        for limb in 0..NUM_LIMBS {
+            builder.assert_eq(
+                cols.b[limb],
+                cols.bit_shift_aux[limb] + cols.bit_shift_carry[limb] * carry_multiplier.clone(),
+            );
+            self.range_bus
+                .send(cols.bit_shift_carry[limb], bit_shift.clone())
+                .eval(builder, is_valid.clone());
+            self.range_bus
+                .send(
+                    cols.bit_shift_aux[limb],
+                    AB::Expr::from_usize(BITMANIP_LIMB_BITS) - bit_shift.clone(),
+                )
+                .eval(builder, is_valid.clone());
+        }
+
+        // Bind idx to the rotate amount rs2 % width per direction. The
+        // quotient is range checked so the congruence holds exactly; idx is in
+        // [0, width) by construction of the markers.
+        let idx = limb_shift * AB::Expr::from_usize(BITMANIP_LIMB_BITS) + bit_shift;
+        let width_inv = AB::F::from_usize(width_bits).inverse();
+        let quotient_bits = BITMANIP_LIMB_BITS - width_bits.ilog2() as usize;
+        self.range_bus
+            .range_check((cols.c[0] - idx.clone()) * width_inv, quotient_bits)
+            .eval(builder, cols.opcode_rol_flag);
+        self.range_bus
+            .range_check((cols.c[0] + idx) * width_inv, quotient_bits + 1)
+            .eval(builder, cols.opcode_ror_flag);
+
+        let expected_opcode = cols.opcode_rol_flag * AB::Expr::from_usize(self.rol_opcode)
+            + cols.opcode_ror_flag * AB::Expr::from_usize(self.ror_opcode)
+            + is_valid.clone() * AB::Expr::from_usize(BITMANIP_OFFSET);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: MinimalInstruction {
+                is_valid,
+                opcode: expected_opcode,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+/// Returns the rotated limbs and the normalized left-rotate amount `idx`.
+pub(crate) fn run_rotate<const NUM_LIMBS: usize>(
+    is_rol: bool,
+    b: &[u16; NUM_LIMBS],
+    c0: u16,
+) -> ([u16; NUM_LIMBS], usize) {
+    let width = NUM_LIMBS * BITMANIP_LIMB_BITS;
+    debug_assert!(width <= 64);
+    let s = (c0 as usize) % width;
+    let idx = if is_rol { s } else { (width - s) % width };
+
+    let value = b
+        .iter()
+        .enumerate()
+        .fold(0u64, |acc, (i, limb)| acc | ((*limb as u64) << (16 * i)));
+    let mask = if width == 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    };
+    let rotated = if idx == 0 {
+        value
+    } else {
+        ((value << idx) | (value >> (width - idx))) & mask
+    };
+    (
+        array::from_fn(|i| ((rotated >> (16 * i)) & 0xffff) as u16),
+        idx,
+    )
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipRotateCoreRecord<const NUM_LIMBS: usize> {
+    pub b: [u16; NUM_LIMBS],
+    pub c: [u16; NUM_LIMBS],
+    pub is_rol: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipRotateExecutor<A, const NUM_LIMBS: usize> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipRotateFiller<A, const NUM_LIMBS: usize> {
+    adapter: A,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
+}
+
+impl<F, A, RA, const NUM_LIMBS: usize> PreflightExecutor<F, RA>
+    for BitManipRotateExecutor<A, NUM_LIMBS>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; NUM_LIMBS]; 2]>,
+            WriteData: From<[[u16; NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (
+            A::RecordMut<'buf>,
+            &'buf mut BitManipRotateCoreRecord<NUM_LIMBS>,
+        ),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BRotate({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_rotate_reg_opcode(local_opcode));
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b, core_record.c] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.is_rol = matches!(local_opcode, ROL | ROLW) as u8;
+
+        let (output, _) = run_rotate(core_record.is_rol != 0, &core_record.b, core_record.c[0]);
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [output].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A, const NUM_LIMBS: usize> TraceFiller<F> for BitManipRotateFiller<A, NUM_LIMBS>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipRotateCoreRecord<NUM_LIMBS> =
+            unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let c = record.c;
+        let is_rol = record.is_rol != 0;
+
+        let core_row: &mut BitManipRotateCoreCols<F, NUM_LIMBS> = core_row.borrow_mut();
+        let (a, idx) = run_rotate(is_rol, &b, c[0]);
+
+        fill_rotate_aux(
+            &mut core_row.bit_shift_marker,
+            &mut core_row.limb_shift_marker,
+            &mut core_row.bit_shift_carry,
+            &mut core_row.bit_shift_aux,
+            &b,
+            idx,
+            &self.range_checker_chip,
+        );
+
+        let width_bits = NUM_LIMBS * BITMANIP_LIMB_BITS;
+        let quotient_bits = BITMANIP_LIMB_BITS - width_bits.ilog2() as usize;
+        if is_rol {
+            self.range_checker_chip
+                .add_count((c[0] as usize - idx) as u32 / width_bits as u32, quotient_bits);
+        } else {
+            self.range_checker_chip.add_count(
+                (c[0] as usize + idx) as u32 / width_bits as u32,
+                quotient_bits + 1,
+            );
+        }
+
+        core_row.opcode_ror_flag = F::from_bool(!is_rol);
+        core_row.opcode_rol_flag = F::from_bool(is_rol);
+        core_row.c = c.map(F::from_u16);
+        core_row.b = b.map(F::from_u16);
+        core_row.a = a.map(F::from_u16);
+    }
+}
+
+/// Fills the shared rotate witness columns (markers plus the carry/aux split
+/// of each `b` limb at `idx % 16`) and issues their range checks.
+pub(super) fn fill_rotate_aux<F: PrimeField32, const NUM_LIMBS: usize>(
+    bit_shift_marker: &mut [F; BITMANIP_LIMB_BITS],
+    limb_shift_marker: &mut [F; NUM_LIMBS],
+    bit_shift_carry: &mut [F; NUM_LIMBS],
+    bit_shift_aux: &mut [F; NUM_LIMBS],
+    b: &[u16; NUM_LIMBS],
+    idx: usize,
+    range_checker: &SharedVariableRangeCheckerChip,
+) {
+    let bit_shift = idx % BITMANIP_LIMB_BITS;
+    let limb_shift = idx / BITMANIP_LIMB_BITS;
+    *bit_shift_marker = [F::ZERO; BITMANIP_LIMB_BITS];
+    bit_shift_marker[bit_shift] = F::ONE;
+    *limb_shift_marker = [F::ZERO; NUM_LIMBS];
+    limb_shift_marker[limb_shift] = F::ONE;
+
+    let aux_bits = BITMANIP_LIMB_BITS - bit_shift;
+    for (limb, &b_limb) in b.iter().enumerate() {
+        let limb_u32 = b_limb as u32;
+        let aux = limb_u32 & ((1u32 << aux_bits) - 1);
+        let carry = limb_u32 >> aux_bits;
+        bit_shift_aux[limb] = F::from_u32(aux);
+        bit_shift_carry[limb] = F::from_u32(carry);
+        range_checker.add_count(carry, bit_shift);
+        range_checker.add_count(aux, aux_bits);
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/rotate_imm.rs
+++ b/extensions/riscv/circuit/src/bitmanip/rotate_imm.rs
@@ -1,0 +1,258 @@
+use std::borrow::{Borrow, BorrowMut};
+
+use openvm_circuit::{
+    arch::*,
+    system::memory::{online::TracingMemory, MemoryAuxColsFactory},
+};
+use openvm_circuit_primitives::{
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerBus},
+    AlignedBytesBorrow, ColumnsAir, StructReflection, StructReflectionHelper,
+};
+use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::{instruction::Instruction, program::DEFAULT_PC_STEP};
+use openvm_stark_backend::{
+    interaction::InteractionBuilder,
+    p3_air::{AirBuilder, BaseAir},
+    p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
+    BaseAirWithPublicValues,
+};
+
+use super::{
+    core::{is_rotate_imm_opcode, BITMANIP_OFFSET},
+    rotate::{fill_rotate_aux, run_rotate},
+    BITMANIP_LIMB_BITS,
+};
+
+/// Rotate-right-by-immediate (RORI at 4 limbs, RORIW at 2 limbs behind the
+/// sign-extending W adapter).
+///
+/// Reuses the left-rotate recombination of [`super::rotate`]: the markers
+/// encode the normalized left-rotate amount `idx = (width - shamt) % width`,
+/// and the instruction immediate is bound to `shamt` via the expression
+/// `width * (is_valid - is_idx_zero) - idx`, where `is_idx_zero` is the
+/// product of the two zero markers (so `shamt = 0` maps to `idx = 0`, not
+/// `width`).
+#[repr(C)]
+#[derive(AlignedBorrow, StructReflection, Debug)]
+pub struct BitManipRotateImmCoreCols<T, const NUM_LIMBS: usize> {
+    pub a: [T; NUM_LIMBS],
+    pub b: [T; NUM_LIMBS],
+    pub bit_shift_marker: [T; BITMANIP_LIMB_BITS],
+    pub limb_shift_marker: [T; NUM_LIMBS],
+    pub bit_shift_carry: [T; NUM_LIMBS],
+    pub bit_shift_aux: [T; NUM_LIMBS],
+}
+
+#[derive(Copy, Clone, Debug, derive_new::new, ColumnsAir)]
+#[columns_via(BitManipRotateImmCoreCols<u8, NUM_LIMBS>)]
+pub struct BitManipRotateImmCoreAir<const NUM_LIMBS: usize> {
+    pub range_bus: VariableRangeCheckerBus,
+    /// Local opcode of the rotate-right-immediate this instantiation serves.
+    pub rori_opcode: usize,
+}
+
+impl<F: Field, const NUM_LIMBS: usize> BaseAir<F> for BitManipRotateImmCoreAir<NUM_LIMBS> {
+    fn width(&self) -> usize {
+        BitManipRotateImmCoreCols::<F, NUM_LIMBS>::width()
+    }
+}
+impl<F: Field, const NUM_LIMBS: usize> BaseAirWithPublicValues<F>
+    for BitManipRotateImmCoreAir<NUM_LIMBS>
+{
+}
+
+impl<AB, I, const NUM_LIMBS: usize> VmCoreAir<AB, I> for BitManipRotateImmCoreAir<NUM_LIMBS>
+where
+    AB: InteractionBuilder,
+    I: VmAdapterInterface<AB::Expr>,
+    I::Reads: From<[[AB::Expr; NUM_LIMBS]; 1]>,
+    I::Writes: From<[[AB::Expr; NUM_LIMBS]; 1]>,
+    I::ProcessedInstruction: From<ImmInstruction<AB::Expr>>,
+{
+    fn eval(
+        &self,
+        builder: &mut AB,
+        local_core: &[AB::Var],
+        _from_pc: AB::Var,
+    ) -> AdapterAirContext<AB::Expr, I> {
+        let cols: &BitManipRotateImmCoreCols<_, NUM_LIMBS> = local_core.borrow();
+        let width_bits = NUM_LIMBS * BITMANIP_LIMB_BITS;
+
+        let mut bit_marker_sum = AB::Expr::ZERO;
+        let mut bit_shift = AB::Expr::ZERO;
+        let mut bit_multiplier = AB::Expr::ZERO;
+        let mut carry_multiplier = AB::Expr::ZERO;
+        for bit in 0..BITMANIP_LIMB_BITS {
+            builder.assert_bool(cols.bit_shift_marker[bit]);
+            let marker: AB::Expr = cols.bit_shift_marker[bit].into();
+            bit_marker_sum += marker.clone();
+            bit_shift += AB::Expr::from_usize(bit) * marker.clone();
+            bit_multiplier += AB::Expr::from_usize(1 << bit) * marker.clone();
+            carry_multiplier += AB::Expr::from_usize(1 << (BITMANIP_LIMB_BITS - bit)) * marker;
+        }
+        builder.assert_bool(bit_marker_sum.clone());
+        let is_valid = bit_marker_sum;
+
+        let mut limb_marker_sum = AB::Expr::ZERO;
+        let mut limb_shift = AB::Expr::ZERO;
+        for limb in 0..NUM_LIMBS {
+            builder.assert_bool(cols.limb_shift_marker[limb]);
+            limb_marker_sum += cols.limb_shift_marker[limb].into();
+            limb_shift += AB::Expr::from_usize(limb) * cols.limb_shift_marker[limb];
+
+            let mut when_limb_shift = builder.when(cols.limb_shift_marker[limb]);
+            for out_limb in 0..NUM_LIMBS {
+                let src_limb = (out_limb + NUM_LIMBS - limb) % NUM_LIMBS;
+                let carry_src = (out_limb + NUM_LIMBS - limb - 1) % NUM_LIMBS;
+                when_limb_shift.assert_eq(
+                    cols.a[out_limb],
+                    cols.bit_shift_aux[src_limb] * bit_multiplier.clone()
+                        + cols.bit_shift_carry[carry_src],
+                );
+            }
+        }
+        builder.assert_eq(limb_marker_sum, is_valid.clone());
+
+        for limb in 0..NUM_LIMBS {
+            builder.assert_eq(
+                cols.b[limb],
+                cols.bit_shift_aux[limb] + cols.bit_shift_carry[limb] * carry_multiplier.clone(),
+            );
+            self.range_bus
+                .send(cols.bit_shift_carry[limb], bit_shift.clone())
+                .eval(builder, is_valid.clone());
+            self.range_bus
+                .send(
+                    cols.bit_shift_aux[limb],
+                    AB::Expr::from_usize(BITMANIP_LIMB_BITS) - bit_shift.clone(),
+                )
+                .eval(builder, is_valid.clone());
+        }
+
+        // shamt = (width - idx) % width, encoded without a modulus by special
+        // casing idx = 0 through the product of the two zero markers.
+        let idx = limb_shift * AB::Expr::from_usize(BITMANIP_LIMB_BITS) + bit_shift;
+        let is_idx_zero = cols.limb_shift_marker[0] * cols.bit_shift_marker[0];
+        let immediate =
+            (is_valid.clone() - is_idx_zero) * AB::Expr::from_usize(width_bits) - idx;
+
+        let expected_opcode = AB::Expr::from_usize(BITMANIP_OFFSET + self.rori_opcode);
+
+        AdapterAirContext {
+            to_pc: None,
+            reads: [cols.b.map(Into::into)].into(),
+            writes: [cols.a.map(Into::into)].into(),
+            instruction: ImmInstruction {
+                is_valid,
+                opcode: expected_opcode,
+                immediate,
+            }
+            .into(),
+        }
+    }
+
+    fn start_offset(&self) -> usize {
+        BITMANIP_OFFSET
+    }
+}
+
+#[repr(C)]
+#[derive(AlignedBytesBorrow, Debug)]
+pub struct BitManipRotateImmCoreRecord<const NUM_LIMBS: usize> {
+    pub b: [u16; NUM_LIMBS],
+    pub imm: u8,
+}
+
+#[derive(Clone, Copy, derive_new::new)]
+pub struct BitManipRotateImmExecutor<A, const NUM_LIMBS: usize> {
+    adapter: A,
+}
+
+#[derive(Clone, derive_new::new)]
+pub struct BitManipRotateImmFiller<A, const NUM_LIMBS: usize> {
+    adapter: A,
+    pub range_checker_chip: SharedVariableRangeCheckerChip,
+}
+
+impl<F, A, RA, const NUM_LIMBS: usize> PreflightExecutor<F, RA>
+    for BitManipRotateImmExecutor<A, NUM_LIMBS>
+where
+    F: PrimeField32,
+    A: 'static
+        + AdapterTraceExecutor<
+            F,
+            ReadData: Into<[[u16; NUM_LIMBS]; 1]>,
+            WriteData: From<[[u16; NUM_LIMBS]; 1]>,
+        >,
+    for<'buf> RA: RecordArena<
+        'buf,
+        EmptyAdapterCoreLayout<F, A>,
+        (
+            A::RecordMut<'buf>,
+            &'buf mut BitManipRotateImmCoreRecord<NUM_LIMBS>,
+        ),
+    >,
+{
+    fn get_opcode_name(&self, opcode: usize) -> String {
+        format!("Rv64BRotateImm({})", opcode - BITMANIP_OFFSET)
+    }
+
+    fn execute(
+        &self,
+        state: VmStateMut<TracingMemory, RA>,
+        instruction: &Instruction<F>,
+    ) -> Result<(), ExecutionError> {
+        let local_opcode = instruction.opcode.local_opcode_idx(BITMANIP_OFFSET);
+        debug_assert!(is_rotate_imm_opcode(local_opcode));
+        let imm = instruction.c.as_canonical_u32();
+
+        let (mut adapter_record, core_record) = state.ctx.alloc(EmptyAdapterCoreLayout::new());
+        A::start(*state.pc, state.memory, &mut adapter_record);
+        [core_record.b] = self
+            .adapter
+            .read(state.memory, instruction, &mut adapter_record)
+            .into();
+        core_record.imm = imm as u8;
+
+        let (output, _) = run_rotate(false, &core_record.b, imm as u16);
+        self.adapter.write(
+            state.memory,
+            instruction,
+            [output].into(),
+            &mut adapter_record,
+        );
+        *state.pc = state.pc.wrapping_add(DEFAULT_PC_STEP);
+        Ok(())
+    }
+}
+
+impl<F, A, const NUM_LIMBS: usize> TraceFiller<F> for BitManipRotateImmFiller<A, NUM_LIMBS>
+where
+    F: PrimeField32,
+    A: 'static + AdapterTraceFiller<F>,
+{
+    fn fill_trace_row(&self, mem_helper: &MemoryAuxColsFactory<F>, row_slice: &mut [F]) {
+        let (adapter_row, mut core_row) = unsafe { row_slice.split_at_mut_unchecked(A::WIDTH) };
+        self.adapter.fill_trace_row(mem_helper, adapter_row);
+        let record: &BitManipRotateImmCoreRecord<NUM_LIMBS> =
+            unsafe { get_record_from_slice(&mut core_row, ()) };
+        let b = record.b;
+        let imm = record.imm;
+
+        let core_row: &mut BitManipRotateImmCoreCols<F, NUM_LIMBS> = core_row.borrow_mut();
+        let (a, idx) = run_rotate(false, &b, imm as u16);
+
+        fill_rotate_aux(
+            &mut core_row.bit_shift_marker,
+            &mut core_row.limb_shift_marker,
+            &mut core_row.bit_shift_carry,
+            &mut core_row.bit_shift_aux,
+            &b,
+            idx,
+            &self.range_checker_chip,
+        );
+
+        core_row.b = b.map(F::from_u16);
+        core_row.a = a.map(F::from_u16);
+    }
+}

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -1,0 +1,232 @@
+use openvm_circuit::{
+    arch::{
+        testing::{TestBuilder, TestChipHarness, VmChipTestBuilder},
+        Arena, ExecutionBridge, PreflightExecutor,
+    },
+    system::memory::{offline_checker::MemoryBridge, SharedMemoryHelper},
+};
+use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
+use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
+use rand::rngs::StdRng;
+
+use super::{
+    core::*, Rv64BitManipImmAir, Rv64BitManipImmChip, Rv64BitManipImmExecutor, Rv64BitManipRegAir,
+    Rv64BitManipRegChip, Rv64BitManipRegExecutor,
+};
+use crate::{
+    adapters::{
+        Rv64BaseAluImmU16AdapterAir, Rv64BaseAluImmU16AdapterExecutor,
+        Rv64BaseAluImmU16AdapterFiller, Rv64BaseAluRegU16AdapterAir,
+        Rv64BaseAluRegU16AdapterExecutor, Rv64BaseAluRegU16AdapterFiller, RV64_REGISTER_NUM_LIMBS,
+    },
+    test_utils::rv64_rand_write_register_or_imm,
+    BitManipImmCoreAir, BitManipImmFiller, BitManipRegCoreAir, BitManipRegFiller,
+};
+
+type F = BabyBear;
+const MAX_INS_CAPACITY: usize = 128;
+
+type RegHarness =
+    TestChipHarness<F, Rv64BitManipRegExecutor, Rv64BitManipRegAir, Rv64BitManipRegChip<F>>;
+type ImmHarness =
+    TestChipHarness<F, Rv64BitManipImmExecutor, Rv64BitManipImmAir, Rv64BitManipImmChip<F>>;
+
+fn create_reg_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+) -> (
+    Rv64BitManipRegAir,
+    Rv64BitManipRegExecutor,
+    Rv64BitManipRegChip<F>,
+) {
+    let air = Rv64BitManipRegAir::new(
+        Rv64BaseAluRegU16AdapterAir::new(execution_bridge, memory_bridge),
+        BitManipRegCoreAir::new(),
+    );
+    let executor = Rv64BitManipRegExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+    let chip = Rv64BitManipRegChip::new(
+        BitManipRegFiller::new(Rv64BaseAluRegU16AdapterFiller::new()),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_reg_harness(tester: &VmChipTestBuilder<F>) -> RegHarness {
+    let (air, executor, chip) = create_reg_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+    );
+    RegHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+}
+
+fn create_imm_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+) -> (
+    Rv64BitManipImmAir,
+    Rv64BitManipImmExecutor,
+    Rv64BitManipImmChip<F>,
+) {
+    let air = Rv64BitManipImmAir::new(
+        Rv64BaseAluImmU16AdapterAir::new(execution_bridge, memory_bridge),
+        BitManipImmCoreAir::new(),
+    );
+    let executor = Rv64BitManipImmExecutor::new(Rv64BaseAluImmU16AdapterExecutor);
+    let chip = Rv64BitManipImmChip::new(
+        BitManipImmFiller::new(Rv64BaseAluImmU16AdapterFiller::new()),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_imm_harness(tester: &VmChipTestBuilder<F>) -> ImmHarness {
+    let (air, executor, chip) = create_imm_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+    );
+    ImmHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+}
+
+fn execute_reg<RA: Arena, E: PreflightExecutor<F, RA>>(
+    tester: &mut impl TestBuilder<F>,
+    executor: &mut E,
+    arena: &mut RA,
+    rng: &mut StdRng,
+    local_opcode: usize,
+    rs1: u64,
+    rs2: u64,
+) {
+    let (instruction, rd) = rv64_rand_write_register_or_imm(
+        tester,
+        rs1.to_le_bytes(),
+        rs2.to_le_bytes(),
+        None,
+        BITMANIP_OFFSET + local_opcode,
+        rng,
+    );
+    tester.execute(executor, arena, &instruction);
+    let expected = run_bitmanip_reg(local_opcode, rs1, rs2).to_le_bytes();
+    assert_eq!(
+        expected.map(F::from_u8),
+        tester.read_bytes::<RV64_REGISTER_NUM_LIMBS>(1, rd)
+    );
+}
+
+fn execute_imm<RA: Arena, E: PreflightExecutor<F, RA>>(
+    tester: &mut impl TestBuilder<F>,
+    executor: &mut E,
+    arena: &mut RA,
+    rng: &mut StdRng,
+    local_opcode: usize,
+    rs1: u64,
+    imm: u32,
+) {
+    let (instruction, rd) = rv64_rand_write_register_or_imm(
+        tester,
+        rs1.to_le_bytes(),
+        [0; RV64_REGISTER_NUM_LIMBS],
+        Some(imm as usize),
+        BITMANIP_OFFSET + local_opcode,
+        rng,
+    );
+    tester.execute(executor, arena, &instruction);
+    let expected = run_bitmanip_imm(local_opcode, rs1, imm).to_le_bytes();
+    assert_eq!(
+        expected.map(F::from_u8),
+        tester.read_bytes::<RV64_REGISTER_NUM_LIMBS>(1, rd)
+    );
+}
+
+#[test]
+fn rv64_bitmanip_reg_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let mut harness = create_reg_harness(&tester);
+
+    let cases = [
+        (SH1ADD, 0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210),
+        (SH2ADD, 0x8000_0000_0000_0001, 0x7fff_ffff_ffff_ffff),
+        (SH3ADD, 0xffff_ffff_ffff_ffff, 2),
+        (ADD_UW, 0xffff_ffff_8000_0001, 9),
+        (SH1ADD_UW, 0xffff_ffff_8000_0001, 9),
+        (SH2ADD_UW, 0xffff_ffff_8000_0001, 9),
+        (SH3ADD_UW, 0xffff_ffff_8000_0001, 9),
+        (ANDN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+        (ORN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+        (XNOR, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+        (ROL, 0x0123_4567_89ab_cdef, 13),
+        (ROR, 0x0123_4567_89ab_cdef, 45),
+        (ROLW, 0x89ab_cdef, 7),
+        (RORW, 0x89ab_cdef, 11),
+        (MIN, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+        (MINU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+        (MAX, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+        (MAXU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+        (BCLR, 0xffff_ffff_ffff_ffff, 63),
+        (BSET, 0, 37),
+        (BINV, 0x1000, 12),
+        (BEXT, 0x8000_0000_0000_0000, 63),
+    ];
+
+    for (local_opcode, rs1, rs2) in cases {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    let tester = tester.build().load(harness).finalize();
+    tester.simple_test().expect("verification failed");
+}
+
+#[test]
+fn rv64_bitmanip_imm_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let mut harness = create_imm_harness(&tester);
+
+    let cases = [
+        (SLLI_UW, 0xffff_ffff_8000_0001, 37),
+        (RORI, 0x0123_4567_89ab_cdef, 45),
+        (RORIW, 0x0000_0000_89ab_cdef, 21),
+        (CLZ, 0x0000_8000_0000_0000, 0),
+        (CTZ, 0x0000_0000_0000_8000, 0),
+        (CLZW, 0x0000_0000_0000_8000, 0),
+        (CTZW, 0x0000_0000_8000_0000, 0),
+        (CPOP, 0xf0f0_f0f0_1234_5678, 0),
+        (CPOPW, 0xffff_0000_1234_5678, 0),
+        (SEXT_B, 0x80, 0),
+        (SEXT_H, 0x8001, 0),
+        (ZEXT_H, 0xffff_ffff_ffff_8001, 0),
+        (ORC_B, 0x0001_0200_0004_0000, 0),
+        (REV8, 0x0123_4567_89ab_cdef, 0),
+        (BCLRI, 0xffff_ffff_ffff_ffff, 47),
+        (BSETI, 0, 48),
+        (BINVI, 0x1000, 12),
+        (BEXTI, 0x8000_0000_0000_0000, 63),
+    ];
+
+    for (local_opcode, rs1, imm) in cases {
+        execute_imm(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            imm,
+        );
+    }
+
+    let tester = tester.build().load(harness).finalize();
+    tester.simple_test().expect("verification failed");
+}

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -24,8 +24,9 @@ use {
             Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegAdapterRecord,
             Rv64BaseAluRegU16AdapterRecord,
         },
-        Rv64BitManipBitwiseInvChipGpu, Rv64BitManipImmChipGpu, Rv64BitManipMinMaxChipGpu,
-        Rv64BitManipRegChipGpu, Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwChipGpu,
+        BitManipBitwiseInvCoreRecord, BitManipMinMaxCoreRecord, Rv64BitManipBitwiseInvChipGpu,
+        Rv64BitManipImmChipGpu, Rv64BitManipMinMaxChipGpu, Rv64BitManipRegChipGpu,
+        Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwChipGpu,
     },
     openvm_circuit::arch::{
         testing::{

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -1,43 +1,60 @@
+use std::sync::Arc;
+
 use openvm_circuit::{
     arch::{
-        testing::{TestBuilder, TestChipHarness, VmChipTestBuilder},
+        testing::{TestBuilder, TestChipHarness, VmChipTestBuilder, BITWISE_OP_LOOKUP_BUS},
         Arena, ExecutionBridge, PreflightExecutor,
     },
     system::memory::{offline_checker::MemoryBridge, SharedMemoryHelper},
 };
-use openvm_circuit_primitives::var_range::SharedVariableRangeCheckerChip;
+use openvm_circuit_primitives::{
+    bitwise_op_lookup::{
+        BitwiseOperationLookupAir, BitwiseOperationLookupBus, BitwiseOperationLookupChip,
+        SharedBitwiseOperationLookupChip,
+    },
+    var_range::SharedVariableRangeCheckerChip,
+};
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::rngs::StdRng;
 #[cfg(feature = "cuda")]
 use {
     crate::{
-        adapters::{Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegU16AdapterRecord},
-        Rv64BitManipImmChipGpu, Rv64BitManipRegChipGpu, Rv64BitManipShAddChipGpu,
-        Rv64BitManipSlliUwChipGpu,
+        adapters::{
+            Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegAdapterRecord,
+            Rv64BaseAluRegU16AdapterRecord,
+        },
+        Rv64BitManipBitwiseInvChipGpu, Rv64BitManipImmChipGpu, Rv64BitManipMinMaxChipGpu,
+        Rv64BitManipRegChipGpu, Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwChipGpu,
     },
     openvm_circuit::arch::{
-        testing::{default_var_range_checker_bus, GpuChipTestBuilder, GpuTestChipHarness},
+        testing::{
+            default_bitwise_lookup_bus, default_var_range_checker_bus, GpuChipTestBuilder,
+            GpuTestChipHarness,
+        },
         EmptyAdapterCoreLayout,
     },
     openvm_circuit_primitives::var_range::VariableRangeCheckerChip,
-    std::sync::Arc,
 };
 
 use super::{
-    core::*, Rv64BitManipImmAir, Rv64BitManipImmChip, Rv64BitManipImmExecutor, Rv64BitManipRegAir,
-    Rv64BitManipRegChip, Rv64BitManipRegExecutor, Rv64BitManipShAddAir, Rv64BitManipShAddChip,
+    core::*, Rv64BitManipBitwiseInvAir, Rv64BitManipBitwiseInvChip, Rv64BitManipBitwiseInvExecutor,
+    Rv64BitManipImmAir, Rv64BitManipImmChip, Rv64BitManipImmExecutor, Rv64BitManipMinMaxAir,
+    Rv64BitManipMinMaxChip, Rv64BitManipMinMaxExecutor, Rv64BitManipRegAir, Rv64BitManipRegChip,
+    Rv64BitManipRegExecutor, Rv64BitManipShAddAir, Rv64BitManipShAddChip,
     Rv64BitManipShAddExecutor, Rv64BitManipSlliUwAir, Rv64BitManipSlliUwChip,
     Rv64BitManipSlliUwExecutor,
 };
 use crate::{
     adapters::{
         Rv64BaseAluImmU16AdapterAir, Rv64BaseAluImmU16AdapterExecutor,
-        Rv64BaseAluImmU16AdapterFiller, Rv64BaseAluRegU16AdapterAir,
-        Rv64BaseAluRegU16AdapterExecutor, Rv64BaseAluRegU16AdapterFiller, RV64_REGISTER_NUM_LIMBS,
+        Rv64BaseAluImmU16AdapterFiller, Rv64BaseAluRegAdapterAir, Rv64BaseAluRegAdapterExecutor,
+        Rv64BaseAluRegAdapterFiller, Rv64BaseAluRegU16AdapterAir, Rv64BaseAluRegU16AdapterExecutor,
+        Rv64BaseAluRegU16AdapterFiller, RV64_BYTE_BITS, RV64_REGISTER_NUM_LIMBS,
     },
     test_utils::rv64_rand_write_register_or_imm,
-    BitManipImmCoreAir, BitManipImmFiller, BitManipRegCoreAir, BitManipRegFiller,
+    BitManipBitwiseInvCoreAir, BitManipBitwiseInvFiller, BitManipImmCoreAir, BitManipImmFiller,
+    BitManipMinMaxCoreAir, BitManipMinMaxFiller, BitManipRegCoreAir, BitManipRegFiller,
     BitManipSlliUwCoreAir, BitManipSlliUwFiller,
 };
 
@@ -58,22 +75,35 @@ const SLLI_UW_CASES: [(usize, u64, u32); 4] = [
     (SLLI_UW, 0xffff_ffff_8000_0001, 37),
     (SLLI_UW, 0x0000_0000_dead_beef, 63),
 ];
-const REG_CASES: [(usize, u64, u64); REG_OP_COUNT] = [
-    (ANDN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
-    (ORN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
-    (XNOR, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+const REG_CASES: [(usize, u64, u64); 8] = [
     (ROL, 0x0123_4567_89ab_cdef, 13),
     (ROR, 0x0123_4567_89ab_cdef, 45),
     (ROLW, 0x89ab_cdef, 7),
     (RORW, 0x89ab_cdef, 11),
-    (MIN, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-    (MINU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-    (MAX, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-    (MAXU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
     (BCLR, 0xffff_ffff_ffff_ffff, 63),
     (BSET, 0, 37),
     (BINV, 0x1000, 12),
     (BEXT, 0x8000_0000_0000_0000, 63),
+];
+const BITWISE_INV_CASES: [(usize, u64, u64); 5] = [
+    (ANDN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+    (ORN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+    (XNOR, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+    (ANDN, 0, 0),
+    (XNOR, u64::MAX, u64::MAX),
+];
+const MIN_MAX_CASES: [(usize, u64, u64); 8] = [
+    (MIN, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (MINU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (MAX, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (MAXU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    // Equal operands (no differing limb).
+    (MIN, 0x0123_4567_89ab_cdef, 0x0123_4567_89ab_cdef),
+    // Signed boundary: i64::MIN vs zero.
+    (MAX, 0x8000_0000_0000_0000, 0),
+    (MINU, 0x8000_0000_0000_0000, 0),
+    // Difference only in the lowest limb.
+    (MAXU, 0xffff_ffff_ffff_ffff, 0xffff_ffff_ffff_fffe),
 ];
 const IMM_CASES: [(usize, u64, u32); IMM_OP_COUNT] = [
     (RORI, 0x0123_4567_89ab_cdef, 45),
@@ -107,6 +137,18 @@ type SlliUwHarness = TestChipHarness<
 >;
 type ImmHarness =
     TestChipHarness<F, Rv64BitManipImmExecutor, Rv64BitManipImmAir, Rv64BitManipImmChip<F>>;
+type BitwiseInvHarness = TestChipHarness<
+    F,
+    Rv64BitManipBitwiseInvExecutor,
+    Rv64BitManipBitwiseInvAir,
+    Rv64BitManipBitwiseInvChip<F>,
+>;
+type MinMaxHarness = TestChipHarness<
+    F,
+    Rv64BitManipMinMaxExecutor,
+    Rv64BitManipMinMaxAir,
+    Rv64BitManipMinMaxChip<F>,
+>;
 
 fn create_shadd_harness_fields(
     memory_bridge: MemoryBridge,
@@ -230,6 +272,83 @@ fn create_imm_harness(tester: &VmChipTestBuilder<F>) -> ImmHarness {
         tester.memory_helper(),
     );
     ImmHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+}
+
+fn create_bitwise_inv_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+    bitwise_chip: SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+) -> (
+    Rv64BitManipBitwiseInvAir,
+    Rv64BitManipBitwiseInvExecutor,
+    Rv64BitManipBitwiseInvChip<F>,
+) {
+    let air = Rv64BitManipBitwiseInvAir::new(
+        Rv64BaseAluRegAdapterAir::new(execution_bridge, memory_bridge),
+        BitManipBitwiseInvCoreAir::new(bitwise_chip.bus()),
+    );
+    let executor = Rv64BitManipBitwiseInvExecutor::new(Rv64BaseAluRegAdapterExecutor::new());
+    let chip = Rv64BitManipBitwiseInvChip::new(
+        BitManipBitwiseInvFiller::new(Rv64BaseAluRegAdapterFiller, bitwise_chip),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_bitwise_inv_harness(
+    tester: &VmChipTestBuilder<F>,
+) -> (
+    BitwiseInvHarness,
+    (
+        BitwiseOperationLookupAir<RV64_BYTE_BITS>,
+        SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+    ),
+) {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        bitwise_bus,
+    ));
+    let (air, executor, chip) = create_bitwise_inv_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+        bitwise_chip.clone(),
+    );
+    let harness = BitwiseInvHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY);
+    (harness, (bitwise_chip.air, bitwise_chip))
+}
+
+fn create_min_max_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+    range_checker: SharedVariableRangeCheckerChip,
+) -> (
+    Rv64BitManipMinMaxAir,
+    Rv64BitManipMinMaxExecutor,
+    Rv64BitManipMinMaxChip<F>,
+) {
+    let air = Rv64BitManipMinMaxAir::new(
+        Rv64BaseAluRegU16AdapterAir::new(execution_bridge, memory_bridge),
+        BitManipMinMaxCoreAir::new(range_checker.bus()),
+    );
+    let executor = Rv64BitManipMinMaxExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+    let chip = Rv64BitManipMinMaxChip::new(
+        BitManipMinMaxFiller::new(Rv64BaseAluRegU16AdapterFiller::new(), range_checker),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_min_max_harness(tester: &VmChipTestBuilder<F>) -> MinMaxHarness {
+    let (air, executor, chip) = create_min_max_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+        tester.range_checker(),
+    );
+    MinMaxHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
 }
 
 fn execute_reg<RA: Arena, E: PreflightExecutor<F, RA>>(
@@ -370,6 +489,54 @@ fn rv64_bitmanip_imm_chip_smoke() {
     tester.simple_test().expect("verification failed");
 }
 
+#[test]
+fn rv64_bitmanip_bitwise_inv_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let (mut harness, bitwise) = create_bitwise_inv_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in BITWISE_INV_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
+    tester.simple_test().expect("verification failed");
+}
+
+#[test]
+fn rv64_bitmanip_min_max_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let mut harness = create_min_max_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in MIN_MAX_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    let tester = tester.build().load(harness).finalize();
+    tester.simple_test().expect("verification failed");
+}
+
 #[cfg(feature = "cuda")]
 type GpuRegHarness = GpuTestChipHarness<
     F,
@@ -377,6 +544,24 @@ type GpuRegHarness = GpuTestChipHarness<
     Rv64BitManipRegAir,
     Rv64BitManipRegChipGpu,
     Rv64BitManipRegChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
+type GpuBitwiseInvHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipBitwiseInvExecutor,
+    Rv64BitManipBitwiseInvAir,
+    Rv64BitManipBitwiseInvChipGpu,
+    Rv64BitManipBitwiseInvChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
+type GpuMinMaxHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipMinMaxExecutor,
+    Rv64BitManipMinMaxAir,
+    Rv64BitManipMinMaxChipGpu,
+    Rv64BitManipMinMaxChip<F>,
 >;
 
 #[cfg(feature = "cuda")]
@@ -464,6 +649,43 @@ fn create_cuda_imm_harness(tester: &GpuChipTestBuilder) -> GpuImmHarness {
 }
 
 #[cfg(feature = "cuda")]
+fn create_cuda_bitwise_inv_harness(tester: &GpuChipTestBuilder) -> GpuBitwiseInvHarness {
+    // The CPU chip only regenerates the trace for comparison; its lookup
+    // requests must be discarded (the GPU kernel already adds them).
+    let dummy_bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        default_bitwise_lookup_bus(),
+    ));
+    let (air, executor, cpu_chip) = create_bitwise_inv_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+        dummy_bitwise_chip,
+    );
+    let gpu_chip = Rv64BitManipBitwiseInvChipGpu::new(
+        tester.range_checker(),
+        tester.bitwise_op_lookup(),
+        tester.timestamp_max_bits(),
+    );
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
+fn create_cuda_min_max_harness(tester: &GpuChipTestBuilder) -> GpuMinMaxHarness {
+    let dummy_range_checker_chip = Arc::new(VariableRangeCheckerChip::new(
+        default_var_range_checker_bus(),
+    ));
+    let (air, executor, cpu_chip) = create_min_max_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+        dummy_range_checker_chip,
+    );
+    let gpu_chip =
+        Rv64BitManipMinMaxChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
 #[test]
 fn test_cuda_bitmanip_shadd_tracegen() {
     let mut rng = create_seeded_rng();
@@ -531,6 +753,85 @@ fn test_cuda_bitmanip_slli_uw_tracegen() {
         .transfer_to_matrix_arena(
             &mut harness.matrix_arena,
             EmptyAdapterCoreLayout::<F, Rv64BaseAluImmU16AdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_bitwise_inv_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester =
+        GpuChipTestBuilder::default().with_bitwise_op_lookup(default_bitwise_lookup_bus());
+    let mut harness = create_cuda_bitwise_inv_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in BITWISE_INV_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluRegAdapterRecord,
+        &'a mut BitManipBitwiseInvCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluRegAdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_min_max_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::default();
+    let mut harness = create_cuda_min_max_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in MIN_MAX_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluRegU16AdapterRecord,
+        &'a mut BitManipMinMaxCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluRegU16AdapterExecutor>::new(),
         );
 
     tester

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -21,12 +21,13 @@ use rand::rngs::StdRng;
 use {
     crate::{
         adapters::{
-            Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegAdapterRecord,
-            Rv64BaseAluRegU16AdapterRecord,
+            Rv64BaseAluImmAdapterRecord, Rv64BaseAluImmU16AdapterRecord,
+            Rv64BaseAluRegAdapterRecord, Rv64BaseAluRegU16AdapterRecord,
         },
-        BitManipBitwiseInvCoreRecord, BitManipMinMaxCoreRecord, Rv64BitManipBitwiseInvChipGpu,
-        Rv64BitManipImmChipGpu, Rv64BitManipMinMaxChipGpu, Rv64BitManipRegChipGpu,
-        Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwChipGpu,
+        BitManipBitwiseInvCoreRecord, BitManipByteUnaryCoreRecord, BitManipMinMaxCoreRecord,
+        Rv64BitManipBitwiseInvChipGpu, Rv64BitManipByteUnaryChipGpu, Rv64BitManipImmChipGpu,
+        Rv64BitManipMinMaxChipGpu, Rv64BitManipRegChipGpu, Rv64BitManipShAddChipGpu,
+        Rv64BitManipSlliUwChipGpu,
     },
     openvm_circuit::arch::{
         testing::{
@@ -40,6 +41,7 @@ use {
 
 use super::{
     core::*, Rv64BitManipBitwiseInvAir, Rv64BitManipBitwiseInvChip, Rv64BitManipBitwiseInvExecutor,
+    Rv64BitManipByteUnaryAir, Rv64BitManipByteUnaryChip, Rv64BitManipByteUnaryExecutor,
     Rv64BitManipImmAir, Rv64BitManipImmChip, Rv64BitManipImmExecutor, Rv64BitManipMinMaxAir,
     Rv64BitManipMinMaxChip, Rv64BitManipMinMaxExecutor, Rv64BitManipRegAir, Rv64BitManipRegChip,
     Rv64BitManipRegExecutor, Rv64BitManipShAddAir, Rv64BitManipShAddChip,
@@ -48,15 +50,17 @@ use super::{
 };
 use crate::{
     adapters::{
+        Rv64BaseAluImmAdapterAir, Rv64BaseAluImmAdapterExecutor, Rv64BaseAluImmAdapterFiller,
         Rv64BaseAluImmU16AdapterAir, Rv64BaseAluImmU16AdapterExecutor,
         Rv64BaseAluImmU16AdapterFiller, Rv64BaseAluRegAdapterAir, Rv64BaseAluRegAdapterExecutor,
         Rv64BaseAluRegAdapterFiller, Rv64BaseAluRegU16AdapterAir, Rv64BaseAluRegU16AdapterExecutor,
         Rv64BaseAluRegU16AdapterFiller, RV64_BYTE_BITS, RV64_REGISTER_NUM_LIMBS,
     },
     test_utils::rv64_rand_write_register_or_imm,
-    BitManipBitwiseInvCoreAir, BitManipBitwiseInvFiller, BitManipImmCoreAir, BitManipImmFiller,
-    BitManipMinMaxCoreAir, BitManipMinMaxFiller, BitManipRegCoreAir, BitManipRegFiller,
-    BitManipSlliUwCoreAir, BitManipSlliUwFiller,
+    BitManipBitwiseInvCoreAir, BitManipBitwiseInvFiller, BitManipByteUnaryCoreAir,
+    BitManipByteUnaryFiller, BitManipImmCoreAir, BitManipImmFiller, BitManipMinMaxCoreAir,
+    BitManipMinMaxFiller, BitManipRegCoreAir, BitManipRegFiller, BitManipSlliUwCoreAir,
+    BitManipSlliUwFiller,
 };
 
 type F = BabyBear;
@@ -106,7 +110,7 @@ const MIN_MAX_CASES: [(usize, u64, u64); 8] = [
     // Difference only in the lowest limb.
     (MAXU, 0xffff_ffff_ffff_ffff, 0xffff_ffff_ffff_fffe),
 ];
-const IMM_CASES: [(usize, u64, u32); IMM_OP_COUNT] = [
+const IMM_CASES: [(usize, u64, u32); 12] = [
     (RORI, 0x0123_4567_89ab_cdef, 45),
     (RORIW, 0x0000_0000_89ab_cdef, 21),
     (CLZ, 0x0000_8000_0000_0000, 0),
@@ -115,15 +119,22 @@ const IMM_CASES: [(usize, u64, u32); IMM_OP_COUNT] = [
     (CTZW, 0x0000_0000_8000_0000, 0),
     (CPOP, 0xf0f0_f0f0_1234_5678, 0),
     (CPOPW, 0xffff_0000_1234_5678, 0),
-    (SEXT_B, 0x80, 0),
-    (SEXT_H, 0x8001, 0),
-    (ZEXT_H, 0xffff_ffff_ffff_8001, 0),
-    (ORC_B, 0x0001_0200_0004_0000, 0),
-    (REV8, 0x0123_4567_89ab_cdef, 0),
     (BCLRI, 0xffff_ffff_ffff_ffff, 47),
     (BSETI, 0, 48),
     (BINVI, 0x1000, 12),
     (BEXTI, 0x8000_0000_0000_0000, 63),
+];
+const BYTE_UNARY_CASES: [(usize, u64, u32); 8] = [
+    // Sign bit set and clear for both extension widths.
+    (SEXT_B, 0x80, 0),
+    (SEXT_B, 0x7f, 0),
+    (SEXT_H, 0x8001, 0),
+    (SEXT_H, 0x1234, 0),
+    (ZEXT_H, 0xffff_ffff_ffff_8001, 0),
+    (ORC_B, 0x0001_0200_0004_0000, 0),
+    // All-zero input: every nz witness is zero.
+    (ORC_B, 0, 0),
+    (REV8, 0x0123_4567_89ab_cdef, 0),
 ];
 
 type RegHarness =
@@ -149,6 +160,12 @@ type MinMaxHarness = TestChipHarness<
     Rv64BitManipMinMaxExecutor,
     Rv64BitManipMinMaxAir,
     Rv64BitManipMinMaxChip<F>,
+>;
+type ByteUnaryHarness = TestChipHarness<
+    F,
+    Rv64BitManipByteUnaryExecutor,
+    Rv64BitManipByteUnaryAir,
+    Rv64BitManipByteUnaryChip<F>,
 >;
 
 fn create_shadd_harness_fields(
@@ -352,6 +369,51 @@ fn create_min_max_harness(tester: &VmChipTestBuilder<F>) -> MinMaxHarness {
     MinMaxHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
 }
 
+fn create_byte_unary_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+    bitwise_chip: SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+) -> (
+    Rv64BitManipByteUnaryAir,
+    Rv64BitManipByteUnaryExecutor,
+    Rv64BitManipByteUnaryChip<F>,
+) {
+    let air = Rv64BitManipByteUnaryAir::new(
+        Rv64BaseAluImmAdapterAir::new(execution_bridge, memory_bridge),
+        BitManipByteUnaryCoreAir::new(bitwise_chip.bus()),
+    );
+    let executor = Rv64BitManipByteUnaryExecutor::new(Rv64BaseAluImmAdapterExecutor::new());
+    let chip = Rv64BitManipByteUnaryChip::new(
+        BitManipByteUnaryFiller::new(Rv64BaseAluImmAdapterFiller, bitwise_chip),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_byte_unary_harness(
+    tester: &VmChipTestBuilder<F>,
+) -> (
+    ByteUnaryHarness,
+    (
+        BitwiseOperationLookupAir<RV64_BYTE_BITS>,
+        SharedBitwiseOperationLookupChip<RV64_BYTE_BITS>,
+    ),
+) {
+    let bitwise_bus = BitwiseOperationLookupBus::new(BITWISE_OP_LOOKUP_BUS);
+    let bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        bitwise_bus,
+    ));
+    let (air, executor, chip) = create_byte_unary_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+        bitwise_chip.clone(),
+    );
+    let harness = ByteUnaryHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY);
+    (harness, (bitwise_chip.air, bitwise_chip))
+}
+
 fn execute_reg<RA: Arena, E: PreflightExecutor<F, RA>>(
     tester: &mut impl TestBuilder<F>,
     executor: &mut E,
@@ -491,6 +553,32 @@ fn rv64_bitmanip_imm_chip_smoke() {
 }
 
 #[test]
+fn rv64_bitmanip_byte_unary_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let (mut harness, bitwise) = create_byte_unary_harness(&tester);
+
+    for (local_opcode, rs1, imm) in BYTE_UNARY_CASES {
+        execute_imm(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            imm,
+        );
+    }
+
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
+    tester.simple_test().expect("verification failed");
+}
+
+#[test]
 fn rv64_bitmanip_bitwise_inv_chip_smoke() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
@@ -564,6 +652,76 @@ type GpuMinMaxHarness = GpuTestChipHarness<
     Rv64BitManipMinMaxChipGpu,
     Rv64BitManipMinMaxChip<F>,
 >;
+
+#[cfg(feature = "cuda")]
+type GpuByteUnaryHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipByteUnaryExecutor,
+    Rv64BitManipByteUnaryAir,
+    Rv64BitManipByteUnaryChipGpu,
+    Rv64BitManipByteUnaryChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
+fn create_cuda_byte_unary_harness(tester: &GpuChipTestBuilder) -> GpuByteUnaryHarness {
+    // The CPU chip only regenerates the trace for comparison; its lookup
+    // requests must be discarded (the GPU kernel already adds them).
+    let dummy_bitwise_chip = Arc::new(BitwiseOperationLookupChip::<RV64_BYTE_BITS>::new(
+        default_bitwise_lookup_bus(),
+    ));
+    let (air, executor, cpu_chip) = create_byte_unary_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+        dummy_bitwise_chip,
+    );
+    let gpu_chip = Rv64BitManipByteUnaryChipGpu::new(
+        tester.range_checker(),
+        tester.bitwise_op_lookup(),
+        tester.timestamp_max_bits(),
+    );
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_byte_unary_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester =
+        GpuChipTestBuilder::default().with_bitwise_op_lookup(default_bitwise_lookup_bus());
+    let mut harness = create_cuda_byte_unary_harness(&tester);
+
+    for (local_opcode, rs1, imm) in BYTE_UNARY_CASES {
+        execute_imm(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            imm,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluImmAdapterRecord,
+        &'a mut BitManipByteUnaryCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluImmAdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
+}
 
 #[cfg(feature = "cuda")]
 type GpuShAddHarness = GpuTestChipHarness<

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -8,6 +8,17 @@ use openvm_circuit::{
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::rngs::StdRng;
+#[cfg(feature = "cuda")]
+use {
+    crate::{
+        adapters::{Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegU16AdapterRecord},
+        Rv64BitManipImmChipGpu, Rv64BitManipRegChipGpu,
+    },
+    openvm_circuit::arch::{
+        testing::{GpuChipTestBuilder, GpuTestChipHarness},
+        EmptyAdapterCoreLayout,
+    },
+};
 
 use super::{
     core::*, Rv64BitManipImmAir, Rv64BitManipImmChip, Rv64BitManipImmExecutor, Rv64BitManipRegAir,
@@ -25,6 +36,50 @@ use crate::{
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
+const REG_CASES: [(usize, u64, u64); REG_OP_COUNT] = [
+    (SH1ADD, 0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210),
+    (SH2ADD, 0x8000_0000_0000_0001, 0x7fff_ffff_ffff_ffff),
+    (SH3ADD, 0xffff_ffff_ffff_ffff, 2),
+    (ADD_UW, 0xffff_ffff_8000_0001, 9),
+    (SH1ADD_UW, 0xffff_ffff_8000_0001, 9),
+    (SH2ADD_UW, 0xffff_ffff_8000_0001, 9),
+    (SH3ADD_UW, 0xffff_ffff_8000_0001, 9),
+    (ANDN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+    (ORN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+    (XNOR, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
+    (ROL, 0x0123_4567_89ab_cdef, 13),
+    (ROR, 0x0123_4567_89ab_cdef, 45),
+    (ROLW, 0x89ab_cdef, 7),
+    (RORW, 0x89ab_cdef, 11),
+    (MIN, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (MINU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (MAX, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (MAXU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
+    (BCLR, 0xffff_ffff_ffff_ffff, 63),
+    (BSET, 0, 37),
+    (BINV, 0x1000, 12),
+    (BEXT, 0x8000_0000_0000_0000, 63),
+];
+const IMM_CASES: [(usize, u64, u32); IMM_OP_COUNT] = [
+    (SLLI_UW, 0xffff_ffff_8000_0001, 37),
+    (RORI, 0x0123_4567_89ab_cdef, 45),
+    (RORIW, 0x0000_0000_89ab_cdef, 21),
+    (CLZ, 0x0000_8000_0000_0000, 0),
+    (CTZ, 0x0000_0000_0000_8000, 0),
+    (CLZW, 0x0000_0000_0000_8000, 0),
+    (CTZW, 0x0000_0000_8000_0000, 0),
+    (CPOP, 0xf0f0_f0f0_1234_5678, 0),
+    (CPOPW, 0xffff_0000_1234_5678, 0),
+    (SEXT_B, 0x80, 0),
+    (SEXT_H, 0x8001, 0),
+    (ZEXT_H, 0xffff_ffff_ffff_8001, 0),
+    (ORC_B, 0x0001_0200_0004_0000, 0),
+    (REV8, 0x0123_4567_89ab_cdef, 0),
+    (BCLRI, 0xffff_ffff_ffff_ffff, 47),
+    (BSETI, 0, 48),
+    (BINVI, 0x1000, 12),
+    (BEXTI, 0x8000_0000_0000_0000, 63),
+];
 
 type RegHarness =
     TestChipHarness<F, Rv64BitManipRegExecutor, Rv64BitManipRegAir, Rv64BitManipRegChip<F>>;
@@ -147,32 +202,7 @@ fn rv64_bitmanip_reg_chip_smoke() {
     let mut tester = VmChipTestBuilder::default();
     let mut harness = create_reg_harness(&tester);
 
-    let cases = [
-        (SH1ADD, 0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210),
-        (SH2ADD, 0x8000_0000_0000_0001, 0x7fff_ffff_ffff_ffff),
-        (SH3ADD, 0xffff_ffff_ffff_ffff, 2),
-        (ADD_UW, 0xffff_ffff_8000_0001, 9),
-        (SH1ADD_UW, 0xffff_ffff_8000_0001, 9),
-        (SH2ADD_UW, 0xffff_ffff_8000_0001, 9),
-        (SH3ADD_UW, 0xffff_ffff_8000_0001, 9),
-        (ANDN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
-        (ORN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
-        (XNOR, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
-        (ROL, 0x0123_4567_89ab_cdef, 13),
-        (ROR, 0x0123_4567_89ab_cdef, 45),
-        (ROLW, 0x89ab_cdef, 7),
-        (RORW, 0x89ab_cdef, 11),
-        (MIN, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-        (MINU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-        (MAX, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-        (MAXU, 0xffff_ffff_ffff_ff00, 0x7fff_ffff_ffff_ffff),
-        (BCLR, 0xffff_ffff_ffff_ffff, 63),
-        (BSET, 0, 37),
-        (BINV, 0x1000, 12),
-        (BEXT, 0x8000_0000_0000_0000, 63),
-    ];
-
-    for (local_opcode, rs1, rs2) in cases {
+    for (local_opcode, rs1, rs2) in REG_CASES {
         execute_reg(
             &mut tester,
             &mut harness.executor,
@@ -194,28 +224,7 @@ fn rv64_bitmanip_imm_chip_smoke() {
     let mut tester = VmChipTestBuilder::default();
     let mut harness = create_imm_harness(&tester);
 
-    let cases = [
-        (SLLI_UW, 0xffff_ffff_8000_0001, 37),
-        (RORI, 0x0123_4567_89ab_cdef, 45),
-        (RORIW, 0x0000_0000_89ab_cdef, 21),
-        (CLZ, 0x0000_8000_0000_0000, 0),
-        (CTZ, 0x0000_0000_0000_8000, 0),
-        (CLZW, 0x0000_0000_0000_8000, 0),
-        (CTZW, 0x0000_0000_8000_0000, 0),
-        (CPOP, 0xf0f0_f0f0_1234_5678, 0),
-        (CPOPW, 0xffff_0000_1234_5678, 0),
-        (SEXT_B, 0x80, 0),
-        (SEXT_H, 0x8001, 0),
-        (ZEXT_H, 0xffff_ffff_ffff_8001, 0),
-        (ORC_B, 0x0001_0200_0004_0000, 0),
-        (REV8, 0x0123_4567_89ab_cdef, 0),
-        (BCLRI, 0xffff_ffff_ffff_ffff, 47),
-        (BSETI, 0, 48),
-        (BINVI, 0x1000, 12),
-        (BEXTI, 0x8000_0000_0000_0000, 63),
-    ];
-
-    for (local_opcode, rs1, imm) in cases {
+    for (local_opcode, rs1, imm) in IMM_CASES {
         execute_imm(
             &mut tester,
             &mut harness.executor,
@@ -229,4 +238,122 @@ fn rv64_bitmanip_imm_chip_smoke() {
 
     let tester = tester.build().load(harness).finalize();
     tester.simple_test().expect("verification failed");
+}
+
+#[cfg(feature = "cuda")]
+type GpuRegHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipRegExecutor,
+    Rv64BitManipRegAir,
+    Rv64BitManipRegChipGpu,
+    Rv64BitManipRegChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
+type GpuImmHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipImmExecutor,
+    Rv64BitManipImmAir,
+    Rv64BitManipImmChipGpu,
+    Rv64BitManipImmChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
+fn create_cuda_reg_harness(tester: &GpuChipTestBuilder) -> GpuRegHarness {
+    let (air, executor, cpu_chip) = create_reg_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+    );
+    let gpu_chip = Rv64BitManipRegChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
+fn create_cuda_imm_harness(tester: &GpuChipTestBuilder) -> GpuImmHarness {
+    let (air, executor, cpu_chip) = create_imm_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+    );
+    let gpu_chip = Rv64BitManipImmChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_reg_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::default();
+    let mut harness = create_cuda_reg_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in REG_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluRegU16AdapterRecord,
+        &'a mut BitManipRegCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluRegU16AdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_imm_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::default();
+    let mut harness = create_cuda_imm_harness(&tester);
+
+    for (local_opcode, rs1, imm) in IMM_CASES {
+        execute_imm(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            imm,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluImmU16AdapterRecord,
+        &'a mut BitManipImmCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluImmU16AdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
 }

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -5,6 +5,7 @@ use openvm_circuit::{
     },
     system::memory::{offline_checker::MemoryBridge, SharedMemoryHelper},
 };
+use openvm_circuit_primitives::var_range::SharedVariableRangeCheckerChip;
 use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::rngs::StdRng;
@@ -12,7 +13,8 @@ use rand::rngs::StdRng;
 use {
     crate::{
         adapters::{Rv64BaseAluImmU16AdapterRecord, Rv64BaseAluRegU16AdapterRecord},
-        Rv64BitManipImmChipGpu, Rv64BitManipRegChipGpu,
+        Rv64BitManipImmChipGpu, Rv64BitManipRegChipGpu, Rv64BitManipShAddChipGpu,
+        Rv64BitManipSlliUwChipGpu,
     },
     openvm_circuit::arch::{
         testing::{GpuChipTestBuilder, GpuTestChipHarness},
@@ -22,7 +24,9 @@ use {
 
 use super::{
     core::*, Rv64BitManipImmAir, Rv64BitManipImmChip, Rv64BitManipImmExecutor, Rv64BitManipRegAir,
-    Rv64BitManipRegChip, Rv64BitManipRegExecutor,
+    Rv64BitManipRegChip, Rv64BitManipRegExecutor, Rv64BitManipShAddAir, Rv64BitManipShAddChip,
+    Rv64BitManipShAddExecutor, Rv64BitManipSlliUwAir, Rv64BitManipSlliUwChip,
+    Rv64BitManipSlliUwExecutor,
 };
 use crate::{
     adapters::{
@@ -32,11 +36,12 @@ use crate::{
     },
     test_utils::rv64_rand_write_register_or_imm,
     BitManipImmCoreAir, BitManipImmFiller, BitManipRegCoreAir, BitManipRegFiller,
+    BitManipSlliUwCoreAir, BitManipSlliUwFiller,
 };
 
 type F = BabyBear;
 const MAX_INS_CAPACITY: usize = 128;
-const REG_CASES: [(usize, u64, u64); REG_OP_COUNT] = [
+const SHADD_CASES: [(usize, u64, u64); SHADD_OP_COUNT] = [
     (SH1ADD, 0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210),
     (SH2ADD, 0x8000_0000_0000_0001, 0x7fff_ffff_ffff_ffff),
     (SH3ADD, 0xffff_ffff_ffff_ffff, 2),
@@ -44,6 +49,14 @@ const REG_CASES: [(usize, u64, u64); REG_OP_COUNT] = [
     (SH1ADD_UW, 0xffff_ffff_8000_0001, 9),
     (SH2ADD_UW, 0xffff_ffff_8000_0001, 9),
     (SH3ADD_UW, 0xffff_ffff_8000_0001, 9),
+];
+const SLLI_UW_CASES: [(usize, u64, u32); 4] = [
+    (SLLI_UW, 0xffff_ffff_8000_0001, 0),
+    (SLLI_UW, 0xffff_ffff_8000_0001, 15),
+    (SLLI_UW, 0xffff_ffff_8000_0001, 37),
+    (SLLI_UW, 0x0000_0000_dead_beef, 63),
+];
+const REG_CASES: [(usize, u64, u64); REG_OP_COUNT] = [
     (ANDN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
     (ORN, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
     (XNOR, 0x55aa_0ff0_f00f_aa55, 0x0f0f_f0f0_3333_cccc),
@@ -61,7 +74,6 @@ const REG_CASES: [(usize, u64, u64); REG_OP_COUNT] = [
     (BEXT, 0x8000_0000_0000_0000, 63),
 ];
 const IMM_CASES: [(usize, u64, u32); IMM_OP_COUNT] = [
-    (SLLI_UW, 0xffff_ffff_8000_0001, 37),
     (RORI, 0x0123_4567_89ab_cdef, 45),
     (RORIW, 0x0000_0000_89ab_cdef, 21),
     (CLZ, 0x0000_8000_0000_0000, 0),
@@ -83,8 +95,80 @@ const IMM_CASES: [(usize, u64, u32); IMM_OP_COUNT] = [
 
 type RegHarness =
     TestChipHarness<F, Rv64BitManipRegExecutor, Rv64BitManipRegAir, Rv64BitManipRegChip<F>>;
+type ShAddHarness =
+    TestChipHarness<F, Rv64BitManipShAddExecutor, Rv64BitManipShAddAir, Rv64BitManipShAddChip<F>>;
+type SlliUwHarness = TestChipHarness<
+    F,
+    Rv64BitManipSlliUwExecutor,
+    Rv64BitManipSlliUwAir,
+    Rv64BitManipSlliUwChip<F>,
+>;
 type ImmHarness =
     TestChipHarness<F, Rv64BitManipImmExecutor, Rv64BitManipImmAir, Rv64BitManipImmChip<F>>;
+
+fn create_shadd_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+    range_checker: SharedVariableRangeCheckerChip,
+) -> (
+    Rv64BitManipShAddAir,
+    Rv64BitManipShAddExecutor,
+    Rv64BitManipShAddChip<F>,
+) {
+    let air = Rv64BitManipShAddAir::new(
+        Rv64BaseAluRegU16AdapterAir::new(execution_bridge, memory_bridge),
+        BitManipShAddCoreAir::new(range_checker.bus()),
+    );
+    let executor = Rv64BitManipShAddExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+    let chip = Rv64BitManipShAddChip::new(
+        BitManipShAddFiller::new(Rv64BaseAluRegU16AdapterFiller::new(), range_checker),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_shadd_harness(tester: &VmChipTestBuilder<F>) -> ShAddHarness {
+    let (air, executor, chip) = create_shadd_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+        tester.range_checker(),
+    );
+    ShAddHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+}
+
+fn create_slli_uw_harness_fields(
+    memory_bridge: MemoryBridge,
+    execution_bridge: ExecutionBridge,
+    memory_helper: SharedMemoryHelper<F>,
+    range_checker: SharedVariableRangeCheckerChip,
+) -> (
+    Rv64BitManipSlliUwAir,
+    Rv64BitManipSlliUwExecutor,
+    Rv64BitManipSlliUwChip<F>,
+) {
+    let air = Rv64BitManipSlliUwAir::new(
+        Rv64BaseAluImmU16AdapterAir::new(execution_bridge, memory_bridge),
+        BitManipSlliUwCoreAir::new(range_checker.bus()),
+    );
+    let executor = Rv64BitManipSlliUwExecutor::new(Rv64BaseAluImmU16AdapterExecutor);
+    let chip = Rv64BitManipSlliUwChip::new(
+        BitManipSlliUwFiller::new(Rv64BaseAluImmU16AdapterFiller::new(), range_checker),
+        memory_helper,
+    );
+    (air, executor, chip)
+}
+
+fn create_slli_uw_harness(tester: &VmChipTestBuilder<F>) -> SlliUwHarness {
+    let (air, executor, chip) = create_slli_uw_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.memory_helper(),
+        tester.range_checker(),
+    );
+    SlliUwHarness::with_capacity(executor, air, chip, MAX_INS_CAPACITY)
+}
 
 fn create_reg_harness_fields(
     memory_bridge: MemoryBridge,
@@ -197,6 +281,50 @@ fn execute_imm<RA: Arena, E: PreflightExecutor<F, RA>>(
 }
 
 #[test]
+fn rv64_bitmanip_shadd_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let mut harness = create_shadd_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in SHADD_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    let tester = tester.build().load(harness).finalize();
+    tester.simple_test().expect("verification failed");
+}
+
+#[test]
+fn rv64_bitmanip_slli_uw_chip_smoke() {
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let mut harness = create_slli_uw_harness(&tester);
+
+    for (local_opcode, rs1, imm) in SLLI_UW_CASES {
+        execute_imm(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            imm,
+        );
+    }
+
+    let tester = tester.build().load(harness).finalize();
+    tester.simple_test().expect("verification failed");
+}
+
+#[test]
 fn rv64_bitmanip_reg_chip_smoke() {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
@@ -250,6 +378,24 @@ type GpuRegHarness = GpuTestChipHarness<
 >;
 
 #[cfg(feature = "cuda")]
+type GpuShAddHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipShAddExecutor,
+    Rv64BitManipShAddAir,
+    Rv64BitManipShAddChipGpu,
+    Rv64BitManipShAddChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
+type GpuSlliUwHarness = GpuTestChipHarness<
+    F,
+    Rv64BitManipSlliUwExecutor,
+    Rv64BitManipSlliUwAir,
+    Rv64BitManipSlliUwChipGpu,
+    Rv64BitManipSlliUwChip<F>,
+>;
+
+#[cfg(feature = "cuda")]
 type GpuImmHarness = GpuTestChipHarness<
     F,
     Rv64BitManipImmExecutor,
@@ -257,6 +403,32 @@ type GpuImmHarness = GpuTestChipHarness<
     Rv64BitManipImmChipGpu,
     Rv64BitManipImmChip<F>,
 >;
+
+#[cfg(feature = "cuda")]
+fn create_cuda_shadd_harness(tester: &GpuChipTestBuilder) -> GpuShAddHarness {
+    let (air, executor, cpu_chip) = create_shadd_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+        tester.cpu_range_checker(),
+    );
+    let gpu_chip =
+        Rv64BitManipShAddChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
+fn create_cuda_slli_uw_harness(tester: &GpuChipTestBuilder) -> GpuSlliUwHarness {
+    let (air, executor, cpu_chip) = create_slli_uw_harness_fields(
+        tester.memory_bridge(),
+        tester.execution_bridge(),
+        tester.dummy_memory_helper(),
+        tester.cpu_range_checker(),
+    );
+    let gpu_chip =
+        Rv64BitManipSlliUwChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
+    GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
 
 #[cfg(feature = "cuda")]
 fn create_cuda_reg_harness(tester: &GpuChipTestBuilder) -> GpuRegHarness {
@@ -278,6 +450,84 @@ fn create_cuda_imm_harness(tester: &GpuChipTestBuilder) -> GpuImmHarness {
     );
     let gpu_chip = Rv64BitManipImmChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
     GpuTestChipHarness::with_capacity(executor, air, gpu_chip, cpu_chip, MAX_INS_CAPACITY)
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_shadd_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::default();
+    let mut harness = create_cuda_shadd_harness(&tester);
+
+    for (local_opcode, rs1, rs2) in SHADD_CASES {
+        execute_reg(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            rs2,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluRegU16AdapterRecord,
+        &'a mut BitManipShAddCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluRegU16AdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn test_cuda_bitmanip_slli_uw_tracegen() {
+    let mut rng = create_seeded_rng();
+    let mut tester = GpuChipTestBuilder::default();
+    let mut harness = create_cuda_slli_uw_harness(&tester);
+
+    for (local_opcode, rs1, imm) in SLLI_UW_CASES {
+        execute_imm(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.dense_arena,
+            &mut rng,
+            local_opcode,
+            rs1,
+            imm,
+        );
+    }
+
+    type Record<'a> = (
+        &'a mut Rv64BaseAluImmU16AdapterRecord,
+        &'a mut BitManipSlliUwCoreRecord,
+    );
+    harness
+        .dense_arena
+        .get_record_seeker::<Record, _>()
+        .transfer_to_matrix_arena(
+            &mut harness.matrix_arena,
+            EmptyAdapterCoreLayout::<F, Rv64BaseAluImmU16AdapterExecutor>::new(),
+        );
+
+    tester
+        .build()
+        .load_gpu_harness(harness)
+        .finalize()
+        .simple_test()
+        .unwrap();
 }
 
 #[cfg(feature = "cuda")]

--- a/extensions/riscv/circuit/src/bitmanip/tests.rs
+++ b/extensions/riscv/circuit/src/bitmanip/tests.rs
@@ -17,9 +17,11 @@ use {
         Rv64BitManipSlliUwChipGpu,
     },
     openvm_circuit::arch::{
-        testing::{GpuChipTestBuilder, GpuTestChipHarness},
+        testing::{default_var_range_checker_bus, GpuChipTestBuilder, GpuTestChipHarness},
         EmptyAdapterCoreLayout,
     },
+    openvm_circuit_primitives::var_range::VariableRangeCheckerChip,
+    std::sync::Arc,
 };
 
 use super::{
@@ -406,11 +408,17 @@ type GpuImmHarness = GpuTestChipHarness<
 
 #[cfg(feature = "cuda")]
 fn create_cuda_shadd_harness(tester: &GpuChipTestBuilder) -> GpuShAddHarness {
+    // The CPU chip only regenerates the trace for comparison against the GPU
+    // trace; its range-checker counts must be discarded (the GPU kernel already
+    // adds them), so give it a dummy chip rather than the hybrid mirror.
+    let dummy_range_checker_chip = Arc::new(VariableRangeCheckerChip::new(
+        default_var_range_checker_bus(),
+    ));
     let (air, executor, cpu_chip) = create_shadd_harness_fields(
         tester.memory_bridge(),
         tester.execution_bridge(),
         tester.dummy_memory_helper(),
-        tester.cpu_range_checker(),
+        dummy_range_checker_chip,
     );
     let gpu_chip =
         Rv64BitManipShAddChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());
@@ -419,11 +427,14 @@ fn create_cuda_shadd_harness(tester: &GpuChipTestBuilder) -> GpuShAddHarness {
 
 #[cfg(feature = "cuda")]
 fn create_cuda_slli_uw_harness(tester: &GpuChipTestBuilder) -> GpuSlliUwHarness {
+    let dummy_range_checker_chip = Arc::new(VariableRangeCheckerChip::new(
+        default_var_range_checker_bus(),
+    ));
     let (air, executor, cpu_chip) = create_slli_uw_harness_fields(
         tester.memory_bridge(),
         tester.execution_bridge(),
         tester.dummy_memory_helper(),
-        tester.cpu_range_checker(),
+        dummy_range_checker_chip,
     );
     let gpu_chip =
         Rv64BitManipSlliUwChipGpu::new(tester.range_checker(), tester.timestamp_max_bits());

--- a/extensions/riscv/circuit/src/cuda_abi.rs
+++ b/extensions/riscv/circuit/src/cuda_abi.rs
@@ -974,6 +974,83 @@ pub mod bitwise_logic_cuda {
     }
 }
 
+pub mod bitmanip_bitwise_inv_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_bitwise_inv_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            d_bitwise_lookup: *mut u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        d_bitwise_lookup: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_bitwise_inv_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            d_bitwise_lookup.as_mut_ptr() as *mut u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
+pub mod bitmanip_min_max_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_min_max_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_min_max_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
 pub mod bitmanip_shadd_cuda {
     use super::*;
 

--- a/extensions/riscv/circuit/src/cuda_abi.rs
+++ b/extensions/riscv/circuit/src/cuda_abi.rs
@@ -974,6 +974,80 @@ pub mod bitwise_logic_cuda {
     }
 }
 
+pub mod bitmanip_shadd_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_shadd_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_shadd_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
+pub mod bitmanip_slli_uw_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_slli_uw_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_slli_uw_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
 pub mod bitmanip_reg_cuda {
     use super::*;
 

--- a/extensions/riscv/circuit/src/cuda_abi.rs
+++ b/extensions/riscv/circuit/src/cuda_abi.rs
@@ -974,6 +974,46 @@ pub mod bitwise_logic_cuda {
     }
 }
 
+pub mod bitmanip_byte_unary_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_byte_unary_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            d_bitwise_lookup: *mut u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        d_bitwise_lookup: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_byte_unary_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            d_bitwise_lookup.as_mut_ptr() as *mut u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
 pub mod bitmanip_bitwise_inv_cuda {
     use super::*;
 

--- a/extensions/riscv/circuit/src/cuda_abi.rs
+++ b/extensions/riscv/circuit/src/cuda_abi.rs
@@ -974,6 +974,80 @@ pub mod bitwise_logic_cuda {
     }
 }
 
+pub mod bitmanip_reg_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_reg_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_reg_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
+pub mod bitmanip_imm_cuda {
+    use super::*;
+
+    extern "C" {
+        fn _rv64_bitmanip_imm_tracegen(
+            d_trace: *mut F,
+            height: usize,
+            width: usize,
+            d_records: DeviceBufferView,
+            d_range_checker: *mut u32,
+            range_checker_num_bins: u32,
+            timestamp_max_bits: u32,
+            stream: cudaStream_t,
+        ) -> i32;
+    }
+
+    pub unsafe fn tracegen(
+        d_trace: &DeviceBuffer<F>,
+        height: usize,
+        d_records: &DeviceBuffer<u8>,
+        d_range_checker: &DeviceBuffer<F>,
+        timestamp_max_bits: u32,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        CudaError::from_result(_rv64_bitmanip_imm_tracegen(
+            d_trace.as_mut_ptr(),
+            height,
+            d_trace.len() / height,
+            d_records.view(),
+            d_range_checker.as_mut_ptr() as *mut u32,
+            d_range_checker.len() as u32,
+            timestamp_max_bits,
+            stream,
+        ))
+    }
+}
+
 pub mod jal_lui_cuda {
     use super::*;
 

--- a/extensions/riscv/circuit/src/extension/cuda.rs
+++ b/extensions/riscv/circuit/src/extension/cuda.rs
@@ -12,22 +12,24 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
 use crate::{
     Rv64AddIAir, Rv64AddIChipGpu, Rv64AddIWAir, Rv64AddIWChipGpu, Rv64AddSubAir, Rv64AddSubChipGpu,
-    Rv64AddSubWAir, Rv64AddSubWChipGpu, Rv64AuipcAir, Rv64AuipcChipGpu, Rv64B, Rv64BitManipImmAir,
-    Rv64BitManipImmChipGpu, Rv64BitManipRegAir, Rv64BitManipRegChipGpu, Rv64BitManipShAddAir,
-    Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwAir, Rv64BitManipSlliUwChipGpu,
-    Rv64BitwiseLogicAir, Rv64BitwiseLogicChipGpu, Rv64BitwiseLogicImmAir,
-    Rv64BitwiseLogicImmChipGpu, Rv64BranchEqualAir, Rv64BranchEqualChipGpu, Rv64BranchLessThanAir,
-    Rv64BranchLessThanChipGpu, Rv64DivRemAir, Rv64DivRemChipGpu, Rv64DivRemWAir,
-    Rv64DivRemWChipGpu, Rv64HintStoreAir, Rv64HintStoreChipGpu, Rv64I, Rv64Io, Rv64JalLuiAir,
-    Rv64JalLuiChipGpu, Rv64JalrAir, Rv64JalrChipGpu, Rv64LessThanAir, Rv64LessThanChipGpu,
-    Rv64LessThanImmAir, Rv64LessThanImmChipGpu, Rv64LoadByteAir, Rv64LoadByteChipGpu,
-    Rv64LoadDoublewordAir, Rv64LoadDoublewordChipGpu, Rv64LoadHalfwordAir, Rv64LoadHalfwordChipGpu,
-    Rv64LoadSignExtendByteAir, Rv64LoadSignExtendByteChipGpu, Rv64LoadSignExtendHalfwordAir,
-    Rv64LoadSignExtendHalfwordChipGpu, Rv64LoadSignExtendWordAir, Rv64LoadSignExtendWordChipGpu,
-    Rv64LoadWordAir, Rv64LoadWordChipGpu, Rv64M, Rv64MulHAir, Rv64MulHChipGpu, Rv64MulWAir,
-    Rv64MulWChipGpu, Rv64MultiplicationAir, Rv64MultiplicationChipGpu, Rv64ShiftLogicalAir,
-    Rv64ShiftLogicalChipGpu, Rv64ShiftLogicalImmAir, Rv64ShiftLogicalImmChipGpu,
-    Rv64ShiftRightArithmeticAir, Rv64ShiftRightArithmeticChipGpu, Rv64ShiftRightArithmeticImmAir,
+    Rv64AddSubWAir, Rv64AddSubWChipGpu, Rv64AuipcAir, Rv64AuipcChipGpu, Rv64B,
+    Rv64BitManipBitwiseInvAir, Rv64BitManipBitwiseInvChipGpu, Rv64BitManipImmAir,
+    Rv64BitManipImmChipGpu, Rv64BitManipMinMaxAir, Rv64BitManipMinMaxChipGpu, Rv64BitManipRegAir,
+    Rv64BitManipRegChipGpu, Rv64BitManipShAddAir, Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwAir,
+    Rv64BitManipSlliUwChipGpu, Rv64BitwiseLogicAir, Rv64BitwiseLogicChipGpu,
+    Rv64BitwiseLogicImmAir, Rv64BitwiseLogicImmChipGpu, Rv64BranchEqualAir, Rv64BranchEqualChipGpu,
+    Rv64BranchLessThanAir, Rv64BranchLessThanChipGpu, Rv64DivRemAir, Rv64DivRemChipGpu,
+    Rv64DivRemWAir, Rv64DivRemWChipGpu, Rv64HintStoreAir, Rv64HintStoreChipGpu, Rv64I, Rv64Io,
+    Rv64JalLuiAir, Rv64JalLuiChipGpu, Rv64JalrAir, Rv64JalrChipGpu, Rv64LessThanAir,
+    Rv64LessThanChipGpu, Rv64LessThanImmAir, Rv64LessThanImmChipGpu, Rv64LoadByteAir,
+    Rv64LoadByteChipGpu, Rv64LoadDoublewordAir, Rv64LoadDoublewordChipGpu, Rv64LoadHalfwordAir,
+    Rv64LoadHalfwordChipGpu, Rv64LoadSignExtendByteAir, Rv64LoadSignExtendByteChipGpu,
+    Rv64LoadSignExtendHalfwordAir, Rv64LoadSignExtendHalfwordChipGpu, Rv64LoadSignExtendWordAir,
+    Rv64LoadSignExtendWordChipGpu, Rv64LoadWordAir, Rv64LoadWordChipGpu, Rv64M, Rv64MulHAir,
+    Rv64MulHChipGpu, Rv64MulWAir, Rv64MulWChipGpu, Rv64MultiplicationAir,
+    Rv64MultiplicationChipGpu, Rv64ShiftLogicalAir, Rv64ShiftLogicalChipGpu,
+    Rv64ShiftLogicalImmAir, Rv64ShiftLogicalImmChipGpu, Rv64ShiftRightArithmeticAir,
+    Rv64ShiftRightArithmeticChipGpu, Rv64ShiftRightArithmeticImmAir,
     Rv64ShiftRightArithmeticImmChipGpu, Rv64ShiftWLogicalAir, Rv64ShiftWLogicalChipGpu,
     Rv64ShiftWLogicalImmAir, Rv64ShiftWLogicalImmChipGpu, Rv64ShiftWRightArithmeticAir,
     Rv64ShiftWRightArithmeticChipGpu, Rv64ShiftWRightArithmeticImmAir,
@@ -353,6 +355,7 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64B> for 
     ) -> Result<(), ChipInventoryError> {
         let timestamp_max_bits = inventory.timestamp_max_bits();
         let range_checker = get_inventory_range_checker(inventory);
+        let bitwise_lu = get_or_create_bitwise_op_lookup(inventory)?;
 
         inventory.next_air::<Rv64BitManipShAddAir>()?;
         let shadd = Rv64BitManipShAddChipGpu::new(range_checker.clone(), timestamp_max_bits);
@@ -369,6 +372,18 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64B> for 
         inventory.next_air::<Rv64BitManipImmAir>()?;
         let imm = Rv64BitManipImmChipGpu::new(range_checker.clone(), timestamp_max_bits);
         inventory.add_executor_chip(imm);
+
+        inventory.next_air::<Rv64BitManipBitwiseInvAir>()?;
+        let bitwise_inv = Rv64BitManipBitwiseInvChipGpu::new(
+            range_checker.clone(),
+            bitwise_lu.clone(),
+            timestamp_max_bits,
+        );
+        inventory.add_executor_chip(bitwise_inv);
+
+        inventory.next_air::<Rv64BitManipMinMaxAir>()?;
+        let min_max = Rv64BitManipMinMaxChipGpu::new(range_checker.clone(), timestamp_max_bits);
+        inventory.add_executor_chip(min_max);
 
         Ok(())
     }

--- a/extensions/riscv/circuit/src/extension/cuda.rs
+++ b/extensions/riscv/circuit/src/extension/cuda.rs
@@ -13,14 +13,15 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 use crate::{
     Rv64AddIAir, Rv64AddIChipGpu, Rv64AddIWAir, Rv64AddIWChipGpu, Rv64AddSubAir, Rv64AddSubChipGpu,
     Rv64AddSubWAir, Rv64AddSubWChipGpu, Rv64AuipcAir, Rv64AuipcChipGpu, Rv64B, Rv64BitManipImmAir,
-    Rv64BitManipImmChipGpu, Rv64BitManipRegAir, Rv64BitManipRegChipGpu, Rv64BitwiseLogicAir,
-    Rv64BitwiseLogicChipGpu, Rv64BitwiseLogicImmAir, Rv64BitwiseLogicImmChipGpu,
-    Rv64BranchEqualAir, Rv64BranchEqualChipGpu, Rv64BranchLessThanAir, Rv64BranchLessThanChipGpu,
-    Rv64DivRemAir, Rv64DivRemChipGpu, Rv64DivRemWAir, Rv64DivRemWChipGpu, Rv64HintStoreAir,
-    Rv64HintStoreChipGpu, Rv64I, Rv64Io, Rv64JalLuiAir, Rv64JalLuiChipGpu, Rv64JalrAir,
-    Rv64JalrChipGpu, Rv64LessThanAir, Rv64LessThanChipGpu, Rv64LessThanImmAir,
-    Rv64LessThanImmChipGpu, Rv64LoadByteAir, Rv64LoadByteChipGpu, Rv64LoadDoublewordAir,
-    Rv64LoadDoublewordChipGpu, Rv64LoadHalfwordAir, Rv64LoadHalfwordChipGpu,
+    Rv64BitManipImmChipGpu, Rv64BitManipRegAir, Rv64BitManipRegChipGpu, Rv64BitManipShAddAir,
+    Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwAir, Rv64BitManipSlliUwChipGpu,
+    Rv64BitwiseLogicAir, Rv64BitwiseLogicChipGpu, Rv64BitwiseLogicImmAir,
+    Rv64BitwiseLogicImmChipGpu, Rv64BranchEqualAir, Rv64BranchEqualChipGpu, Rv64BranchLessThanAir,
+    Rv64BranchLessThanChipGpu, Rv64DivRemAir, Rv64DivRemChipGpu, Rv64DivRemWAir,
+    Rv64DivRemWChipGpu, Rv64HintStoreAir, Rv64HintStoreChipGpu, Rv64I, Rv64Io, Rv64JalLuiAir,
+    Rv64JalLuiChipGpu, Rv64JalrAir, Rv64JalrChipGpu, Rv64LessThanAir, Rv64LessThanChipGpu,
+    Rv64LessThanImmAir, Rv64LessThanImmChipGpu, Rv64LoadByteAir, Rv64LoadByteChipGpu,
+    Rv64LoadDoublewordAir, Rv64LoadDoublewordChipGpu, Rv64LoadHalfwordAir, Rv64LoadHalfwordChipGpu,
     Rv64LoadSignExtendByteAir, Rv64LoadSignExtendByteChipGpu, Rv64LoadSignExtendHalfwordAir,
     Rv64LoadSignExtendHalfwordChipGpu, Rv64LoadSignExtendWordAir, Rv64LoadSignExtendWordChipGpu,
     Rv64LoadWordAir, Rv64LoadWordChipGpu, Rv64M, Rv64MulHAir, Rv64MulHChipGpu, Rv64MulWAir,
@@ -352,6 +353,14 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64B> for 
     ) -> Result<(), ChipInventoryError> {
         let timestamp_max_bits = inventory.timestamp_max_bits();
         let range_checker = get_inventory_range_checker(inventory);
+
+        inventory.next_air::<Rv64BitManipShAddAir>()?;
+        let shadd = Rv64BitManipShAddChipGpu::new(range_checker.clone(), timestamp_max_bits);
+        inventory.add_executor_chip(shadd);
+
+        inventory.next_air::<Rv64BitManipSlliUwAir>()?;
+        let slli_uw = Rv64BitManipSlliUwChipGpu::new(range_checker.clone(), timestamp_max_bits);
+        inventory.add_executor_chip(slli_uw);
 
         inventory.next_air::<Rv64BitManipRegAir>()?;
         let reg = Rv64BitManipRegChipGpu::new(range_checker.clone(), timestamp_max_bits);

--- a/extensions/riscv/circuit/src/extension/cuda.rs
+++ b/extensions/riscv/circuit/src/extension/cuda.rs
@@ -13,9 +13,10 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 use crate::{
     Rv64AddIAir, Rv64AddIChipGpu, Rv64AddIWAir, Rv64AddIWChipGpu, Rv64AddSubAir, Rv64AddSubChipGpu,
     Rv64AddSubWAir, Rv64AddSubWChipGpu, Rv64AuipcAir, Rv64AuipcChipGpu, Rv64B,
-    Rv64BitManipBitwiseInvAir, Rv64BitManipBitwiseInvChipGpu, Rv64BitManipImmAir,
-    Rv64BitManipImmChipGpu, Rv64BitManipMinMaxAir, Rv64BitManipMinMaxChipGpu, Rv64BitManipRegAir,
-    Rv64BitManipRegChipGpu, Rv64BitManipShAddAir, Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwAir,
+    Rv64BitManipBitwiseInvAir, Rv64BitManipBitwiseInvChipGpu, Rv64BitManipByteUnaryAir,
+    Rv64BitManipByteUnaryChipGpu, Rv64BitManipImmAir, Rv64BitManipImmChipGpu,
+    Rv64BitManipMinMaxAir, Rv64BitManipMinMaxChipGpu, Rv64BitManipRegAir, Rv64BitManipRegChipGpu,
+    Rv64BitManipShAddAir, Rv64BitManipShAddChipGpu, Rv64BitManipSlliUwAir,
     Rv64BitManipSlliUwChipGpu, Rv64BitwiseLogicAir, Rv64BitwiseLogicChipGpu,
     Rv64BitwiseLogicImmAir, Rv64BitwiseLogicImmChipGpu, Rv64BranchEqualAir, Rv64BranchEqualChipGpu,
     Rv64BranchLessThanAir, Rv64BranchLessThanChipGpu, Rv64DivRemAir, Rv64DivRemChipGpu,
@@ -384,6 +385,14 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64B> for 
         inventory.next_air::<Rv64BitManipMinMaxAir>()?;
         let min_max = Rv64BitManipMinMaxChipGpu::new(range_checker.clone(), timestamp_max_bits);
         inventory.add_executor_chip(min_max);
+
+        inventory.next_air::<Rv64BitManipByteUnaryAir>()?;
+        let byte_unary = Rv64BitManipByteUnaryChipGpu::new(
+            range_checker.clone(),
+            bitwise_lu.clone(),
+            timestamp_max_bits,
+        );
+        inventory.add_executor_chip(byte_unary);
 
         Ok(())
     }

--- a/extensions/riscv/circuit/src/extension/cuda.rs
+++ b/extensions/riscv/circuit/src/extension/cuda.rs
@@ -12,7 +12,8 @@ use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
 use crate::{
     Rv64AddIAir, Rv64AddIChipGpu, Rv64AddIWAir, Rv64AddIWChipGpu, Rv64AddSubAir, Rv64AddSubChipGpu,
-    Rv64AddSubWAir, Rv64AddSubWChipGpu, Rv64AuipcAir, Rv64AuipcChipGpu, Rv64BitwiseLogicAir,
+    Rv64AddSubWAir, Rv64AddSubWChipGpu, Rv64AuipcAir, Rv64AuipcChipGpu, Rv64B, Rv64BitManipImmAir,
+    Rv64BitManipImmChipGpu, Rv64BitManipRegAir, Rv64BitManipRegChipGpu, Rv64BitwiseLogicAir,
     Rv64BitwiseLogicChipGpu, Rv64BitwiseLogicImmAir, Rv64BitwiseLogicImmChipGpu,
     Rv64BranchEqualAir, Rv64BranchEqualChipGpu, Rv64BranchLessThanAir, Rv64BranchLessThanChipGpu,
     Rv64DivRemAir, Rv64DivRemChipGpu, Rv64DivRemWAir, Rv64DivRemWChipGpu, Rv64HintStoreAir,
@@ -336,6 +337,29 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64M> for 
             timestamp_max_bits,
         );
         inventory.add_executor_chip(divrem_w);
+
+        Ok(())
+    }
+}
+
+// This implementation is specific to GpuBackend because the lookup chips
+// (VariableRangeCheckerChipGPU, BitwiseOperationLookupChipGPU) are specific to GpuBackend.
+impl VmProverExtension<GpuBabyBearPoseidon2Engine, DenseRecordArena, Rv64B> for Rv64ImGpuProverExt {
+    fn extend_prover(
+        &self,
+        _: &Rv64B,
+        inventory: &mut ChipInventory<BabyBearPoseidon2Config, DenseRecordArena, GpuBackend>,
+    ) -> Result<(), ChipInventoryError> {
+        let timestamp_max_bits = inventory.timestamp_max_bits();
+        let range_checker = get_inventory_range_checker(inventory);
+
+        inventory.next_air::<Rv64BitManipRegAir>()?;
+        let reg = Rv64BitManipRegChipGpu::new(range_checker.clone(), timestamp_max_bits);
+        inventory.add_executor_chip(reg);
+
+        inventory.next_air::<Rv64BitManipImmAir>()?;
+        let imm = Rv64BitManipImmChipGpu::new(range_checker.clone(), timestamp_max_bits);
+        inventory.add_executor_chip(imm);
 
         Ok(())
     }

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -182,6 +182,8 @@ pub enum Rv64MExecutor {
 /// RISC-V 64-bit Bit-Manipulation Instruction Executors
 #[derive(Clone, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
 pub enum Rv64BExecutor {
+    BitManipShAdd(Rv64BitManipShAddExecutor),
+    BitManipSlliUw(Rv64BitManipSlliUwExecutor),
     BitManipReg(Rv64BitManipRegExecutor),
     BitManipImm(Rv64BitManipImmExecutor),
 }
@@ -1366,9 +1368,9 @@ impl VmExecutionExtension for Rv64B {
         &self,
         inventory: &mut ExecutorInventoryBuilder<Rv64BExecutor>,
     ) -> Result<(), ExecutorInventoryError> {
-        let reg = Rv64BitManipRegExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+        let shadd = Rv64BitManipShAddExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
         inventory.add_executor(
-            reg,
+            shadd,
             [
                 ShAddOpcode::SH1ADD.global_opcode(),
                 ShAddOpcode::SH2ADD.global_opcode(),
@@ -1377,6 +1379,16 @@ impl VmExecutionExtension for Rv64B {
                 ShAddOpcode::SH1ADD_UW.global_opcode(),
                 ShAddOpcode::SH2ADD_UW.global_opcode(),
                 ShAddOpcode::SH3ADD_UW.global_opcode(),
+            ],
+        )?;
+
+        let slli_uw = Rv64BitManipSlliUwExecutor::new(Rv64BaseAluImmU16AdapterExecutor);
+        inventory.add_executor(slli_uw, [SlliUwOpcode::SLLI_UW.global_opcode()])?;
+
+        let reg = Rv64BitManipRegExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+        inventory.add_executor(
+            reg,
+            [
                 BitwiseInvOpcode::ANDN.global_opcode(),
                 BitwiseInvOpcode::ORN.global_opcode(),
                 BitwiseInvOpcode::XNOR.global_opcode(),
@@ -1399,7 +1411,6 @@ impl VmExecutionExtension for Rv64B {
         inventory.add_executor(
             imm,
             [
-                SlliUwOpcode::SLLI_UW.global_opcode(),
                 RotateImmOpcode::RORI.global_opcode(),
                 RotateWImmOpcode::RORIW.global_opcode(),
                 CountZerosOpcode::CLZ.global_opcode(),
@@ -1432,6 +1443,19 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64B {
             memory_bridge,
         } = inventory.system().port();
         let exec_bridge = ExecutionBridge::new(execution_bus, program_bus);
+        let range_bus = inventory.range_checker().bus;
+
+        let shadd = Rv64BitManipShAddAir::new(
+            Rv64BaseAluRegU16AdapterAir::new(exec_bridge, memory_bridge),
+            BitManipShAddCoreAir::new(range_bus),
+        );
+        inventory.add_air(shadd);
+
+        let slli_uw = Rv64BitManipSlliUwAir::new(
+            Rv64BaseAluImmU16AdapterAir::new(exec_bridge, memory_bridge),
+            BitManipSlliUwCoreAir::new(range_bus),
+        );
+        inventory.add_air(slli_uw);
 
         let reg = Rv64BitManipRegAir::new(
             Rv64BaseAluRegU16AdapterAir::new(exec_bridge, memory_bridge),
@@ -1464,7 +1488,21 @@ where
     ) -> Result<(), ChipInventoryError> {
         let range_checker = inventory.range_checker()?.clone();
         let timestamp_max_bits = inventory.timestamp_max_bits();
-        let mem_helper = SharedMemoryHelper::new(range_checker, timestamp_max_bits);
+        let mem_helper = SharedMemoryHelper::new(range_checker.clone(), timestamp_max_bits);
+
+        inventory.next_air::<Rv64BitManipShAddAir>()?;
+        let shadd = Rv64BitManipShAddChip::new(
+            BitManipShAddFiller::new(Rv64BaseAluRegU16AdapterFiller::new(), range_checker.clone()),
+            mem_helper.clone(),
+        );
+        inventory.add_executor_chip(shadd);
+
+        inventory.next_air::<Rv64BitManipSlliUwAir>()?;
+        let slli_uw = Rv64BitManipSlliUwChip::new(
+            BitManipSlliUwFiller::new(Rv64BaseAluImmU16AdapterFiller::new(), range_checker.clone()),
+            mem_helper.clone(),
+        );
+        inventory.add_executor_chip(slli_uw);
 
         inventory.next_air::<Rv64BitManipRegAir>()?;
         let reg = Rv64BitManipRegChip::new(

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -188,6 +188,7 @@ pub enum Rv64BExecutor {
     BitManipImm(Rv64BitManipImmExecutor),
     BitManipBitwiseInv(Rv64BitManipBitwiseInvExecutor),
     BitManipMinMax(Rv64BitManipMinMaxExecutor),
+    BitManipByteUnary(Rv64BitManipByteUnaryExecutor),
 }
 
 /// RISC-V 64-bit Io Instruction Executors
@@ -1414,11 +1415,6 @@ impl VmExecutionExtension for Rv64B {
                 CountZerosWOpcode::CTZW.global_opcode(),
                 CpopOpcode::CPOP.global_opcode(),
                 CpopWOpcode::CPOPW.global_opcode(),
-                ByteUnaryOpcode::SEXT_B.global_opcode(),
-                ByteUnaryOpcode::SEXT_H.global_opcode(),
-                ByteUnaryOpcode::ZEXT_H.global_opcode(),
-                ByteUnaryOpcode::ORC_B.global_opcode(),
-                ByteUnaryOpcode::REV8.global_opcode(),
                 SingleBitImmOpcode::BCLRI.global_opcode(),
                 SingleBitImmOpcode::BSETI.global_opcode(),
                 SingleBitImmOpcode::BINVI.global_opcode(),
@@ -1447,6 +1443,18 @@ impl VmExecutionExtension for Rv64B {
                 MinMaxOpcode::MINU.global_opcode(),
                 MinMaxOpcode::MAX.global_opcode(),
                 MinMaxOpcode::MAXU.global_opcode(),
+            ],
+        )?;
+
+        let byte_unary = Rv64BitManipByteUnaryExecutor::new(Rv64BaseAluImmAdapterExecutor::new());
+        inventory.add_executor(
+            byte_unary,
+            [
+                ByteUnaryOpcode::SEXT_B.global_opcode(),
+                ByteUnaryOpcode::SEXT_H.global_opcode(),
+                ByteUnaryOpcode::ZEXT_H.global_opcode(),
+                ByteUnaryOpcode::ORC_B.global_opcode(),
+                ByteUnaryOpcode::REV8.global_opcode(),
             ],
         )?;
 
@@ -1511,6 +1519,12 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64B {
             BitManipMinMaxCoreAir::new(range_bus),
         );
         inventory.add_air(min_max);
+
+        let byte_unary = Rv64BitManipByteUnaryAir::new(
+            Rv64BaseAluImmAdapterAir::new(exec_bridge, memory_bridge),
+            BitManipByteUnaryCoreAir::new(bitwise_lu),
+        );
+        inventory.add_air(byte_unary);
 
         Ok(())
     }
@@ -1577,7 +1591,7 @@ where
 
         inventory.next_air::<Rv64BitManipBitwiseInvAir>()?;
         let bitwise_inv = Rv64BitManipBitwiseInvChip::new(
-            BitManipBitwiseInvFiller::new(Rv64BaseAluRegAdapterFiller, bitwise_lu),
+            BitManipBitwiseInvFiller::new(Rv64BaseAluRegAdapterFiller, bitwise_lu.clone()),
             mem_helper.clone(),
         );
         inventory.add_executor_chip(bitwise_inv);
@@ -1585,9 +1599,16 @@ where
         inventory.next_air::<Rv64BitManipMinMaxAir>()?;
         let min_max = Rv64BitManipMinMaxChip::new(
             BitManipMinMaxFiller::new(Rv64BaseAluRegU16AdapterFiller::new(), range_checker),
-            mem_helper,
+            mem_helper.clone(),
         );
         inventory.add_executor_chip(min_max);
+
+        inventory.next_air::<Rv64BitManipByteUnaryAir>()?;
+        let byte_unary = Rv64BitManipByteUnaryChip::new(
+            BitManipByteUnaryFiller::new(Rv64BaseAluImmAdapterFiller, bitwise_lu),
+            mem_helper,
+        );
+        inventory.add_executor_chip(byte_unary);
 
         Ok(())
     }

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -23,11 +23,13 @@ use openvm_circuit_primitives::{
 use openvm_cpu_backend::{CpuBackend, CpuDevice};
 use openvm_instructions::{program::DEFAULT_PC_STEP, LocalOpcode, PhantomDiscriminant};
 use openvm_riscv_transpiler::{
-    BaseAluImmOpcode, BaseAluOpcode, BaseAluWImmOpcode, BaseAluWOpcode, BranchEqualOpcode,
-    BranchLessThanOpcode, DivRemOpcode, DivRemWOpcode, LessThanImmOpcode, LessThanOpcode,
-    MulHOpcode, MulOpcode, MulWOpcode, Rv64AuipcOpcode, Rv64HintStoreOpcode, Rv64JalLuiOpcode,
-    Rv64JalrOpcode, Rv64LoadStoreOpcode, Rv64Phantom, ShiftImmOpcode, ShiftOpcode, ShiftWImmOpcode,
-    ShiftWOpcode,
+    BaseAluImmOpcode, BaseAluOpcode, BaseAluWImmOpcode, BaseAluWOpcode, BitwiseInvOpcode,
+    BranchEqualOpcode, BranchLessThanOpcode, ByteUnaryOpcode, CountZerosOpcode, CountZerosWOpcode,
+    CpopOpcode, CpopWOpcode, DivRemOpcode, DivRemWOpcode, LessThanImmOpcode, LessThanOpcode,
+    MinMaxOpcode, MulHOpcode, MulOpcode, MulWOpcode, RotateImmOpcode, RotateOpcode,
+    RotateWImmOpcode, RotateWOpcode, Rv64AuipcOpcode, Rv64HintStoreOpcode, Rv64JalLuiOpcode,
+    Rv64JalrOpcode, Rv64LoadStoreOpcode, Rv64Phantom, ShAddOpcode, ShiftImmOpcode, ShiftOpcode,
+    ShiftWImmOpcode, ShiftWOpcode, SingleBitImmOpcode, SingleBitOpcode, SlliUwOpcode,
 };
 #[cfg(feature = "rvr")]
 use openvm_stark_backend::p3_field::PrimeField32;
@@ -73,6 +75,10 @@ pub struct Rv64M {
     #[serde(default = "default_range_tuple_checker_sizes")]
     pub range_tuple_checker_sizes: [u32; 2],
 }
+
+/// RISC-V 64-bit bit-manipulation extension (Zba + Zbb + Zbs).
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+pub struct Rv64B;
 
 impl Default for Rv64M {
     fn default() -> Self {
@@ -164,6 +170,13 @@ pub enum Rv64MExecutor {
     MultiplicationHigh(Rv64MulHExecutor),
     DivRem(Rv64DivRemExecutor),
     DivRemW(Rv64DivRemWExecutor),
+}
+
+/// RISC-V 64-bit Bit-Manipulation Instruction Executors
+#[derive(Clone, From, AnyEnum, Executor, MeteredExecutor, PreflightExecutor)]
+pub enum Rv64BExecutor {
+    BitManipReg(Rv64BitManipRegExecutor),
+    BitManipImm(Rv64BitManipImmExecutor),
 }
 
 /// RISC-V 64-bit Io Instruction Executors
@@ -1334,6 +1347,131 @@ where
             mem_helper.clone(),
         );
         inventory.add_executor_chip(divrem_w);
+
+        Ok(())
+    }
+}
+
+impl VmExecutionExtension for Rv64B {
+    type Executor = Rv64BExecutor;
+
+    fn extend_execution(
+        &self,
+        inventory: &mut ExecutorInventoryBuilder<Rv64BExecutor>,
+    ) -> Result<(), ExecutorInventoryError> {
+        let reg = Rv64BitManipRegExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+        inventory.add_executor(
+            reg,
+            [
+                ShAddOpcode::SH1ADD.global_opcode(),
+                ShAddOpcode::SH2ADD.global_opcode(),
+                ShAddOpcode::SH3ADD.global_opcode(),
+                ShAddOpcode::ADD_UW.global_opcode(),
+                ShAddOpcode::SH1ADD_UW.global_opcode(),
+                ShAddOpcode::SH2ADD_UW.global_opcode(),
+                ShAddOpcode::SH3ADD_UW.global_opcode(),
+                BitwiseInvOpcode::ANDN.global_opcode(),
+                BitwiseInvOpcode::ORN.global_opcode(),
+                BitwiseInvOpcode::XNOR.global_opcode(),
+                RotateOpcode::ROL.global_opcode(),
+                RotateOpcode::ROR.global_opcode(),
+                RotateWOpcode::ROLW.global_opcode(),
+                RotateWOpcode::RORW.global_opcode(),
+                MinMaxOpcode::MIN.global_opcode(),
+                MinMaxOpcode::MINU.global_opcode(),
+                MinMaxOpcode::MAX.global_opcode(),
+                MinMaxOpcode::MAXU.global_opcode(),
+                SingleBitOpcode::BCLR.global_opcode(),
+                SingleBitOpcode::BSET.global_opcode(),
+                SingleBitOpcode::BINV.global_opcode(),
+                SingleBitOpcode::BEXT.global_opcode(),
+            ],
+        )?;
+
+        let imm = Rv64BitManipImmExecutor::new(Rv64BaseAluImmU16AdapterExecutor);
+        inventory.add_executor(
+            imm,
+            [
+                SlliUwOpcode::SLLI_UW.global_opcode(),
+                RotateImmOpcode::RORI.global_opcode(),
+                RotateWImmOpcode::RORIW.global_opcode(),
+                CountZerosOpcode::CLZ.global_opcode(),
+                CountZerosOpcode::CTZ.global_opcode(),
+                CountZerosWOpcode::CLZW.global_opcode(),
+                CountZerosWOpcode::CTZW.global_opcode(),
+                CpopOpcode::CPOP.global_opcode(),
+                CpopWOpcode::CPOPW.global_opcode(),
+                ByteUnaryOpcode::SEXT_B.global_opcode(),
+                ByteUnaryOpcode::SEXT_H.global_opcode(),
+                ByteUnaryOpcode::ZEXT_H.global_opcode(),
+                ByteUnaryOpcode::ORC_B.global_opcode(),
+                ByteUnaryOpcode::REV8.global_opcode(),
+                SingleBitImmOpcode::BCLRI.global_opcode(),
+                SingleBitImmOpcode::BSETI.global_opcode(),
+                SingleBitImmOpcode::BINVI.global_opcode(),
+                SingleBitImmOpcode::BEXTI.global_opcode(),
+            ],
+        )?;
+
+        Ok(())
+    }
+}
+
+impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64B {
+    fn extend_circuit(&self, inventory: &mut AirInventory<SC>) -> Result<(), AirInventoryError> {
+        let SystemPort {
+            execution_bus,
+            program_bus,
+            memory_bridge,
+        } = inventory.system().port();
+        let exec_bridge = ExecutionBridge::new(execution_bus, program_bus);
+
+        let reg = Rv64BitManipRegAir::new(
+            Rv64BaseAluRegU16AdapterAir::new(exec_bridge, memory_bridge),
+            BitManipRegCoreAir::new(),
+        );
+        inventory.add_air(reg);
+
+        let imm = Rv64BitManipImmAir::new(
+            Rv64BaseAluImmU16AdapterAir::new(exec_bridge, memory_bridge),
+            BitManipImmCoreAir::new(),
+        );
+        inventory.add_air(imm);
+
+        Ok(())
+    }
+}
+
+impl<E, SC, RA> VmProverExtension<E, RA, Rv64B> for Rv64ImCpuProverExt
+where
+    SC: StarkProtocolConfig,
+    E: StarkEngine<SC = SC, PB = CpuBackend<SC>, PD = CpuDevice<SC>>,
+    RA: RowMajorMatrixArena<Val<SC>>,
+    Val<SC>: VmField,
+    SC::EF: Ord,
+{
+    fn extend_prover(
+        &self,
+        _: &Rv64B,
+        inventory: &mut ChipInventory<SC, RA, CpuBackend<SC>>,
+    ) -> Result<(), ChipInventoryError> {
+        let range_checker = inventory.range_checker()?.clone();
+        let timestamp_max_bits = inventory.timestamp_max_bits();
+        let mem_helper = SharedMemoryHelper::new(range_checker, timestamp_max_bits);
+
+        inventory.next_air::<Rv64BitManipRegAir>()?;
+        let reg = Rv64BitManipRegChip::new(
+            BitManipRegFiller::new(Rv64BaseAluRegU16AdapterFiller::new()),
+            mem_helper.clone(),
+        );
+        inventory.add_executor_chip(reg);
+
+        inventory.next_air::<Rv64BitManipImmAir>()?;
+        let imm = Rv64BitManipImmChip::new(
+            BitManipImmFiller::new(Rv64BaseAluImmU16AdapterFiller::new()),
+            mem_helper,
+        );
+        inventory.add_executor_chip(imm);
 
         Ok(())
     }

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -36,8 +36,8 @@ use openvm_stark_backend::p3_field::PrimeField32;
 use openvm_stark_backend::{StarkEngine, StarkProtocolConfig, Val};
 #[cfg(feature = "rvr")]
 use rvr_openvm_ext_riscv::{
-    Rv64IExtension, Rv64IoExtension, Rv64IoRuntimeHooks, Rv64MExtension, Rv64PhantomExtension,
-    Rv64PhantomRuntimeHooks,
+    Rv64BExtension, Rv64IExtension, Rv64IoExtension, Rv64IoRuntimeHooks, Rv64MExtension,
+    Rv64PhantomExtension, Rv64PhantomRuntimeHooks,
 };
 #[cfg(feature = "rvr")]
 use rvr_openvm_lift::{RvrExtensionCtx, RvrExtensions, VmRvrExtension};
@@ -120,6 +120,13 @@ impl<F: PrimeField32> VmRvrExtension<F> for Rv64Io {
 impl<F: PrimeField32> VmRvrExtension<F> for Rv64M {
     fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
         extensions.register_lifter(Rv64MExtension::new());
+    }
+}
+
+#[cfg(feature = "rvr")]
+impl<F: PrimeField32> VmRvrExtension<F> for Rv64B {
+    fn extend_rvr(&self, extensions: &mut RvrExtensions, _ctx: Option<&RvrExtensionCtx>) {
+        extensions.register_lifter(Rv64BExtension::new());
     }
 }
 

--- a/extensions/riscv/circuit/src/extension/mod.rs
+++ b/extensions/riscv/circuit/src/extension/mod.rs
@@ -186,6 +186,8 @@ pub enum Rv64BExecutor {
     BitManipSlliUw(Rv64BitManipSlliUwExecutor),
     BitManipReg(Rv64BitManipRegExecutor),
     BitManipImm(Rv64BitManipImmExecutor),
+    BitManipBitwiseInv(Rv64BitManipBitwiseInvExecutor),
+    BitManipMinMax(Rv64BitManipMinMaxExecutor),
 }
 
 /// RISC-V 64-bit Io Instruction Executors
@@ -1389,17 +1391,10 @@ impl VmExecutionExtension for Rv64B {
         inventory.add_executor(
             reg,
             [
-                BitwiseInvOpcode::ANDN.global_opcode(),
-                BitwiseInvOpcode::ORN.global_opcode(),
-                BitwiseInvOpcode::XNOR.global_opcode(),
                 RotateOpcode::ROL.global_opcode(),
                 RotateOpcode::ROR.global_opcode(),
                 RotateWOpcode::ROLW.global_opcode(),
                 RotateWOpcode::RORW.global_opcode(),
-                MinMaxOpcode::MIN.global_opcode(),
-                MinMaxOpcode::MINU.global_opcode(),
-                MinMaxOpcode::MAX.global_opcode(),
-                MinMaxOpcode::MAXU.global_opcode(),
                 SingleBitOpcode::BCLR.global_opcode(),
                 SingleBitOpcode::BSET.global_opcode(),
                 SingleBitOpcode::BINV.global_opcode(),
@@ -1431,6 +1426,30 @@ impl VmExecutionExtension for Rv64B {
             ],
         )?;
 
+        // NOTE: executor registration order must match the AIR/chip order in
+        // `VmCircuitExtension` / `VmProverExtension` (chips pair with
+        // executors positionally).
+        let bitwise_inv = Rv64BitManipBitwiseInvExecutor::new(Rv64BaseAluRegAdapterExecutor);
+        inventory.add_executor(
+            bitwise_inv,
+            [
+                BitwiseInvOpcode::ANDN.global_opcode(),
+                BitwiseInvOpcode::ORN.global_opcode(),
+                BitwiseInvOpcode::XNOR.global_opcode(),
+            ],
+        )?;
+
+        let min_max = Rv64BitManipMinMaxExecutor::new(Rv64BaseAluRegU16AdapterExecutor);
+        inventory.add_executor(
+            min_max,
+            [
+                MinMaxOpcode::MIN.global_opcode(),
+                MinMaxOpcode::MINU.global_opcode(),
+                MinMaxOpcode::MAX.global_opcode(),
+                MinMaxOpcode::MAXU.global_opcode(),
+            ],
+        )?;
+
         Ok(())
     }
 }
@@ -1444,6 +1463,18 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64B {
         } = inventory.system().port();
         let exec_bridge = ExecutionBridge::new(execution_bus, program_bus);
         let range_bus = inventory.range_checker().bus;
+
+        let bitwise_lu = {
+            let existing_air = inventory.find_air::<BitwiseOperationLookupAir<8>>().next();
+            if let Some(air) = existing_air {
+                air.bus
+            } else {
+                let bus = BitwiseOperationLookupBus::new(inventory.new_bus_idx());
+                let air = BitwiseOperationLookupAir::<8>::new(bus);
+                inventory.add_air(air);
+                air.bus
+            }
+        };
 
         let shadd = Rv64BitManipShAddAir::new(
             Rv64BaseAluRegU16AdapterAir::new(exec_bridge, memory_bridge),
@@ -1469,6 +1500,18 @@ impl<SC: StarkProtocolConfig> VmCircuitExtension<SC> for Rv64B {
         );
         inventory.add_air(imm);
 
+        let bitwise_inv = Rv64BitManipBitwiseInvAir::new(
+            Rv64BaseAluRegAdapterAir::new(exec_bridge, memory_bridge),
+            BitManipBitwiseInvCoreAir::new(bitwise_lu),
+        );
+        inventory.add_air(bitwise_inv);
+
+        let min_max = Rv64BitManipMinMaxAir::new(
+            Rv64BaseAluRegU16AdapterAir::new(exec_bridge, memory_bridge),
+            BitManipMinMaxCoreAir::new(range_bus),
+        );
+        inventory.add_air(min_max);
+
         Ok(())
     }
 }
@@ -1489,6 +1532,20 @@ where
         let range_checker = inventory.range_checker()?.clone();
         let timestamp_max_bits = inventory.timestamp_max_bits();
         let mem_helper = SharedMemoryHelper::new(range_checker.clone(), timestamp_max_bits);
+
+        let bitwise_lu = {
+            let existing_chip = inventory
+                .find_chip::<SharedBitwiseOperationLookupChip<8>>()
+                .next();
+            if let Some(chip) = existing_chip {
+                chip.clone()
+            } else {
+                let air: &BitwiseOperationLookupAir<8> = inventory.next_air()?;
+                let chip = Arc::new(BitwiseOperationLookupChip::new(air.bus));
+                inventory.add_periphery_chip(chip.clone());
+                chip
+            }
+        };
 
         inventory.next_air::<Rv64BitManipShAddAir>()?;
         let shadd = Rv64BitManipShAddChip::new(
@@ -1514,9 +1571,23 @@ where
         inventory.next_air::<Rv64BitManipImmAir>()?;
         let imm = Rv64BitManipImmChip::new(
             BitManipImmFiller::new(Rv64BaseAluImmU16AdapterFiller::new()),
-            mem_helper,
+            mem_helper.clone(),
         );
         inventory.add_executor_chip(imm);
+
+        inventory.next_air::<Rv64BitManipBitwiseInvAir>()?;
+        let bitwise_inv = Rv64BitManipBitwiseInvChip::new(
+            BitManipBitwiseInvFiller::new(Rv64BaseAluRegAdapterFiller, bitwise_lu),
+            mem_helper.clone(),
+        );
+        inventory.add_executor_chip(bitwise_inv);
+
+        inventory.next_air::<Rv64BitManipMinMaxAir>()?;
+        let min_max = Rv64BitManipMinMaxChip::new(
+            BitManipMinMaxFiller::new(Rv64BaseAluRegU16AdapterFiller::new(), range_checker),
+            mem_helper,
+        );
+        inventory.add_executor_chip(min_max);
 
         Ok(())
     }

--- a/extensions/riscv/circuit/src/lib.rs
+++ b/extensions/riscv/circuit/src/lib.rs
@@ -19,6 +19,7 @@ mod add_sub;
 mod add_sub_w;
 mod addi;
 mod auipc;
+mod bitmanip;
 mod bitwise_logic;
 mod bitwise_logic_imm;
 mod branch_eq;
@@ -46,6 +47,7 @@ pub use add_sub::*;
 pub use add_sub_w::*;
 pub use addi::*;
 pub use auipc::*;
+pub use bitmanip::*;
 pub use bitwise_logic::*;
 pub use bitwise_logic_imm::*;
 pub use branch_eq::*;
@@ -86,6 +88,7 @@ cfg_if::cfg_if! {
     } else {
         pub use self::{
             Rv64ICpuBuilder as Rv64IBuilder,
+            Rv64ImBCpuBuilder as Rv64ImBBuilder,
             Rv64ImCpuBuilder as Rv64ImBuilder,
         };
     }
@@ -120,6 +123,18 @@ pub struct Rv64ImConfig {
 // Default implementation uses no init file
 impl InitFileGenerator for Rv64ImConfig {}
 
+/// Config for a VM with base, IO, multiplication, and bit-manipulation extensions.
+#[derive(Clone, Debug, Default, VmConfig, derive_new::new, Serialize, Deserialize)]
+pub struct Rv64ImBConfig {
+    #[config]
+    pub rv64im: Rv64ImConfig,
+    #[extension]
+    pub bitmanip: Rv64B,
+}
+
+// Default implementation uses no init file
+impl InitFileGenerator for Rv64ImBConfig {}
+
 impl Default for Rv64IConfig {
     fn default() -> Self {
         let system = SystemConfig::default();
@@ -147,6 +162,15 @@ impl Rv64ImConfig {
         Self {
             rv64i: Rv64IConfig::with_public_values_bytes(num_public_values_bytes),
             mul: Default::default(),
+        }
+    }
+}
+
+impl Rv64ImBConfig {
+    pub fn with_public_values_bytes(num_public_values_bytes: usize) -> Self {
+        Self {
+            rv64im: Rv64ImConfig::with_public_values_bytes(num_public_values_bytes),
+            bitmanip: Default::default(),
         }
     }
 }
@@ -218,6 +242,45 @@ where
         )?;
         let inventory = &mut chip_complex.inventory;
         VmProverExtension::<E, _, _>::extend_prover(&Rv64ImCpuProverExt, &config.mul, inventory)?;
+        Ok(chip_complex)
+    }
+}
+
+#[derive(Clone)]
+pub struct Rv64ImBCpuBuilder;
+
+impl<SC, E> VmBuilder<E> for Rv64ImBCpuBuilder
+where
+    SC: StarkProtocolConfig,
+    E: StarkEngine<SC = SC, PB = CpuBackend<SC>, PD = CpuDevice<SC>>,
+    Val<SC>: VmField,
+    SC::EF: Ord,
+{
+    type VmConfig = Rv64ImBConfig;
+    type SystemChipInventory = SystemChipInventory<SC>;
+    type RecordArena = MatrixRecordArena<Val<SC>>;
+
+    fn create_chip_complex(
+        &self,
+        config: &Self::VmConfig,
+        circuit: AirInventory<E::SC>,
+        device_ctx: &EngineDeviceCtx<E>,
+    ) -> Result<
+        VmChipComplex<E::SC, Self::RecordArena, E::PB, Self::SystemChipInventory>,
+        ChipInventoryError,
+    > {
+        let mut chip_complex = VmBuilder::<E>::create_chip_complex(
+            &Rv64ImCpuBuilder,
+            &config.rv64im,
+            circuit,
+            device_ctx,
+        )?;
+        let inventory = &mut chip_complex.inventory;
+        VmProverExtension::<E, _, _>::extend_prover(
+            &Rv64ImCpuProverExt,
+            &config.bitmanip,
+            inventory,
+        )?;
         Ok(chip_complex)
     }
 }

--- a/extensions/riscv/circuit/src/lib.rs
+++ b/extensions/riscv/circuit/src/lib.rs
@@ -83,6 +83,7 @@ cfg_if::cfg_if! {
         pub(crate) mod cuda_abi;
         pub use self::{
             Rv64IGpuBuilder as Rv64IBuilder,
+            Rv64ImBGpuBuilder as Rv64ImBBuilder,
             Rv64ImGpuBuilder as Rv64ImBuilder,
         };
     } else {
@@ -364,6 +365,46 @@ impl VmBuilder<GpuBabyBearPoseidon2Engine> for Rv64ImGpuBuilder {
         VmProverExtension::<GpuBabyBearPoseidon2Engine, _, _>::extend_prover(
             &Rv64ImGpuProverExt,
             &config.mul,
+            inventory,
+        )?;
+        Ok(chip_complex)
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Clone)]
+pub struct Rv64ImBGpuBuilder;
+
+#[cfg(feature = "cuda")]
+impl VmBuilder<GpuBabyBearPoseidon2Engine> for Rv64ImBGpuBuilder {
+    type VmConfig = Rv64ImBConfig;
+    type SystemChipInventory = SystemChipInventoryGPU;
+    type RecordArena = DenseRecordArena;
+
+    fn create_chip_complex(
+        &self,
+        config: &Self::VmConfig,
+        circuit: AirInventory<BabyBearPoseidon2Config>,
+        device_ctx: &EngineDeviceCtx<GpuBabyBearPoseidon2Engine>,
+    ) -> Result<
+        VmChipComplex<
+            BabyBearPoseidon2Config,
+            Self::RecordArena,
+            GpuBackend,
+            Self::SystemChipInventory,
+        >,
+        ChipInventoryError,
+    > {
+        let mut chip_complex = VmBuilder::<GpuBabyBearPoseidon2Engine>::create_chip_complex(
+            &Rv64ImGpuBuilder,
+            &config.rv64im,
+            circuit,
+            device_ctx,
+        )?;
+        let inventory = &mut chip_complex.inventory;
+        VmProverExtension::<GpuBabyBearPoseidon2Engine, _, _>::extend_prover(
+            &Rv64ImGpuProverExt,
+            &config.bitmanip,
             inventory,
         )?;
         Ok(chip_complex)

--- a/extensions/riscv/rvr/c/rv64b.h
+++ b/extensions/riscv/rvr/c/rv64b.h
@@ -1,0 +1,81 @@
+#ifndef OPENVM_RVR_RV64B_H
+#define OPENVM_RVR_RV64B_H
+
+#include <stdint.h>
+
+static __attribute__((always_inline)) inline uint64_t rv64b_sext8(uint8_t value) {
+  return (uint64_t)(int64_t)(int8_t)value;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_sext16(uint16_t value) {
+  return (uint64_t)(int64_t)(int16_t)value;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_sext32(uint32_t value) {
+  return (uint64_t)(int64_t)(int32_t)value;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_rol64(uint64_t value,
+                                                                  uint64_t shift) {
+  uint32_t amount = (uint32_t)shift & 0x3fu;
+  return (value << amount) | (value >> ((64u - amount) & 0x3fu));
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_ror64(uint64_t value,
+                                                                  uint64_t shift) {
+  uint32_t amount = (uint32_t)shift & 0x3fu;
+  return (value >> amount) | (value << ((64u - amount) & 0x3fu));
+}
+
+static __attribute__((always_inline)) inline uint32_t rv64b_rol32(uint32_t value,
+                                                                  uint64_t shift) {
+  uint32_t amount = (uint32_t)shift & 0x1fu;
+  return (uint32_t)((value << amount) | (value >> ((32u - amount) & 0x1fu)));
+}
+
+static __attribute__((always_inline)) inline uint32_t rv64b_ror32(uint32_t value,
+                                                                  uint64_t shift) {
+  uint32_t amount = (uint32_t)shift & 0x1fu;
+  return (uint32_t)((value >> amount) | (value << ((32u - amount) & 0x1fu)));
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_clz64(uint64_t value) {
+  return value == 0 ? 64ull : (uint64_t)__builtin_clzll(value);
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_ctz64(uint64_t value) {
+  return value == 0 ? 64ull : (uint64_t)__builtin_ctzll(value);
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_clz32(uint32_t value) {
+  return value == 0 ? 32ull : (uint64_t)__builtin_clz(value);
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_ctz32(uint32_t value) {
+  return value == 0 ? 32ull : (uint64_t)__builtin_ctz(value);
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_cpop64(uint64_t value) {
+  return (uint64_t)__builtin_popcountll(value);
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_cpop32(uint32_t value) {
+  return (uint64_t)__builtin_popcount(value);
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_orc_b(uint64_t value) {
+  uint64_t out = 0;
+  for (uint32_t i = 0; i < 8; ++i) {
+    uint64_t byte = (value >> (8u * i)) & 0xffu;
+    if (byte != 0) {
+      out |= 0xffull << (8u * i);
+    }
+  }
+  return out;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_rev8(uint64_t value) {
+  return __builtin_bswap64(value);
+}
+
+#endif /* OPENVM_RVR_RV64B_H */

--- a/extensions/riscv/rvr/c/rv64b.h
+++ b/extensions/riscv/rvr/c/rv64b.h
@@ -15,6 +15,25 @@ static __attribute__((always_inline)) inline uint64_t rv64b_sext32(uint32_t valu
   return (uint64_t)(int64_t)(int32_t)value;
 }
 
+// Function boundaries keep the generated call sites free of operand-shape
+// warnings (e.g. -Wtautological-unsigned-zero-compare when constant
+// propagation folds an operand to 0).
+static __attribute__((always_inline)) inline uint64_t rv64b_min64(uint64_t lhs, uint64_t rhs) {
+  return (int64_t)lhs < (int64_t)rhs ? lhs : rhs;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_minu64(uint64_t lhs, uint64_t rhs) {
+  return lhs < rhs ? lhs : rhs;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_max64(uint64_t lhs, uint64_t rhs) {
+  return (int64_t)lhs > (int64_t)rhs ? lhs : rhs;
+}
+
+static __attribute__((always_inline)) inline uint64_t rv64b_maxu64(uint64_t lhs, uint64_t rhs) {
+  return lhs > rhs ? lhs : rhs;
+}
+
 static __attribute__((always_inline)) inline uint64_t rv64b_rol64(uint64_t value,
                                                                   uint64_t shift) {
   uint32_t amount = (uint32_t)shift & 0x3fu;

--- a/extensions/riscv/rvr/src/b.rs
+++ b/extensions/riscv/rvr/src/b.rs
@@ -1,0 +1,340 @@
+//! RV64B instruction lifting and C code generation.
+
+mod instruction;
+
+use openvm_instructions::{
+    riscv::{RV64_IMM_AS, RV64_REGISTER_AS},
+    LocalOpcode,
+};
+use openvm_riscv_transpiler::{
+    BitwiseInvOpcode, ByteUnaryOpcode, CountZerosOpcode, CountZerosWOpcode, CpopOpcode,
+    CpopWOpcode, MinMaxOpcode, RotateImmOpcode, RotateOpcode, RotateWImmOpcode, RotateWOpcode,
+    ShAddOpcode, SingleBitImmOpcode, SingleBitOpcode, SlliUwOpcode,
+};
+use rvr_openvm_ir::{ExtInstr, InstrAt, LiftedInstr};
+use rvr_openvm_lift::{RvrExtension, RvrInstruction};
+
+use self::instruction::{BitManipOp, Rv64BInstr};
+use crate::instruction::{decode_reg, NopInstr, ZERO};
+
+/// RVR extension for RV64B bit-manipulation instructions (Zba + Zbb + Zbs).
+pub struct Rv64BExtension;
+
+impl Rv64BExtension {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for Rv64BExtension {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RvrExtension for Rv64BExtension {
+    fn try_lift(&self, insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
+        try_lift(insn, pc)
+    }
+
+    fn c_headers(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("rv64b.h", include_str!("../c/rv64b.h"))]
+    }
+
+    fn max_main_memory_pages_per_instruction(&self) -> usize {
+        0
+    }
+}
+
+pub(crate) fn try_lift(insn: &RvrInstruction, pc: u64) -> Option<LiftedInstr> {
+    let opcode = insn.opcode.as_usize();
+
+    if let Some(op) = reg_op(opcode) {
+        return lift_reg(insn, pc, op);
+    }
+    if let Some(op) = imm_op(opcode) {
+        return lift_imm(insn, pc, op);
+    }
+
+    None
+}
+
+fn lift_reg(insn: &RvrInstruction, pc: u64, op: BitManipOp) -> Option<LiftedInstr> {
+    if insn.d != RV64_REGISTER_AS || insn.e != RV64_REGISTER_AS {
+        return None;
+    }
+
+    let rd = decode_reg(insn.a);
+    if rd == ZERO {
+        return Some(body(pc, NopInstr));
+    }
+    Some(body(
+        pc,
+        Rv64BInstr::Reg {
+            op,
+            rd,
+            lhs: decode_reg(insn.b),
+            rhs: decode_reg(insn.c),
+        },
+    ))
+}
+
+fn lift_imm(insn: &RvrInstruction, pc: u64, op: BitManipOp) -> Option<LiftedInstr> {
+    if insn.d != RV64_REGISTER_AS || insn.e != RV64_IMM_AS {
+        return None;
+    }
+    if !valid_imm(op, insn.c) {
+        return None;
+    }
+
+    let rd = decode_reg(insn.a);
+    if rd == ZERO {
+        return Some(body(pc, NopInstr));
+    }
+    Some(body(
+        pc,
+        Rv64BInstr::Imm {
+            op,
+            rd,
+            lhs: decode_reg(insn.b),
+            imm: insn.c,
+        },
+    ))
+}
+
+fn valid_imm(op: BitManipOp, imm: u32) -> bool {
+    match op {
+        BitManipOp::RorIw => imm < 32,
+        BitManipOp::SlliUw
+        | BitManipOp::Rori
+        | BitManipOp::BclrI
+        | BitManipOp::BsetI
+        | BitManipOp::BinvI
+        | BitManipOp::BextI => imm < 64,
+        _ => true,
+    }
+}
+
+fn reg_op(opcode: usize) -> Option<BitManipOp> {
+    Some(match opcode {
+        x if x == ShAddOpcode::SH1ADD.global_opcode_usize() => BitManipOp::Sh1Add,
+        x if x == ShAddOpcode::SH2ADD.global_opcode_usize() => BitManipOp::Sh2Add,
+        x if x == ShAddOpcode::SH3ADD.global_opcode_usize() => BitManipOp::Sh3Add,
+        x if x == ShAddOpcode::ADD_UW.global_opcode_usize() => BitManipOp::AddUw,
+        x if x == ShAddOpcode::SH1ADD_UW.global_opcode_usize() => BitManipOp::Sh1AddUw,
+        x if x == ShAddOpcode::SH2ADD_UW.global_opcode_usize() => BitManipOp::Sh2AddUw,
+        x if x == ShAddOpcode::SH3ADD_UW.global_opcode_usize() => BitManipOp::Sh3AddUw,
+        x if x == BitwiseInvOpcode::ANDN.global_opcode_usize() => BitManipOp::AndN,
+        x if x == BitwiseInvOpcode::ORN.global_opcode_usize() => BitManipOp::OrN,
+        x if x == BitwiseInvOpcode::XNOR.global_opcode_usize() => BitManipOp::Xnor,
+        x if x == RotateOpcode::ROL.global_opcode_usize() => BitManipOp::Rol,
+        x if x == RotateOpcode::ROR.global_opcode_usize() => BitManipOp::Ror,
+        x if x == RotateWOpcode::ROLW.global_opcode_usize() => BitManipOp::RolW,
+        x if x == RotateWOpcode::RORW.global_opcode_usize() => BitManipOp::RorW,
+        x if x == MinMaxOpcode::MIN.global_opcode_usize() => BitManipOp::Min,
+        x if x == MinMaxOpcode::MINU.global_opcode_usize() => BitManipOp::MinU,
+        x if x == MinMaxOpcode::MAX.global_opcode_usize() => BitManipOp::Max,
+        x if x == MinMaxOpcode::MAXU.global_opcode_usize() => BitManipOp::MaxU,
+        x if x == SingleBitOpcode::BCLR.global_opcode_usize() => BitManipOp::Bclr,
+        x if x == SingleBitOpcode::BSET.global_opcode_usize() => BitManipOp::Bset,
+        x if x == SingleBitOpcode::BINV.global_opcode_usize() => BitManipOp::Binv,
+        x if x == SingleBitOpcode::BEXT.global_opcode_usize() => BitManipOp::Bext,
+        _ => return None,
+    })
+}
+
+fn imm_op(opcode: usize) -> Option<BitManipOp> {
+    Some(match opcode {
+        x if x == SlliUwOpcode::SLLI_UW.global_opcode_usize() => BitManipOp::SlliUw,
+        x if x == RotateImmOpcode::RORI.global_opcode_usize() => BitManipOp::Rori,
+        x if x == RotateWImmOpcode::RORIW.global_opcode_usize() => BitManipOp::RorIw,
+        x if x == CountZerosOpcode::CLZ.global_opcode_usize() => BitManipOp::Clz,
+        x if x == CountZerosOpcode::CTZ.global_opcode_usize() => BitManipOp::Ctz,
+        x if x == CountZerosWOpcode::CLZW.global_opcode_usize() => BitManipOp::ClzW,
+        x if x == CountZerosWOpcode::CTZW.global_opcode_usize() => BitManipOp::CtzW,
+        x if x == CpopOpcode::CPOP.global_opcode_usize() => BitManipOp::Cpop,
+        x if x == CpopWOpcode::CPOPW.global_opcode_usize() => BitManipOp::CpopW,
+        x if x == ByteUnaryOpcode::SEXT_B.global_opcode_usize() => BitManipOp::SextB,
+        x if x == ByteUnaryOpcode::SEXT_H.global_opcode_usize() => BitManipOp::SextH,
+        x if x == ByteUnaryOpcode::ZEXT_H.global_opcode_usize() => BitManipOp::ZextH,
+        x if x == ByteUnaryOpcode::ORC_B.global_opcode_usize() => BitManipOp::OrcB,
+        x if x == ByteUnaryOpcode::REV8.global_opcode_usize() => BitManipOp::Rev8,
+        x if x == SingleBitImmOpcode::BCLRI.global_opcode_usize() => BitManipOp::BclrI,
+        x if x == SingleBitImmOpcode::BSETI.global_opcode_usize() => BitManipOp::BsetI,
+        x if x == SingleBitImmOpcode::BINVI.global_opcode_usize() => BitManipOp::BinvI,
+        x if x == SingleBitImmOpcode::BEXTI.global_opcode_usize() => BitManipOp::BextI,
+        _ => return None,
+    })
+}
+
+fn body(pc: u64, instr: impl ExtInstr + 'static) -> LiftedInstr {
+    LiftedInstr::Body(InstrAt {
+        pc,
+        instr: Box::new(instr),
+        source_loc: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_instructions::{instruction::Instruction, riscv::RV64_REGISTER_NUM_LIMBS, VmOpcode};
+    use p3_baby_bear::BabyBear;
+    use rvr_openvm_ir::InstrAt;
+
+    use super::*;
+
+    fn instruction(opcode: VmOpcode, operands: [usize; 7]) -> RvrInstruction {
+        RvrInstruction::from_field(&Instruction::<BabyBear>::from_usize(opcode, operands))
+    }
+
+    fn reg_operands(rd: usize, d: u32, e: u32) -> [usize; 7] {
+        [
+            rd,
+            2 * RV64_REGISTER_NUM_LIMBS,
+            3 * RV64_REGISTER_NUM_LIMBS,
+            d as usize,
+            e as usize,
+            1,
+            0,
+        ]
+    }
+
+    fn imm_operands(rd: usize, imm: usize, d: u32, e: u32) -> [usize; 7] {
+        [
+            rd,
+            2 * RV64_REGISTER_NUM_LIMBS,
+            imm,
+            d as usize,
+            e as usize,
+            1,
+            0,
+        ]
+    }
+
+    fn lifted_name(insn: &RvrInstruction) -> Option<String> {
+        Rv64BExtension
+            .try_lift(insn, 0x100)
+            .map(|lifted| match lifted {
+                LiftedInstr::Body(InstrAt { instr, .. }) => instr.opname().to_string(),
+                LiftedInstr::Term { .. } => {
+                    unreachable!("RV64B instructions do not terminate blocks")
+                }
+            })
+    }
+
+    #[test]
+    fn register_bitmanip_families_are_domain_separated() {
+        let opcodes = [
+            (ShAddOpcode::SH1ADD.global_opcode(), "sh1add"),
+            (ShAddOpcode::SH2ADD.global_opcode(), "sh2add"),
+            (ShAddOpcode::SH3ADD.global_opcode(), "sh3add"),
+            (ShAddOpcode::ADD_UW.global_opcode(), "add.uw"),
+            (ShAddOpcode::SH1ADD_UW.global_opcode(), "sh1add.uw"),
+            (ShAddOpcode::SH2ADD_UW.global_opcode(), "sh2add.uw"),
+            (ShAddOpcode::SH3ADD_UW.global_opcode(), "sh3add.uw"),
+            (BitwiseInvOpcode::ANDN.global_opcode(), "andn"),
+            (BitwiseInvOpcode::ORN.global_opcode(), "orn"),
+            (BitwiseInvOpcode::XNOR.global_opcode(), "xnor"),
+            (RotateOpcode::ROL.global_opcode(), "rol"),
+            (RotateOpcode::ROR.global_opcode(), "ror"),
+            (RotateWOpcode::ROLW.global_opcode(), "rolw"),
+            (RotateWOpcode::RORW.global_opcode(), "rorw"),
+            (MinMaxOpcode::MIN.global_opcode(), "min"),
+            (MinMaxOpcode::MINU.global_opcode(), "minu"),
+            (MinMaxOpcode::MAX.global_opcode(), "max"),
+            (MinMaxOpcode::MAXU.global_opcode(), "maxu"),
+            (SingleBitOpcode::BCLR.global_opcode(), "bclr"),
+            (SingleBitOpcode::BSET.global_opcode(), "bset"),
+            (SingleBitOpcode::BINV.global_opcode(), "binv"),
+            (SingleBitOpcode::BEXT.global_opcode(), "bext"),
+        ];
+        for (opcode, name) in opcodes {
+            let valid = instruction(
+                opcode,
+                reg_operands(RV64_REGISTER_NUM_LIMBS, RV64_REGISTER_AS, RV64_REGISTER_AS),
+            );
+            assert_eq!(lifted_name(&valid).as_deref(), Some(name));
+
+            let wrong_domain = instruction(
+                opcode,
+                reg_operands(RV64_REGISTER_NUM_LIMBS, RV64_REGISTER_AS, RV64_IMM_AS),
+            );
+            assert!(Rv64BExtension.try_lift(&wrong_domain, 0x100).is_none());
+        }
+    }
+
+    #[test]
+    fn immediate_bitmanip_families_are_domain_separated() {
+        let opcodes = [
+            (SlliUwOpcode::SLLI_UW.global_opcode(), "slli.uw", 63),
+            (RotateImmOpcode::RORI.global_opcode(), "rori", 63),
+            (RotateWImmOpcode::RORIW.global_opcode(), "roriw", 31),
+            (CountZerosOpcode::CLZ.global_opcode(), "clz", 0),
+            (CountZerosOpcode::CTZ.global_opcode(), "ctz", 0),
+            (CountZerosWOpcode::CLZW.global_opcode(), "clzw", 0),
+            (CountZerosWOpcode::CTZW.global_opcode(), "ctzw", 0),
+            (CpopOpcode::CPOP.global_opcode(), "cpop", 0),
+            (CpopWOpcode::CPOPW.global_opcode(), "cpopw", 0),
+            (ByteUnaryOpcode::SEXT_B.global_opcode(), "sext.b", 0),
+            (ByteUnaryOpcode::SEXT_H.global_opcode(), "sext.h", 0),
+            (ByteUnaryOpcode::ZEXT_H.global_opcode(), "zext.h", 0),
+            (ByteUnaryOpcode::ORC_B.global_opcode(), "orc.b", 0),
+            (ByteUnaryOpcode::REV8.global_opcode(), "rev8", 0),
+            (SingleBitImmOpcode::BCLRI.global_opcode(), "bclri", 63),
+            (SingleBitImmOpcode::BSETI.global_opcode(), "bseti", 63),
+            (SingleBitImmOpcode::BINVI.global_opcode(), "binvi", 63),
+            (SingleBitImmOpcode::BEXTI.global_opcode(), "bexti", 63),
+        ];
+        for (opcode, name, imm) in opcodes {
+            let valid = instruction(
+                opcode,
+                imm_operands(RV64_REGISTER_NUM_LIMBS, imm, RV64_REGISTER_AS, RV64_IMM_AS),
+            );
+            assert_eq!(lifted_name(&valid).as_deref(), Some(name));
+
+            let wrong_domain = instruction(
+                opcode,
+                imm_operands(
+                    RV64_REGISTER_NUM_LIMBS,
+                    imm,
+                    RV64_REGISTER_AS,
+                    RV64_REGISTER_AS,
+                ),
+            );
+            assert!(Rv64BExtension.try_lift(&wrong_domain, 0x100).is_none());
+        }
+    }
+
+    #[test]
+    fn invalid_shift_immediates_do_not_lift() {
+        for opcode in [
+            SlliUwOpcode::SLLI_UW.global_opcode(),
+            RotateImmOpcode::RORI.global_opcode(),
+            SingleBitImmOpcode::BCLRI.global_opcode(),
+            SingleBitImmOpcode::BSETI.global_opcode(),
+            SingleBitImmOpcode::BINVI.global_opcode(),
+            SingleBitImmOpcode::BEXTI.global_opcode(),
+        ] {
+            let insn = instruction(
+                opcode,
+                imm_operands(RV64_REGISTER_NUM_LIMBS, 64, RV64_REGISTER_AS, RV64_IMM_AS),
+            );
+            assert!(Rv64BExtension.try_lift(&insn, 0x100).is_none());
+        }
+
+        let roriw = instruction(
+            RotateWImmOpcode::RORIW.global_opcode(),
+            imm_operands(RV64_REGISTER_NUM_LIMBS, 32, RV64_REGISTER_AS, RV64_IMM_AS),
+        );
+        assert!(Rv64BExtension.try_lift(&roriw, 0x100).is_none());
+    }
+
+    #[test]
+    fn writes_to_x0_remain_nops() {
+        let insn = instruction(
+            ShAddOpcode::SH1ADD.global_opcode(),
+            reg_operands(0, RV64_REGISTER_AS, RV64_REGISTER_AS),
+        );
+        assert_eq!(lifted_name(&insn).as_deref(), Some("nop"));
+    }
+}

--- a/extensions/riscv/rvr/src/b/instruction.rs
+++ b/extensions/riscv/rvr/src/b/instruction.rs
@@ -1,0 +1,210 @@
+//! RV64B instruction nodes and C code generation.
+
+use rvr_openvm_ir::{CfgEffect, ExtEmitCtx, ExtInstr};
+
+use crate::instruction::Reg;
+
+/// RV64B bit-manipulation operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BitManipOp {
+    Sh1Add,
+    Sh2Add,
+    Sh3Add,
+    AddUw,
+    Sh1AddUw,
+    Sh2AddUw,
+    Sh3AddUw,
+    SlliUw,
+    AndN,
+    OrN,
+    Xnor,
+    Rol,
+    Ror,
+    Rori,
+    RolW,
+    RorW,
+    RorIw,
+    Clz,
+    Ctz,
+    ClzW,
+    CtzW,
+    Cpop,
+    CpopW,
+    Min,
+    MinU,
+    Max,
+    MaxU,
+    SextB,
+    SextH,
+    ZextH,
+    OrcB,
+    Rev8,
+    Bclr,
+    Bset,
+    Binv,
+    Bext,
+    BclrI,
+    BsetI,
+    BinvI,
+    BextI,
+}
+
+impl BitManipOp {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Sh1Add => "sh1add",
+            Self::Sh2Add => "sh2add",
+            Self::Sh3Add => "sh3add",
+            Self::AddUw => "add.uw",
+            Self::Sh1AddUw => "sh1add.uw",
+            Self::Sh2AddUw => "sh2add.uw",
+            Self::Sh3AddUw => "sh3add.uw",
+            Self::SlliUw => "slli.uw",
+            Self::AndN => "andn",
+            Self::OrN => "orn",
+            Self::Xnor => "xnor",
+            Self::Rol => "rol",
+            Self::Ror => "ror",
+            Self::Rori => "rori",
+            Self::RolW => "rolw",
+            Self::RorW => "rorw",
+            Self::RorIw => "roriw",
+            Self::Clz => "clz",
+            Self::Ctz => "ctz",
+            Self::ClzW => "clzw",
+            Self::CtzW => "ctzw",
+            Self::Cpop => "cpop",
+            Self::CpopW => "cpopw",
+            Self::Min => "min",
+            Self::MinU => "minu",
+            Self::Max => "max",
+            Self::MaxU => "maxu",
+            Self::SextB => "sext.b",
+            Self::SextH => "sext.h",
+            Self::ZextH => "zext.h",
+            Self::OrcB => "orc.b",
+            Self::Rev8 => "rev8",
+            Self::Bclr => "bclr",
+            Self::Bset => "bset",
+            Self::Binv => "binv",
+            Self::Bext => "bext",
+            Self::BclrI => "bclri",
+            Self::BsetI => "bseti",
+            Self::BinvI => "binvi",
+            Self::BextI => "bexti",
+        }
+    }
+}
+
+/// An RV64B instruction implemented by this extension.
+#[derive(Debug, Clone)]
+pub(crate) enum Rv64BInstr {
+    /// Register-register bit-manipulation operation.
+    Reg {
+        op: BitManipOp,
+        rd: Reg,
+        lhs: Reg,
+        rhs: Reg,
+    },
+    /// Register-immediate or unary bit-manipulation operation.
+    Imm {
+        op: BitManipOp,
+        rd: Reg,
+        lhs: Reg,
+        imm: u32,
+    },
+}
+
+impl ExtInstr for Rv64BInstr {
+    fn opname(&self) -> &str {
+        match self {
+            Self::Reg { op, .. } | Self::Imm { op, .. } => op.name(),
+        }
+    }
+
+    fn accesses_memory(&self) -> bool {
+        false
+    }
+
+    fn emit_c(&self, ctx: &mut dyn ExtEmitCtx) {
+        match self {
+            Self::Reg { op, rd, lhs, rhs } => {
+                let lhs = parens(ctx.read_var(*lhs));
+                let rhs = parens(ctx.read_var(*rhs));
+                ctx.write_var(*rd, &reg_expr(*op, &lhs, &rhs));
+            }
+            Self::Imm { op, rd, lhs, imm } => {
+                let lhs = parens(ctx.read_var(*lhs));
+                ctx.write_var(*rd, &imm_expr(*op, &lhs, *imm));
+            }
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn ExtInstr> {
+        Box::new(self.clone())
+    }
+
+    fn cfg_effect(&self) -> CfgEffect {
+        let dst = match self {
+            Self::Reg { rd, .. } | Self::Imm { rd, .. } => *rd,
+        };
+        CfgEffect::WriteUnknown { dst }
+    }
+}
+
+fn parens(value: String) -> String {
+    format!("({value})")
+}
+
+fn reg_expr(op: BitManipOp, lhs: &str, rhs: &str) -> String {
+    match op {
+        BitManipOp::Sh1Add => format!("({lhs} << 1) + {rhs}"),
+        BitManipOp::Sh2Add => format!("({lhs} << 2) + {rhs}"),
+        BitManipOp::Sh3Add => format!("({lhs} << 3) + {rhs}"),
+        BitManipOp::AddUw => format!("(uint64_t)(uint32_t){lhs} + {rhs}"),
+        BitManipOp::Sh1AddUw => format!("(((uint64_t)(uint32_t){lhs}) << 1) + {rhs}"),
+        BitManipOp::Sh2AddUw => format!("(((uint64_t)(uint32_t){lhs}) << 2) + {rhs}"),
+        BitManipOp::Sh3AddUw => format!("(((uint64_t)(uint32_t){lhs}) << 3) + {rhs}"),
+        BitManipOp::AndN => format!("{lhs} & ~{rhs}"),
+        BitManipOp::OrN => format!("{lhs} | ~{rhs}"),
+        BitManipOp::Xnor => format!("~({lhs} ^ {rhs})"),
+        BitManipOp::Rol => format!("rv64b_rol64({lhs}, {rhs})"),
+        BitManipOp::Ror => format!("rv64b_ror64({lhs}, {rhs})"),
+        BitManipOp::RolW => format!("rv64b_sext32(rv64b_rol32((uint32_t){lhs}, {rhs}))"),
+        BitManipOp::RorW => format!("rv64b_sext32(rv64b_ror32((uint32_t){lhs}, {rhs}))"),
+        BitManipOp::Min => format!("((int64_t){lhs} < (int64_t){rhs} ? {lhs} : {rhs})"),
+        BitManipOp::MinU => format!("({lhs} < {rhs} ? {lhs} : {rhs})"),
+        BitManipOp::Max => format!("((int64_t){lhs} > (int64_t){rhs} ? {lhs} : {rhs})"),
+        BitManipOp::MaxU => format!("({lhs} > {rhs} ? {lhs} : {rhs})"),
+        BitManipOp::Bclr => format!("{lhs} & ~(1ull << ({rhs} & 0x3full))"),
+        BitManipOp::Bset => format!("{lhs} | (1ull << ({rhs} & 0x3full))"),
+        BitManipOp::Binv => format!("{lhs} ^ (1ull << ({rhs} & 0x3full))"),
+        BitManipOp::Bext => format!("({lhs} >> ({rhs} & 0x3full)) & 1ull"),
+        _ => unreachable!("invalid RV64B register operation"),
+    }
+}
+
+fn imm_expr(op: BitManipOp, lhs: &str, imm: u32) -> String {
+    let imm = format!("{imm}u");
+    match op {
+        BitManipOp::SlliUw => format!("((uint64_t)(uint32_t){lhs}) << {imm}"),
+        BitManipOp::Rori => format!("rv64b_ror64({lhs}, {imm})"),
+        BitManipOp::RorIw => format!("rv64b_sext32(rv64b_ror32((uint32_t){lhs}, {imm}))"),
+        BitManipOp::Clz => format!("rv64b_clz64({lhs})"),
+        BitManipOp::Ctz => format!("rv64b_ctz64({lhs})"),
+        BitManipOp::ClzW => format!("rv64b_clz32((uint32_t){lhs})"),
+        BitManipOp::CtzW => format!("rv64b_ctz32((uint32_t){lhs})"),
+        BitManipOp::Cpop => format!("rv64b_cpop64({lhs})"),
+        BitManipOp::CpopW => format!("rv64b_cpop32((uint32_t){lhs})"),
+        BitManipOp::SextB => format!("rv64b_sext8((uint8_t){lhs})"),
+        BitManipOp::SextH => format!("rv64b_sext16((uint16_t){lhs})"),
+        BitManipOp::ZextH => format!("(uint64_t)(uint16_t){lhs}"),
+        BitManipOp::OrcB => format!("rv64b_orc_b({lhs})"),
+        BitManipOp::Rev8 => format!("rv64b_rev8({lhs})"),
+        BitManipOp::BclrI => format!("{lhs} & ~(1ull << {imm})"),
+        BitManipOp::BsetI => format!("{lhs} | (1ull << {imm})"),
+        BitManipOp::BinvI => format!("{lhs} ^ (1ull << {imm})"),
+        BitManipOp::BextI => format!("({lhs} >> {imm}) & 1ull"),
+        _ => unreachable!("invalid RV64B immediate operation"),
+    }
+}

--- a/extensions/riscv/rvr/src/b/instruction.rs
+++ b/extensions/riscv/rvr/src/b/instruction.rs
@@ -172,10 +172,13 @@ fn reg_expr(op: BitManipOp, lhs: &str, rhs: &str) -> String {
         BitManipOp::Ror => format!("rv64b_ror64({lhs}, {rhs})"),
         BitManipOp::RolW => format!("rv64b_sext32(rv64b_rol32((uint32_t){lhs}, {rhs}))"),
         BitManipOp::RorW => format!("rv64b_sext32(rv64b_ror32((uint32_t){lhs}, {rhs}))"),
-        BitManipOp::Min => format!("((int64_t){lhs} < (int64_t){rhs} ? {lhs} : {rhs})"),
-        BitManipOp::MinU => format!("({lhs} < {rhs} ? {lhs} : {rhs})"),
-        BitManipOp::Max => format!("((int64_t){lhs} > (int64_t){rhs} ? {lhs} : {rhs})"),
-        BitManipOp::MaxU => format!("({lhs} > {rhs} ? {lhs} : {rhs})"),
+        // Helper calls rather than inline ternaries: constant propagation can
+        // fold an operand to 0, and an inline unsigned `< 0` comparison trips
+        // -Werror=tautological-unsigned-zero-compare in the generated C.
+        BitManipOp::Min => format!("rv64b_min64({lhs}, {rhs})"),
+        BitManipOp::MinU => format!("rv64b_minu64({lhs}, {rhs})"),
+        BitManipOp::Max => format!("rv64b_max64({lhs}, {rhs})"),
+        BitManipOp::MaxU => format!("rv64b_maxu64({lhs}, {rhs})"),
         BitManipOp::Bclr => format!("{lhs} & ~(1ull << ({rhs} & 0x3full))"),
         BitManipOp::Bset => format!("{lhs} | (1ull << ({rhs} & 0x3full))"),
         BitManipOp::Binv => format!("{lhs} ^ (1ull << ({rhs} & 0x3full))"),

--- a/extensions/riscv/rvr/src/lib.rs
+++ b/extensions/riscv/rvr/src/lib.rs
@@ -1,15 +1,17 @@
 //! RV64 extensions for rvr-openvm.
 //!
 //! Provides opcode lifters, C code generation, and runtime hooks for RV64I,
-//! RV64M, RV64 IO, and RV64-specific phantom instructions.
+//! RV64M, RV64B, RV64 IO, and RV64-specific phantom instructions.
 #![cfg(feature = "rvr")]
 
+mod b;
 mod i;
 mod instruction;
 mod io;
 mod m;
 mod phantom;
 
+pub use b::Rv64BExtension;
 pub use i::Rv64IExtension;
 pub use io::{Rv64IoExtension, Rv64IoRuntimeHooks};
 pub use m::Rv64MExtension;

--- a/extensions/riscv/tests/programs/examples/bitmanip.rs
+++ b/extensions/riscv/tests/programs/examples/bitmanip.rs
@@ -1,0 +1,188 @@
+#![cfg_attr(
+    all(not(feature = "std"), any(openvm_intrinsics, target_os = "openvm")),
+    no_main
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+openvm::entry!(main);
+
+#[cfg(target_arch = "riscv64")]
+mod riscv64 {
+    use core::arch::asm;
+
+    macro_rules! rr {
+        ($name:ident, $mnemonic:literal) => {
+            fn $name(a: u64, b: u64) -> u64 {
+                let out: u64;
+                unsafe {
+                    asm!(
+                        concat!($mnemonic, " {out}, {a}, {b}"),
+                        out = lateout(reg) out,
+                        a = in(reg) a,
+                        b = in(reg) b,
+                        options(nomem, nostack)
+                    );
+                }
+                out
+            }
+        };
+    }
+
+    macro_rules! ri {
+        ($name:ident, $mnemonic:literal, $imm:literal) => {
+            fn $name(a: u64) -> u64 {
+                let out: u64;
+                unsafe {
+                    asm!(
+                        concat!($mnemonic, " {out}, {a}, ", $imm),
+                        out = lateout(reg) out,
+                        a = in(reg) a,
+                        options(nomem, nostack)
+                    );
+                }
+                out
+            }
+        };
+    }
+
+    macro_rules! unary {
+        ($name:ident, $mnemonic:literal) => {
+            fn $name(a: u64) -> u64 {
+                let out: u64;
+                unsafe {
+                    asm!(
+                        concat!($mnemonic, " {out}, {a}"),
+                        out = lateout(reg) out,
+                        a = in(reg) a,
+                        options(nomem, nostack)
+                    );
+                }
+                out
+            }
+        };
+    }
+
+    rr!(add_uw, "add.uw");
+    rr!(sh1add, "sh1add");
+    rr!(sh2add, "sh2add");
+    rr!(sh3add, "sh3add");
+    rr!(sh1add_uw, "sh1add.uw");
+    rr!(sh2add_uw, "sh2add.uw");
+    rr!(sh3add_uw, "sh3add.uw");
+    ri!(slli_uw, "slli.uw", "13");
+
+    rr!(andn, "andn");
+    rr!(orn, "orn");
+    rr!(xnor, "xnor");
+    unary!(clz, "clz");
+    unary!(ctz, "ctz");
+    unary!(cpop, "cpop");
+    unary!(clzw, "clzw");
+    unary!(ctzw, "ctzw");
+    unary!(cpopw, "cpopw");
+    rr!(min, "min");
+    rr!(minu, "minu");
+    rr!(max, "max");
+    rr!(maxu, "maxu");
+    unary!(sext_b, "sext.b");
+    unary!(sext_h, "sext.h");
+    unary!(zext_h, "zext.h");
+    rr!(rol, "rol");
+    rr!(ror, "ror");
+    ri!(rori, "rori", "13");
+    rr!(rolw, "rolw");
+    rr!(rorw, "rorw");
+    ri!(roriw, "roriw", "13");
+    unary!(orc_b, "orc.b");
+    unary!(rev8, "rev8");
+
+    rr!(bclr, "bclr");
+    rr!(bset, "bset");
+    rr!(binv, "binv");
+    rr!(bext, "bext");
+    ri!(bclri, "bclri", "47");
+    ri!(bseti, "bseti", "48");
+    ri!(binvi, "binvi", "49");
+    ri!(bexti, "bexti", "50");
+
+    fn check(actual: u64, expected: u64) {
+        if actual != expected {
+            openvm::process::panic();
+        }
+    }
+
+    fn sext32(x: u32) -> u64 {
+        (x as i32 as i64) as u64
+    }
+
+    fn orc_b_expected(x: u64) -> u64 {
+        let mut out = 0;
+        let mut i = 0;
+        while i < 8 {
+            if ((x >> (i * 8)) & 0xff) != 0 {
+                out |= 0xffu64 << (i * 8);
+            }
+            i += 1;
+        }
+        out
+    }
+
+    pub fn run() {
+        let x = core::hint::black_box(0x8123_4567_89ab_cdefu64);
+        let y = core::hint::black_box(0x7654_3210_fedc_ba91u64);
+        let u = core::hint::black_box(0x00f0_0000_1000_0000u64);
+        let shamt64 = (y & 63) as u32;
+        let shamt32 = (y & 31) as u32;
+
+        check(add_uw(x, y), (x as u32 as u64).wrapping_add(y));
+        check(sh1add(x, y), x.wrapping_shl(1).wrapping_add(y));
+        check(sh2add(x, y), x.wrapping_shl(2).wrapping_add(y));
+        check(sh3add(x, y), x.wrapping_shl(3).wrapping_add(y));
+        check(sh1add_uw(x, y), ((x as u32 as u64) << 1).wrapping_add(y));
+        check(sh2add_uw(x, y), ((x as u32 as u64) << 2).wrapping_add(y));
+        check(sh3add_uw(x, y), ((x as u32 as u64) << 3).wrapping_add(y));
+        check(slli_uw(x), (x as u32 as u64) << 13);
+
+        check(andn(x, y), x & !y);
+        check(orn(x, y), x | !y);
+        check(xnor(x, y), !(x ^ y));
+        check(clz(x), x.leading_zeros() as u64);
+        check(ctz(x), x.trailing_zeros() as u64);
+        check(cpop(x), x.count_ones() as u64);
+        check(clzw(x), (x as u32).leading_zeros() as u64);
+        check(ctzw(x), (x as u32).trailing_zeros() as u64);
+        check(cpopw(x), (x as u32).count_ones() as u64);
+        check(min(x, y), core::cmp::min(x as i64, y as i64) as u64);
+        check(minu(x, y), core::cmp::min(x, y));
+        check(max(x, y), core::cmp::max(x as i64, y as i64) as u64);
+        check(maxu(x, y), core::cmp::max(x, y));
+        check(sext_b(x), (x as i8 as i64) as u64);
+        check(sext_h(x), (x as i16 as i64) as u64);
+        check(zext_h(x), x & 0xffff);
+        check(rol(x, y), x.rotate_left(shamt64));
+        check(ror(x, y), x.rotate_right(shamt64));
+        check(rori(x), x.rotate_right(13));
+        check(rolw(x, y), sext32((x as u32).rotate_left(shamt32)));
+        check(rorw(x, y), sext32((x as u32).rotate_right(shamt32)));
+        check(roriw(x), sext32((x as u32).rotate_right(13)));
+        check(orc_b(u), orc_b_expected(u));
+        check(rev8(x), x.swap_bytes());
+
+        check(bclr(x, y), x & !(1u64 << shamt64));
+        check(bset(x, y), x | (1u64 << shamt64));
+        check(binv(x, y), x ^ (1u64 << shamt64));
+        check(bext(x, y), (x >> shamt64) & 1);
+        check(bclri(x), x & !(1u64 << 47));
+        check(bseti(x), x | (1u64 << 48));
+        check(binvi(x), x ^ (1u64 << 49));
+        check(bexti(x), (x >> 50) & 1);
+    }
+}
+
+#[cfg(target_arch = "riscv64")]
+pub fn main() {
+    riscv64::run();
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+pub fn main() {}

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -23,11 +23,13 @@ mod tests {
         exe::VmExe, instruction::Instruction, riscv::RV64_REGISTER_NUM_LIMBS, LocalOpcode,
         SystemOpcode,
     };
-    use openvm_riscv_circuit::{Rv64IBuilder, Rv64IConfig, Rv64ImBuilder, Rv64ImConfig};
+    use openvm_riscv_circuit::{
+        Rv64IBuilder, Rv64IConfig, Rv64ImBBuilder, Rv64ImBConfig, Rv64ImBuilder, Rv64ImConfig,
+    };
     use openvm_riscv_guest::MAX_HINT_BUFFER_DWORDS;
     use openvm_riscv_transpiler::{
-        DivRemOpcode, MulHOpcode, MulOpcode, Rv64ITranspilerExtension, Rv64IoTranspilerExtension,
-        Rv64MTranspilerExtension,
+        DivRemOpcode, MulHOpcode, MulOpcode, Rv64BTranspilerExtension, Rv64ITranspilerExtension,
+        Rv64IoTranspilerExtension, Rv64MTranspilerExtension,
     };
     use openvm_stark_sdk::{
         openvm_stark_backend::p3_field::PrimeCharacteristicRing, p3_baby_bear::BabyBear,
@@ -43,6 +45,56 @@ mod tests {
     type F = BabyBear;
     #[cfg(all(feature = "rvr", not(feature = "unprotected")))]
     const RVR_OOB_CHILD_ENV: &str = "OPENVM_RVR_OOB_CHILD";
+
+    #[cfg(feature = "rvr")]
+    const BITMANIP_GOLDEN_WORDS: &[u32] = &[
+        0x087302bb, // add.uw
+        0x20a4a433, // sh1add
+        0x20d645b3, // sh2add
+        0x2107e733, // sh3add
+        0x213928bb, // sh1add.uw
+        0x216aca3b, // sh2add.uw
+        0x219c6bbb, // sh3add.uw
+        0x0a5d9d1b, // slli.uw
+        0x407372b3, // andn
+        0x40a4e433, // orn
+        0x40d645b3, // xnor
+        0x60079713, // clz
+        0x60189813, // ctz
+        0x60299913, // cpop
+        0x600a9a1b, // clzw
+        0x601b9b1b, // ctzw
+        0x602c9c1b, // cpopw
+        0x0a7342b3, // min
+        0x0aa4d433, // minu
+        0x0ad665b3, // max
+        0x0b07f733, // maxu
+        0x60491893, // sext.b
+        0x605a1993, // sext.h
+        0x080b4abb, // zext.h
+        0x607312b3, // rol
+        0x60a4d433, // ror
+        0x62d65593, // rori
+        0x60f716bb, // rolw
+        0x6128d83b, // rorw
+        0x615a599b, // roriw
+        0x287bdb13, // orc.b
+        0x6b8cdc13, // rev8
+        0x487312b3, // bclr
+        0x28a49433, // bset
+        0x68d615b3, // binv
+        0x4907d733, // bext
+        0x4af91893, // bclri
+        0x2b0a1993, // bseti
+        0x6b1b1a93, // binvi
+        0x4b2c5b93, // bexti
+    ];
+
+    #[cfg(feature = "rvr")]
+    fn addi_word(rd: u32, imm: i32) -> u32 {
+        assert!((-2048..=2047).contains(&imm));
+        (((imm as u32) & 0xfff) << 20) | (rd << 7) | 0x13
+    }
 
     #[cfg(test)]
     fn test_rv64im_config() -> Rv64ImConfig {
@@ -127,6 +179,39 @@ mod tests {
     #[cfg(feature = "rvr")]
     fn test_rvr_hint_io() {
         execute_rvr_example_with_input("hint", vec![vec![0, 1, 2, 3]]);
+    }
+
+    #[test]
+    #[cfg(feature = "rvr")]
+    fn test_rvr_bitmanip_golden_program() {
+        let mut words = (1..32)
+            .map(|rd| addi_word(rd, rd as i32 * 37 - 997))
+            .collect::<Vec<_>>();
+        words.extend_from_slice(BITMANIP_GOLDEN_WORDS);
+
+        let mut instructions = Transpiler::<F>::default()
+            .with_extension(Rv64ITranspilerExtension)
+            .with_extension(Rv64MTranspilerExtension)
+            .with_extension(Rv64IoTranspilerExtension)
+            .with_extension(Rv64BTranspilerExtension)
+            .transpile(&words)
+            .unwrap();
+        instructions.push(Some(Instruction {
+            opcode: SystemOpcode::TERMINATE.global_opcode(),
+            ..Default::default()
+        }));
+        let exe = VmExe::new(
+            openvm_instructions::program::Program::new_without_debug_infos_with_option(
+                &instructions,
+                0,
+            ),
+        );
+        let config = Rv64ImBConfig {
+            rv64im: test_rv64im_config(),
+            ..Default::default()
+        };
+
+        air_test(Rv64ImBBuilder, config, exe);
     }
 
     #[test]

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -187,6 +187,10 @@ mod tests {
         let mut words = (1..32)
             .map(|rd| addi_word(rd, rd as i32 * 37 - 997))
             .collect::<Vec<_>>();
+        // Re-seed minu's rs2 (x10) with zero: constant propagation then folds
+        // the operand to a literal 0 in the generated C, which used to trip
+        // -Werror=tautological-unsigned-zero-compare in the rvr backend.
+        words.push(addi_word(10, 0));
         words.extend_from_slice(BITMANIP_GOLDEN_WORDS);
 
         let mut instructions = Transpiler::<F>::default()

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -29,14 +29,14 @@ mod tests {
     use openvm_riscv_guest::MAX_HINT_BUFFER_DWORDS;
     use openvm_riscv_transpiler::{
         DivRemOpcode, MulHOpcode, MulOpcode, Rv64BTranspilerExtension, Rv64ITranspilerExtension,
-        Rv64IoTranspilerExtension, Rv64MTranspilerExtension,
+        Rv64IoTranspilerExtension, Rv64MTranspilerExtension, ShAddOpcode, SingleBitImmOpcode,
     };
     use openvm_stark_sdk::{
         openvm_stark_backend::p3_field::PrimeCharacteristicRing, p3_baby_bear::BabyBear,
     };
     use openvm_toolchain_tests::{
         build_example_program_at_path, build_example_program_at_path_with_features,
-        get_programs_dir,
+        build_example_program_at_path_with_features_and_rustc_flags, get_programs_dir,
     };
     use openvm_transpiler::{transpiler::Transpiler, FromElf};
     use strum::IntoEnumIterator;
@@ -459,6 +459,48 @@ mod tests {
                 .with_extension(Rv64MTranspilerExtension),
         )?;
         air_test_with_min_segments(Rv64ImBuilder, config, exe, vec![], min_segments);
+        Ok(())
+    }
+
+    #[test]
+    fn test_rv64imb_target_features() -> Result<()> {
+        let config = Rv64ImBConfig {
+            rv64im: test_rv64im_config(),
+            ..Default::default()
+        };
+        let elf = build_example_program_at_path_with_features_and_rustc_flags(
+            get_programs_dir!(),
+            "bitmanip",
+            std::iter::empty::<&str>(),
+            ["-C", "target-feature=+zba,+zbb,+zbs"],
+            &config,
+        )?;
+        let exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv64ITranspilerExtension)
+                .with_extension(Rv64IoTranspilerExtension)
+                .with_extension(Rv64MTranspilerExtension)
+                .with_extension(Rv64BTranspilerExtension),
+        )?;
+
+        let first_bitmanip_opcode = ShAddOpcode::SH1ADD.global_opcode().as_usize();
+        let last_bitmanip_opcode = SingleBitImmOpcode::BEXTI.global_opcode().as_usize();
+        let bitmanip_count = exe
+            .program
+            .instructions_and_debug_infos
+            .iter()
+            .flatten()
+            .filter(|(insn, _)| {
+                (first_bitmanip_opcode..=last_bitmanip_opcode).contains(&insn.opcode.as_usize())
+            })
+            .count();
+        assert!(
+            bitmanip_count >= 40,
+            "expected at least 40 bitmanip instructions, found {bitmanip_count}"
+        );
+
+        air_test_with_min_segments(Rv64ImBBuilder, config, exe, vec![], 1);
         Ok(())
     }
 

--- a/extensions/riscv/transpiler/src/instructions.rs
+++ b/extensions/riscv/transpiler/src/instructions.rs
@@ -468,6 +468,354 @@ pub enum LessThanImmOpcode {
 }
 
 // =================================================================================================
+// Bit-manipulation opcodes (Zba / Zbb / Zbs), used by the RV64B extension.
+// Classes occupy 0x2A0..0x2C8; 0x299..0x30F is otherwise unallocated.
+// =================================================================================================
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2a0]
+#[repr(usize)]
+#[allow(non_camel_case_types)]
+pub enum ShAddOpcode {
+    SH1ADD,
+    SH2ADD,
+    SH3ADD,
+    ADD_UW,
+    SH1ADD_UW,
+    SH2ADD_UW,
+    SH3ADD_UW,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2a7]
+#[repr(usize)]
+#[allow(non_camel_case_types)]
+pub enum SlliUwOpcode {
+    SLLI_UW,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2a8]
+#[repr(usize)]
+pub enum BitwiseInvOpcode {
+    ANDN,
+    ORN,
+    XNOR,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2ab]
+#[repr(usize)]
+pub enum RotateOpcode {
+    ROL,
+    ROR,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2ad]
+#[repr(usize)]
+pub enum RotateImmOpcode {
+    RORI,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2ae]
+#[repr(usize)]
+pub enum RotateWOpcode {
+    ROLW,
+    RORW,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2b0]
+#[repr(usize)]
+pub enum RotateWImmOpcode {
+    RORIW,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2b1]
+#[repr(usize)]
+pub enum CountZerosOpcode {
+    CLZ,
+    CTZ,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2b3]
+#[repr(usize)]
+pub enum CountZerosWOpcode {
+    CLZW,
+    CTZW,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2b5]
+#[repr(usize)]
+pub enum CpopOpcode {
+    CPOP,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2b6]
+#[repr(usize)]
+pub enum CpopWOpcode {
+    CPOPW,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2b7]
+#[repr(usize)]
+pub enum MinMaxOpcode {
+    MIN,
+    MINU,
+    MAX,
+    MAXU,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2bb]
+#[repr(usize)]
+#[allow(non_camel_case_types)]
+pub enum ByteUnaryOpcode {
+    SEXT_B,
+    SEXT_H,
+    ZEXT_H,
+    ORC_B,
+    REV8,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2c0]
+#[repr(usize)]
+pub enum SingleBitOpcode {
+    BCLR,
+    BSET,
+    BINV,
+    BEXT,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumCount,
+    EnumIter,
+    FromRepr,
+    LocalOpcode,
+    Serialize,
+    Deserialize,
+)]
+#[opcode_offset = 0x2c4]
+#[repr(usize)]
+pub enum SingleBitImmOpcode {
+    BCLRI,
+    BSETI,
+    BINVI,
+    BEXTI,
+}
+
+// =================================================================================================
 // Phantom opcodes
 // =================================================================================================
 
@@ -481,4 +829,168 @@ pub enum Rv64Phantom {
     PrintStr,
     /// Prepare given amount of random numbers for hinting.
     HintRandom,
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::EnumCount;
+
+    use super::*;
+
+    /// Every opcode class in this file, as (name, class offset, opcode count).
+    fn all_classes() -> Vec<(&'static str, usize, usize)> {
+        vec![
+            ("BaseAlu", BaseAluOpcode::CLASS_OFFSET, BaseAluOpcode::COUNT),
+            ("Shift", ShiftOpcode::CLASS_OFFSET, ShiftOpcode::COUNT),
+            (
+                "LessThan",
+                LessThanOpcode::CLASS_OFFSET,
+                LessThanOpcode::COUNT,
+            ),
+            (
+                "Rv64LoadStore",
+                Rv64LoadStoreOpcode::CLASS_OFFSET,
+                Rv64LoadStoreOpcode::COUNT,
+            ),
+            (
+                "BranchEqual",
+                BranchEqualOpcode::CLASS_OFFSET,
+                BranchEqualOpcode::COUNT,
+            ),
+            (
+                "BranchLessThan",
+                BranchLessThanOpcode::CLASS_OFFSET,
+                BranchLessThanOpcode::COUNT,
+            ),
+            (
+                "Rv64JalLui",
+                Rv64JalLuiOpcode::CLASS_OFFSET,
+                Rv64JalLuiOpcode::COUNT,
+            ),
+            (
+                "Rv64Jalr",
+                Rv64JalrOpcode::CLASS_OFFSET,
+                Rv64JalrOpcode::COUNT,
+            ),
+            (
+                "Rv64Auipc",
+                Rv64AuipcOpcode::CLASS_OFFSET,
+                Rv64AuipcOpcode::COUNT,
+            ),
+            ("Mul", MulOpcode::CLASS_OFFSET, MulOpcode::COUNT),
+            ("MulH", MulHOpcode::CLASS_OFFSET, MulHOpcode::COUNT),
+            ("DivRem", DivRemOpcode::CLASS_OFFSET, DivRemOpcode::COUNT),
+            (
+                "Rv64HintStore",
+                Rv64HintStoreOpcode::CLASS_OFFSET,
+                Rv64HintStoreOpcode::COUNT,
+            ),
+            (
+                "BaseAluW",
+                BaseAluWOpcode::CLASS_OFFSET,
+                BaseAluWOpcode::COUNT,
+            ),
+            (
+                "BaseAluWImm",
+                BaseAluWImmOpcode::CLASS_OFFSET,
+                BaseAluWImmOpcode::COUNT,
+            ),
+            ("ShiftW", ShiftWOpcode::CLASS_OFFSET, ShiftWOpcode::COUNT),
+            (
+                "ShiftWImm",
+                ShiftWImmOpcode::CLASS_OFFSET,
+                ShiftWImmOpcode::COUNT,
+            ),
+            ("MulW", MulWOpcode::CLASS_OFFSET, MulWOpcode::COUNT),
+            ("DivRemW", DivRemWOpcode::CLASS_OFFSET, DivRemWOpcode::COUNT),
+            (
+                "BaseAluImm",
+                BaseAluImmOpcode::CLASS_OFFSET,
+                BaseAluImmOpcode::COUNT,
+            ),
+            (
+                "ShiftImm",
+                ShiftImmOpcode::CLASS_OFFSET,
+                ShiftImmOpcode::COUNT,
+            ),
+            (
+                "LessThanImm",
+                LessThanImmOpcode::CLASS_OFFSET,
+                LessThanImmOpcode::COUNT,
+            ),
+            ("ShAdd", ShAddOpcode::CLASS_OFFSET, ShAddOpcode::COUNT),
+            ("SlliUw", SlliUwOpcode::CLASS_OFFSET, SlliUwOpcode::COUNT),
+            (
+                "BitwiseInv",
+                BitwiseInvOpcode::CLASS_OFFSET,
+                BitwiseInvOpcode::COUNT,
+            ),
+            ("Rotate", RotateOpcode::CLASS_OFFSET, RotateOpcode::COUNT),
+            (
+                "RotateImm",
+                RotateImmOpcode::CLASS_OFFSET,
+                RotateImmOpcode::COUNT,
+            ),
+            ("RotateW", RotateWOpcode::CLASS_OFFSET, RotateWOpcode::COUNT),
+            (
+                "RotateWImm",
+                RotateWImmOpcode::CLASS_OFFSET,
+                RotateWImmOpcode::COUNT,
+            ),
+            (
+                "CountZeros",
+                CountZerosOpcode::CLASS_OFFSET,
+                CountZerosOpcode::COUNT,
+            ),
+            (
+                "CountZerosW",
+                CountZerosWOpcode::CLASS_OFFSET,
+                CountZerosWOpcode::COUNT,
+            ),
+            ("Cpop", CpopOpcode::CLASS_OFFSET, CpopOpcode::COUNT),
+            ("CpopW", CpopWOpcode::CLASS_OFFSET, CpopWOpcode::COUNT),
+            ("MinMax", MinMaxOpcode::CLASS_OFFSET, MinMaxOpcode::COUNT),
+            (
+                "ByteUnary",
+                ByteUnaryOpcode::CLASS_OFFSET,
+                ByteUnaryOpcode::COUNT,
+            ),
+            (
+                "SingleBit",
+                SingleBitOpcode::CLASS_OFFSET,
+                SingleBitOpcode::COUNT,
+            ),
+            (
+                "SingleBitImm",
+                SingleBitImmOpcode::CLASS_OFFSET,
+                SingleBitImmOpcode::COUNT,
+            ),
+        ]
+    }
+
+    #[test]
+    fn opcode_classes_are_disjoint() {
+        let mut classes = all_classes();
+        classes.sort_by_key(|(_, offset, _)| *offset);
+        for pair in classes.windows(2) {
+            let (prev_name, prev_offset, prev_count) = pair[0];
+            let (next_name, next_offset, _) = pair[1];
+            assert!(
+                prev_offset + prev_count <= next_offset,
+                "opcode classes {prev_name} ({prev_offset:#x}+{prev_count}) and {next_name} \
+                 ({next_offset:#x}) overlap"
+            );
+        }
+    }
+
+    #[test]
+    fn bitmanip_classes_stay_in_reserved_range() {
+        // The B-extension classes live in 0x2A0..0x2C8; the next extension
+        // (keccak256) starts at 0x310. Growing past 0x2FF requires checking
+        // the workspace-wide offset allocation again.
+        let bitmanip_start = ShAddOpcode::CLASS_OFFSET;
+        let bitmanip_end = SingleBitImmOpcode::CLASS_OFFSET + SingleBitImmOpcode::COUNT;
+        assert_eq!(bitmanip_start, 0x2a0);
+        assert_eq!(bitmanip_end, 0x2c8);
+    }
 }

--- a/extensions/riscv/transpiler/src/lib.rs
+++ b/extensions/riscv/transpiler/src/lib.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use openvm_decoder::{
     instruction_formats::{IType, RType},
-    process_instruction,
+    is_bitmanip_instruction, process_instruction,
 };
 use openvm_instructions::{
     instruction::Instruction, riscv::RV64_REGISTER_NUM_LIMBS, LocalOpcode, PhantomDiscriminant,
@@ -34,6 +34,13 @@ pub struct Rv64MTranspilerExtension;
 #[derive(Default)]
 pub struct Rv64IoTranspilerExtension;
 
+/// Transpiler extension for the RISC-V bit-manipulation instructions
+/// (Zba + Zbb + Zbs). It claims exactly the words for which
+/// [`is_bitmanip_instruction`] holds, which [`Rv64ITranspilerExtension`]
+/// skips, so both extensions can be registered together unambiguously.
+#[derive(Default)]
+pub struct Rv64BTranspilerExtension;
+
 impl<F: PrimeField32> TranspilerExtension<F> for Rv64ITranspilerExtension {
     fn process_custom(&self, instruction_stream: &[u32]) -> Option<TranspilerOutput<F>> {
         let mut transpiler = InstructionTranspiler::<F>(PhantomData);
@@ -41,6 +48,13 @@ impl<F: PrimeField32> TranspilerExtension<F> for Rv64ITranspilerExtension {
             return None;
         }
         let instruction_u32 = instruction_stream[0];
+
+        // Bit-manipulation (Zba/Zbb/Zbs) words belong to
+        // `Rv64BTranspilerExtension`; when it is not registered they fall
+        // through to `unimp` like any other unsupported instruction.
+        if is_bitmanip_instruction(instruction_u32) {
+            return None;
+        }
 
         let opcode = (instruction_u32 & 0x7f) as u8;
         let funct3 = ((instruction_u32 >> 12) & 0b111) as u8; // All our instructions are R-, I- or B-type
@@ -103,6 +117,26 @@ impl<F: PrimeField32> TranspilerExtension<F> for Rv64ITranspilerExtension {
             }
             _ => process_instruction(&mut transpiler, instruction_u32),
         };
+
+        instruction.map(TranspilerOutput::one_to_one)
+    }
+}
+
+impl<F: PrimeField32> TranspilerExtension<F> for Rv64BTranspilerExtension {
+    fn process_custom(&self, instruction_stream: &[u32]) -> Option<TranspilerOutput<F>> {
+        if instruction_stream.is_empty() {
+            return None;
+        }
+        let instruction_u32 = instruction_stream[0];
+
+        if !is_bitmanip_instruction(instruction_u32) {
+            return None;
+        }
+
+        let instruction = process_instruction(
+            &mut InstructionTranspiler::<F>(PhantomData),
+            instruction_u32,
+        );
 
         instruction.map(TranspilerOutput::one_to_one)
     }

--- a/extensions/riscv/transpiler/src/rrs.rs
+++ b/extensions/riscv/transpiler/src/rrs.rs
@@ -12,14 +12,33 @@ use openvm_transpiler::util::{
 };
 
 use crate::{
-    BaseAluImmOpcode, BaseAluOpcode, BaseAluWImmOpcode, BaseAluWOpcode, BranchEqualOpcode,
-    BranchLessThanOpcode, DivRemOpcode, DivRemWOpcode, LessThanImmOpcode, LessThanOpcode,
-    MulHOpcode, MulOpcode, MulWOpcode, Rv64AuipcOpcode, Rv64JalLuiOpcode, Rv64JalrOpcode,
-    Rv64LoadStoreOpcode, ShiftImmOpcode, ShiftOpcode, ShiftWImmOpcode, ShiftWOpcode,
+    BaseAluImmOpcode, BaseAluOpcode, BaseAluWImmOpcode, BaseAluWOpcode, BitwiseInvOpcode,
+    BranchEqualOpcode, BranchLessThanOpcode, ByteUnaryOpcode, CountZerosOpcode, CountZerosWOpcode,
+    CpopOpcode, CpopWOpcode, DivRemOpcode, DivRemWOpcode, LessThanImmOpcode, LessThanOpcode,
+    MinMaxOpcode, MulHOpcode, MulOpcode, MulWOpcode, RotateImmOpcode, RotateOpcode,
+    RotateWImmOpcode, RotateWOpcode, Rv64AuipcOpcode, Rv64JalLuiOpcode, Rv64JalrOpcode,
+    Rv64LoadStoreOpcode, ShAddOpcode, ShiftImmOpcode, ShiftOpcode, ShiftWImmOpcode, ShiftWOpcode,
+    SingleBitImmOpcode, SingleBitOpcode, SlliUwOpcode,
 };
 
 /// A transpiler that converts the 32-bit encoded instructions into instructions.
 pub(crate) struct InstructionTranspiler<F>(pub PhantomData<F>);
+
+/// Unary bit-manipulation ops (`rd = f(rs1)`) reuse the ALU-immediate operand
+/// layout with a zero immediate, so they can run on the one-register-read
+/// immediate adapters. The raw `imm` field of these words carries the funct12
+/// sub-operation selector, which must not leak into the operands.
+fn from_unary<F: PrimeField32>(opcode: usize, rd: usize, rs1: usize) -> Instruction<F> {
+    from_i_type(
+        opcode,
+        &IType {
+            imm: 0,
+            rs1,
+            funct3: 0,
+            rd,
+        },
+    )
+}
 
 impl<F: PrimeField32> InstructionProcessor for InstructionTranspiler<F> {
     type InstructionResult = Instruction<F>;
@@ -492,6 +511,352 @@ impl<F: PrimeField32> InstructionProcessor for InstructionTranspiler<F> {
             0,
             &dec_insn,
             false,
+        )
+    }
+
+    // ---- Zba ----
+
+    fn process_add_uw(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::ADD_UW.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_sh1add(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::SH1ADD.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_sh2add(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::SH2ADD.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_sh3add(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::SH3ADD.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_sh1add_uw(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::SH1ADD_UW.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_sh2add_uw(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::SH2ADD_UW.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_sh3add_uw(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            ShAddOpcode::SH3ADD_UW.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_slli_uw(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(SlliUwOpcode::SLLI_UW.global_opcode().as_usize(), &dec_insn)
+    }
+
+    // ---- Zbb: logical with negate ----
+
+    fn process_andn(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            BitwiseInvOpcode::ANDN.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_orn(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            BitwiseInvOpcode::ORN.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_xnor(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            BitwiseInvOpcode::XNOR.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    // ---- Zbb: counts (unary) ----
+
+    fn process_clz(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            CountZerosOpcode::CLZ.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_ctz(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            CountZerosOpcode::CTZ.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_cpop(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            CpopOpcode::CPOP.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_clzw(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            CountZerosWOpcode::CLZW.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_ctzw(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            CountZerosWOpcode::CTZW.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_cpopw(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            CpopWOpcode::CPOPW.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    // ---- Zbb: min/max ----
+
+    fn process_min(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            MinMaxOpcode::MIN.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_minu(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            MinMaxOpcode::MINU.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_max(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            MinMaxOpcode::MAX.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_maxu(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            MinMaxOpcode::MAXU.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    // ---- Zbb: sign/zero extension (unary) ----
+
+    fn process_sext_b(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            ByteUnaryOpcode::SEXT_B.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_sext_h(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            ByteUnaryOpcode::SEXT_H.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_zext_h(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        // R-type encoding with rs2 hardwired to zero; transpiles as unary.
+        from_unary(
+            ByteUnaryOpcode::ZEXT_H.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    // ---- Zbb: rotates ----
+
+    fn process_rol(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            RotateOpcode::ROL.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_ror(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            RotateOpcode::ROR.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_rori(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(RotateImmOpcode::RORI.global_opcode().as_usize(), &dec_insn)
+    }
+
+    fn process_rolw(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            RotateWOpcode::ROLW.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_rorw(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            RotateWOpcode::RORW.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_roriw(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(
+            RotateWImmOpcode::RORIW.global_opcode().as_usize(),
+            &dec_insn,
+        )
+    }
+
+    // ---- Zbb: byte ops (unary) ----
+
+    fn process_orc_b(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            ByteUnaryOpcode::ORC_B.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    fn process_rev8(&mut self, dec_insn: IType) -> Self::InstructionResult {
+        from_unary(
+            ByteUnaryOpcode::REV8.global_opcode().as_usize(),
+            dec_insn.rd,
+            dec_insn.rs1,
+        )
+    }
+
+    // ---- Zbs ----
+
+    fn process_bclr(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            SingleBitOpcode::BCLR.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_bset(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            SingleBitOpcode::BSET.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_binv(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            SingleBitOpcode::BINV.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_bext(&mut self, dec_insn: RType) -> Self::InstructionResult {
+        from_r_type(
+            SingleBitOpcode::BEXT.global_opcode().as_usize(),
+            1,
+            &dec_insn,
+            false,
+        )
+    }
+
+    fn process_bclri(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(
+            SingleBitImmOpcode::BCLRI.global_opcode().as_usize(),
+            &dec_insn,
+        )
+    }
+
+    fn process_bseti(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(
+            SingleBitImmOpcode::BSETI.global_opcode().as_usize(),
+            &dec_insn,
+        )
+    }
+
+    fn process_binvi(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(
+            SingleBitImmOpcode::BINVI.global_opcode().as_usize(),
+            &dec_insn,
+        )
+    }
+
+    fn process_bexti(&mut self, dec_insn: ITypeShamt) -> Self::InstructionResult {
+        from_i_type_shamt(
+            SingleBitImmOpcode::BEXTI.global_opcode().as_usize(),
+            &dec_insn,
         )
     }
 


### PR DESCRIPTION
This PR adds support for `zbb`, `zba` and `zbs` extensions. The PR is intended for benchmarking purposes only.

**Benchmark results**
Baseline: https://github.com/axiom-crypto/openvm-eth/actions/runs/30566664481
With basic bit manipulation extension (per iterative improvement):
1. https://github.com/axiom-crypto/openvm-eth/actions/runs/30563761940
2. https://github.com/axiom-crypto/openvm-eth/actions/runs/30569687868/job/90962949246

Resolves INT-8922