### PR TITLE
fix: reject malformed EvmProof input instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4685,6 +4685,7 @@ dependencies = [
  "p3-matrix",
  "serde",
  "test-case",
+ "thiserror 1.0.69",
  "tracing",
 ]
 

--- a/crates/continuations/Cargo.toml
+++ b/crates/continuations/Cargo.toml
@@ -33,6 +33,7 @@ cfg-if.workspace = true
 num-bigint.workspace = true
 hex.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 
 openvm-cuda-common = { workspace = true, optional = true }
 openvm-cuda-backend = { workspace = true, optional = true }

--- a/crates/continuations/src/commit_bytes.rs
+++ b/crates/continuations/src/commit_bytes.rs
@@ -13,16 +13,28 @@ pub const COMMIT_NUM_BYTES: usize = 32;
 /// an unsigned integer in base `F::MODULUS`. Each commit can be converted to a Bn254 using the
 /// trivial identification as natural numbers or into a `u32` digest by decomposing the big integer
 /// base-`F::MODULUS`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Encode)]
 pub struct CommitBytes([u8; COMMIT_NUM_BYTES]);
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum CommitBytesError {
+    #[error("non-canonical CommitBytes for BabyBear digest")]
+    NonCanonical,
+}
+
 impl CommitBytes {
+    /// Use this rather than [`CommitBytes::new`] for bytes from an untrusted source.
+    pub fn try_new(bytes: [u8; COMMIT_NUM_BYTES]) -> Result<Self, CommitBytesError> {
+        if u32_digest_to_bytes(&bytes_to_u32_digest(&bytes)) == bytes {
+            Ok(Self(bytes))
+        } else {
+            Err(CommitBytesError::NonCanonical)
+        }
+    }
+
+    /// Panics if `bytes` is non-canonical.
     pub fn new(bytes: [u8; COMMIT_NUM_BYTES]) -> Self {
-        assert!(
-            u32_digest_to_bytes(&bytes_to_u32_digest(&bytes)) == bytes,
-            "non-canonical CommitBytes for BabyBear digest"
-        );
-        Self(bytes)
+        Self::try_new(bytes).expect("non-canonical CommitBytes for BabyBear digest")
     }
 
     pub fn as_slice(&self) -> &[u8; COMMIT_NUM_BYTES] {
@@ -146,7 +158,15 @@ impl<'de> Deserialize<'de> for CommitBytes {
             .map_err(serde::de::Error::custom)?
             .try_into()
             .map_err(|_| serde::de::Error::custom("expected 32 bytes"))?;
-        Ok(CommitBytes::new(bytes))
+        CommitBytes::try_new(bytes).map_err(serde::de::Error::custom)
+    }
+}
+
+// Hand-written so that decoding goes through `try_new` instead of bypassing the canonicity check.
+impl Decode for CommitBytes {
+    fn decode<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let bytes = <[u8; COMMIT_NUM_BYTES]>::decode(reader)?;
+        CommitBytes::try_new(bytes).map_err(std::io::Error::other)
     }
 }
 
@@ -192,5 +212,49 @@ mod bn254 {
         let start = COMMIT_NUM_BYTES - bytes.len();
         ret[start..].copy_from_slice(&bytes);
         ret
+    }
+}
+
+/// Untrusted input paths must reject non-canonical bytes as errors rather than panicking.
+#[cfg(test)]
+mod tests {
+    use serde::de::IntoDeserializer;
+
+    use super::*;
+
+    /// Largest canonical digest, i.e. `F::MODULUS^8 - 1`.
+    fn max_canonical() -> [u8; COMMIT_NUM_BYTES] {
+        u32_digest_to_bytes(&[F::ORDER_U32 - 1; DIGEST_SIZE])
+    }
+
+    #[test]
+    fn try_new_canonicity() {
+        assert!(CommitBytes::try_new([0u8; COMMIT_NUM_BYTES]).is_ok());
+        assert!(CommitBytes::try_new(max_canonical()).is_ok());
+        assert_eq!(
+            CommitBytes::try_new([0xff; COMMIT_NUM_BYTES]),
+            Err(CommitBytesError::NonCanonical)
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_non_canonical() {
+        let hex = format!("0x{}", hex::encode([0xffu8; COMMIT_NUM_BYTES]));
+        let de: serde::de::value::StrDeserializer<serde::de::value::Error> =
+            hex.as_str().into_deserializer();
+        assert!(CommitBytes::deserialize(de).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_non_canonical() {
+        let encoded = [0xffu8; COMMIT_NUM_BYTES];
+        assert!(CommitBytes::decode(&mut encoded.as_slice()).is_err());
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let commit = CommitBytes::try_new(max_canonical()).unwrap();
+        let bytes = commit.encode_to_vec().unwrap();
+        assert_eq!(CommitBytes::decode_from_bytes(&bytes).unwrap(), commit);
     }
 }

--- a/crates/sdk/src/prover/evm.rs
+++ b/crates/sdk/src/prover/evm.rs
@@ -125,7 +125,7 @@ where
             .halo2_prover
             .as_ref()
             .unwrap()
-            .prove_for_evm(&root_proof);
+            .prove_for_evm(&root_proof)?;
         Ok(evm_proof)
     }
 }

--- a/crates/sdk/src/prover/halo2.rs
+++ b/crates/sdk/src/prover/halo2.rs
@@ -7,7 +7,10 @@ use openvm_static_verifier::{
 };
 use tracing::{info, info_span};
 
-use crate::{keygen::Halo2ProvingKey, types::EvmProof};
+use crate::{
+    keygen::Halo2ProvingKey,
+    types::{EvmProof, EvmProofConversionError},
+};
 
 #[derive(Clone)]
 pub struct Halo2Prover {
@@ -35,7 +38,10 @@ impl Halo2Prover {
         }
     }
 
-    pub fn prove_for_evm(&self, root_proof: &Proof<RootSC>) -> EvmProof {
+    pub fn prove_for_evm(
+        &self,
+        root_proof: &Proof<RootSC>,
+    ) -> Result<EvmProof, EvmProofConversionError> {
         #[cfg(feature = "metrics")]
         {
             let verifier_k = self.halo2_pk.verifier.pinning.metadata.config_params.k;
@@ -54,7 +60,7 @@ impl Halo2Prover {
                 .halo2_pk
                 .wrapper
                 .prove_for_evm(&self.wrapper_srs, snark);
-            EvmProof::from(raw)
+            EvmProof::try_from(raw)
         })
     }
 

--- a/crates/sdk/src/solidity.rs
+++ b/crates/sdk/src/solidity.rs
@@ -215,7 +215,9 @@ pub(crate) fn verify_evm_halo2_proof(
     evm_proof: crate::types::EvmProof,
 ) -> Result<u64, SdkError> {
     // Convert EvmProof → RawEvmProof for the static verifier's evm_verify
-    let raw_evm_proof: openvm_static_verifier::keygen::RawEvmProof = evm_proof.into();
+    let raw_evm_proof: openvm_static_verifier::keygen::RawEvmProof = evm_proof
+        .try_into()
+        .map_err(|err| SdkError::Other(eyre::eyre!("EVM proof verification failed: {err}")))?;
     let deployment_code = &openvm_verifier.artifact.bytecode;
 
     let gas_cost = openvm_static_verifier::keygen::evm_verify(deployment_code, &raw_evm_proof)

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -115,10 +115,14 @@ pub struct EvmProof {
 #[cfg(feature = "evm-prove")]
 #[derive(Debug, thiserror::Error)]
 pub enum EvmProofConversionError {
-    #[error("Invalid length of instances: expected at least 3, got {0}")]
+    #[error("Invalid length of instances: expected more than {}, got {0}", NUM_BN254_ACCUMULATOR + 2)]
     InvalidLengthInstances(usize),
-    #[error("Invalid length of user public values")]
-    InvalidUserPublicValuesLength,
+    #[error("Accumulator length {0} is not a multiple of {BN254_BYTES}")]
+    InvalidAccumulatorLength(usize),
+    #[error("Value is not a canonical Bn254 scalar")]
+    NonCanonicalScalar,
+    #[error(transparent)]
+    NonCanonicalCommit(#[from] openvm_continuations::CommitBytesError),
 }
 
 #[cfg(feature = "evm-prove")]
@@ -152,9 +156,9 @@ impl EvmProof {
     }
 
     #[cfg(feature = "evm-verify")]
-    pub fn fallback_calldata(&self) -> Vec<u8> {
-        let raw: openvm_static_verifier::keygen::RawEvmProof = self.clone().into();
-        encode_raw_evm_proof_calldata(&raw)
+    pub fn fallback_calldata(&self) -> Result<Vec<u8>, EvmProofConversionError> {
+        let raw: openvm_static_verifier::keygen::RawEvmProof = self.clone().try_into()?;
+        Ok(encode_raw_evm_proof_calldata(&raw))
     }
 }
 
@@ -185,16 +189,18 @@ pub fn encode_raw_evm_proof_calldata(
 /// - `instances[13]`: app_vm_commit (Fr)
 /// - `instances[14..]`: user public values (each byte as Fr)
 #[cfg(feature = "evm-prove")]
-impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
-    fn from(raw: openvm_static_verifier::keygen::RawEvmProof) -> Self {
+impl TryFrom<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
+    type Error = EvmProofConversionError;
+
+    fn try_from(raw: openvm_static_verifier::keygen::RawEvmProof) -> Result<Self, Self::Error> {
         use openvm_continuations::CommitBytes;
 
         let openvm_static_verifier::keygen::RawEvmProof { instances, proof } = raw;
-        assert!(
-            instances.len() > NUM_BN254_ACCUMULATOR + 2,
-            "RawEvmProof instances must have at least {} elements (accumulator + exe commit + vk commit)",
-            NUM_BN254_ACCUMULATOR + 2
-        );
+        if instances.len() <= NUM_BN254_ACCUMULATOR + 2 {
+            return Err(EvmProofConversionError::InvalidLengthInstances(
+                instances.len(),
+            ));
+        }
 
         // instances[0..12] are the KZG accumulator
         let accumulator = instances[0..NUM_BN254_ACCUMULATOR]
@@ -224,11 +230,11 @@ impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
             .collect::<Vec<u8>>();
 
         let app_commit = AppExecutionCommit {
-            app_exe_commit: CommitBytes::new(app_exe_bytes),
-            app_vm_commit: CommitBytes::new(app_vm_bytes),
+            app_exe_commit: CommitBytes::try_new(app_exe_bytes)?,
+            app_vm_commit: CommitBytes::try_new(app_vm_bytes)?,
         };
 
-        Self {
+        Ok(Self {
             version: format!("v{OPENVM_VERSION}"),
             app_commit,
             user_public_values,
@@ -236,15 +242,22 @@ impl From<openvm_static_verifier::keygen::RawEvmProof> for EvmProof {
                 accumulator: evm_accumulator,
                 proof,
             },
-        }
+        })
     }
 }
 
-/// Convert `EvmProof` → `RawEvmProof`.
+/// Convert `EvmProof` → `RawEvmProof`. Fallible because `evm_proof` may be untrusted.
 #[cfg(feature = "evm-prove")]
-impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
-    fn from(evm_proof: EvmProof) -> Self {
+impl TryFrom<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
+    type Error = EvmProofConversionError;
+
+    fn try_from(evm_proof: EvmProof) -> Result<Self, Self::Error> {
         use openvm_static_verifier::Fr;
+
+        fn to_fr(le_bytes: &[u8; 32]) -> Result<Fr, EvmProofConversionError> {
+            Option::from(Fr::from_bytes(le_bytes))
+                .ok_or(EvmProofConversionError::NonCanonicalScalar)
+        }
 
         let EvmProof {
             app_commit,
@@ -255,6 +268,12 @@ impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
 
         let ProofData { accumulator, proof } = proof_data;
 
+        if !accumulator.len().is_multiple_of(BN254_BYTES) {
+            return Err(EvmProofConversionError::InvalidAccumulatorLength(
+                accumulator.len(),
+            ));
+        }
+
         // Reverse each 32-byte chunk from big-endian (EVM) to little-endian (Fr)
         let mut reversed_accumulator = Vec::with_capacity(accumulator.len());
         accumulator
@@ -264,32 +283,33 @@ impl From<EvmProof> for openvm_static_verifier::keygen::RawEvmProof {
         // CommitBytes is big-endian; Fr::from_bytes expects little-endian
         let mut app_exe_bytes = *app_commit.app_exe_commit.as_slice();
         app_exe_bytes.reverse();
-        let app_exe_fr = Fr::from_bytes(&app_exe_bytes).unwrap();
+        let app_exe_fr = to_fr(&app_exe_bytes)?;
 
         let mut app_vm_bytes = *app_commit.app_vm_commit.as_slice();
         app_vm_bytes.reverse();
-        let app_vm_fr = Fr::from_bytes(&app_vm_bytes).unwrap();
+        let app_vm_fr = to_fr(&app_vm_bytes)?;
 
         let user_pvs_frs: Vec<Fr> = user_public_values
             .into_iter()
             .map(|byte| {
                 let mut bytes = [0u8; 32];
                 bytes[0] = byte;
-                Fr::from_bytes(&bytes).unwrap()
+                to_fr(&bytes)
             })
-            .collect();
+            .collect::<Result<_, _>>()?;
 
         // Reconstruct instances: accumulator + commits + user PVs
         let mut instances = Vec::new();
         for chunk in reversed_accumulator.chunks(BN254_BYTES) {
+            // Length checked above, so every chunk is full-width.
             let c: [u8; 32] = chunk.try_into().unwrap();
-            instances.push(Fr::from_bytes(&c).unwrap());
+            instances.push(to_fr(&c)?);
         }
         instances.push(app_exe_fr);
         instances.push(app_vm_fr);
         instances.extend(user_pvs_frs);
 
-        openvm_static_verifier::keygen::RawEvmProof { instances, proof }
+        Ok(openvm_static_verifier::keygen::RawEvmProof { instances, proof })
     }
 }
 


### PR DESCRIPTION
Three panics were reachable from a single attacker-supplied `EvmProof` JSON on the `cargo openvm verify evm` path, all before any cryptographic verification ran: a non-canonical commit (release `assert!` in `CommitBytes::Deserialize`), an accumulator length not a multiple of 32 (`try_into().unwrap()`), and a non-canonical Bn254 scalar (`Fr::from_bytes(..).unwrap()`). All three now return typed errors.

Host-side input validation only: no soundness impact, no vk change, Solidity verifier untouched.

## `openvm-continuations`

`commit_bytes.rs` — add `CommitBytes::try_new` and use it in `Deserialize`. `new` is kept as a panicking wrapper for the many call sites that build commits from data canonical by construction.

`Decode` is now hand-written instead of derived: the derive constructed the tuple struct directly, so the codec path could produce a non-canonical `CommitBytes` that the serde path rejects. Not one of the reported issues and not reachable from untrusted input today — separable if preferred.

## `openvm-sdk`

`types.rs` — both conversions become `TryFrom`. `EvmProof → RawEvmProof` is the attacker-reachable direction and now validates accumulator length and every scalar; the reverse is prover-output only but carried the same class of bug, including a real one where a valid `Fr` can exceed `F::MODULUS^8` and so be non-canonical as a `CommitBytes`. `EvmProofConversionError` gains three variants, drops one dead one, and has an incorrect message corrected — all four remaining variants are now constructed, where previously none were.

`solidity.rs`, `prover/halo2.rs`, `prover/evm.rs` — propagate the new `Result`. The cascade stops at `prove_evm`, which already returned `eyre::Result`.