### PR TITLE
perf: remove redundant columns from `XorinVmAir`

### DIFF
--- a/extensions/keccak256/circuit/cuda/include/xorin.cuh
+++ b/extensions/keccak256/circuit/cuda/include/xorin.cuh
@@ -16,9 +16,9 @@ struct XorinInstructionCols {
     T buffer_reg_ptr;
     T input_reg_ptr;
     T len_reg_ptr;
-    // Low 32 bits of [buffer_reg_ptr:8]_1 as u16 cells.
+    // Low 32 bits of the buffer register as u16 cells.
     T buffer_ptr_limbs[RV64_PTR_U16_LIMBS];
-    // Low 32 bits of [input_reg_ptr:8]_1 as u16 cells.
+    // Low 32 bits of the input register as u16 cells.
     T input_ptr_limbs[RV64_PTR_U16_LIMBS];
     T start_timestamp;
 };

--- a/extensions/keccak256/circuit/cuda/include/xorin.cuh
+++ b/extensions/keccak256/circuit/cuda/include/xorin.cuh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include "primitives/constants.h"
 #include "system/memory/offline_checker.cuh"
 
@@ -41,8 +40,7 @@ struct XorinMemoryCols {
     MemoryReadAuxCols<T> register_aux_cols[XORIN_REGISTER_READS];
     MemoryReadAuxCols<T> input_bytes_read_aux_cols[keccak256::KECCAK_RATE_MEM_OPS];
     MemoryReadAuxCols<T> buffer_bytes_read_aux_cols[keccak256::KECCAK_RATE_MEM_OPS];
-    MemoryWriteAuxCols<T, BLOCK_FE_WIDTH>
-        buffer_bytes_write_aux_cols[keccak256::KECCAK_RATE_MEM_OPS];
+    MemoryBaseAuxCols<T> buffer_bytes_write_base_aux[keccak256::KECCAK_RATE_MEM_OPS];
 };
 
 template <typename T>
@@ -50,24 +48,6 @@ struct XorinVmCols {
     XorinSpongeCols<T> sponge;
     XorinInstructionCols<T> instruction;
     XorinMemoryCols<T> mem_oc;
-};
-
-struct XorinVmRecord {
-    uint32_t from_pc;
-    uint32_t timestamp;
-    uint32_t rd_ptr;
-    uint32_t rs1_ptr;
-    uint32_t rs2_ptr;
-    uint32_t buffer;
-    uint32_t input;
-    uint32_t len;
-    uint8_t buffer_limbs[XORIN_RATE_BYTES];
-    uint8_t input_limbs[XORIN_RATE_BYTES];
-    MemoryReadAuxRecord register_aux_cols[XORIN_REGISTER_READS];
-    MemoryReadAuxRecord input_read_aux_cols[keccak256::KECCAK_RATE_MEM_OPS];
-    MemoryReadAuxRecord buffer_read_aux_cols[keccak256::KECCAK_RATE_MEM_OPS];
-    MemoryWriteBytesAuxRecord<program::DEFAULT_BLOCK_SIZE>
-        buffer_write_aux_cols[keccak256::KECCAK_RATE_MEM_OPS];
 };
 
 } // namespace xorin

--- a/extensions/keccak256/circuit/cuda/include/xorin.cuh
+++ b/extensions/keccak256/circuit/cuda/include/xorin.cuh
@@ -16,14 +16,10 @@ struct XorinInstructionCols {
     T buffer_reg_ptr;
     T input_reg_ptr;
     T len_reg_ptr;
-    T buffer_ptr;
     // Low 32 bits of [buffer_reg_ptr:8]_1 as u16 cells.
     T buffer_ptr_limbs[RV64_PTR_U16_LIMBS];
-    T input_ptr;
     // Low 32 bits of [input_reg_ptr:8]_1 as u16 cells.
     T input_ptr_limbs[RV64_PTR_U16_LIMBS];
-    T len;
-    T len_limb;
     T start_timestamp;
 };
 

--- a/extensions/keccak256/circuit/cuda/rvr/xorin.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/xorin.cu
@@ -34,7 +34,7 @@ static __device__ bool xorin_replay_event(
     DeviceBufferConstView<PreflightMemoryEvent> memory,
     DeviceBufferConstView<PreflightInitialWrite> seeds,
     DeviceBufferConstView<uint32_t> predecessors,
-    ReplayPreviousValue &previous,
+    uint32_t &previous_timestamp,
     uint32_t *error
 ) {
     if (event_idx >= memory.len() || event_idx >= predecessors.len()) {
@@ -42,6 +42,7 @@ static __device__ bool xorin_replay_event(
         return false;
     }
     auto const &event = memory[event_idx];
+    ReplayPreviousValue previous;
     if (event.timestamp != timestamp || preflight_address_space(event) != address_space ||
         event.pointer != pointer || preflight_is_write(event) != is_write ||
         !replay_previous_value(
@@ -50,6 +51,7 @@ static __device__ bool xorin_replay_event(
         preflight_set_error(error, XORIN_REPLAY_ERROR);
         return false;
     }
+    previous_timestamp = previous.timestamp;
     return true;
 }
 
@@ -122,7 +124,7 @@ __global__ void xorin_replay_tracegen(
     }
 
     size_t event_idx = step.memory_start;
-    ReplayPreviousValue register_previous[XORIN_REGISTER_READS];
+    uint32_t register_previous_timestamps[XORIN_REGISTER_READS];
     uint32_t register_ptrs[XORIN_REGISTER_READS] = {
         buffer_reg_ptr, input_reg_ptr, len_reg_ptr
     };
@@ -138,7 +140,7 @@ __global__ void xorin_replay_tracegen(
                 memory,
                 seeds,
                 predecessors,
-                register_previous[i],
+                register_previous_timestamps[i],
                 error
             )) {
             return;
@@ -174,9 +176,9 @@ __global__ void xorin_replay_tracegen(
 
     uint8_t buffer_bytes[XORIN_RATE_BYTES] = {};
     uint8_t input_bytes[XORIN_RATE_BYTES] = {};
-    ReplayPreviousValue buffer_read_previous[keccak256::KECCAK_RATE_MEM_OPS];
-    ReplayPreviousValue input_read_previous[keccak256::KECCAK_RATE_MEM_OPS];
-    ReplayPreviousValue buffer_write_previous[keccak256::KECCAK_RATE_MEM_OPS];
+    uint32_t buffer_read_previous_timestamps[keccak256::KECCAK_RATE_MEM_OPS];
+    uint32_t input_read_previous_timestamps[keccak256::KECCAK_RATE_MEM_OPS];
+    uint32_t buffer_write_previous_timestamps[keccak256::KECCAK_RATE_MEM_OPS];
 
     for (uint32_t i = 0; i < num_blocks; i++) {
         if (!xorin_replay_event(
@@ -188,7 +190,7 @@ __global__ void xorin_replay_tracegen(
                 memory,
                 seeds,
                 predecessors,
-                buffer_read_previous[i],
+                buffer_read_previous_timestamps[i],
                 error
             )) {
             return;
@@ -206,7 +208,7 @@ __global__ void xorin_replay_tracegen(
                 memory,
                 seeds,
                 predecessors,
-                input_read_previous[i],
+                input_read_previous_timestamps[i],
                 error
             )) {
             return;
@@ -224,7 +226,7 @@ __global__ void xorin_replay_tracegen(
                 memory,
                 seeds,
                 predecessors,
-                buffer_write_previous[i],
+                buffer_write_previous_timestamps[i],
                 error
             )) {
             return;
@@ -277,24 +279,24 @@ __global__ void xorin_replay_tracegen(
     for (size_t i = 0; i < XORIN_REGISTER_READS; i++) {
         mem_helper.fill(
             XORIN_SLICE(mem_oc.register_aux_cols[i].base),
-            register_previous[i].timestamp,
+            register_previous_timestamps[i],
             from.timestamp + static_cast<uint32_t>(i)
         );
     }
     for (uint32_t i = 0; i < num_blocks; i++) {
         mem_helper.fill(
             XORIN_SLICE(mem_oc.buffer_bytes_read_aux_cols[i].base),
-            buffer_read_previous[i].timestamp,
+            buffer_read_previous_timestamps[i],
             from.timestamp + XORIN_REGISTER_READS + i
         );
         mem_helper.fill(
             XORIN_SLICE(mem_oc.input_bytes_read_aux_cols[i].base),
-            input_read_previous[i].timestamp,
+            input_read_previous_timestamps[i],
             from.timestamp + XORIN_REGISTER_READS + num_blocks + i
         );
         mem_helper.fill(
             XORIN_SLICE(mem_oc.buffer_bytes_write_base_aux[i]),
-            buffer_write_previous[i].timestamp,
+            buffer_write_previous_timestamps[i],
             from.timestamp + XORIN_REGISTER_READS + 2 * num_blocks + i
         );
     }

--- a/extensions/keccak256/circuit/cuda/rvr/xorin.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/xorin.cu
@@ -23,7 +23,6 @@ static constexpr uint32_t XORIN_REPLAY_ERROR = 801;
 
 #define XORIN_WRITE(FIELD, VALUE) COL_WRITE_VALUE(row, XorinVmCols, FIELD, VALUE)
 #define XORIN_WRITE_ARRAY(FIELD, VALUES) COL_WRITE_ARRAY(row, XorinVmCols, FIELD, VALUES)
-#define XORIN_FILL_ZERO(FIELD) COL_FILL_ZERO(row, XorinVmCols, FIELD)
 #define XORIN_SLICE(FIELD) row.slice_from(COL_INDEX(XorinVmCols, FIELD))
 
 static __device__ bool xorin_replay_event(
@@ -298,12 +297,9 @@ __global__ void xorin_replay_tracegen(
             from.timestamp + XORIN_REGISTER_READS + num_blocks + i
         );
         mem_helper.fill(
-            XORIN_SLICE(mem_oc.buffer_bytes_write_aux_cols[i].base),
+            XORIN_SLICE(mem_oc.buffer_bytes_write_base_aux[i]),
             buffer_write_previous[i].timestamp,
             from.timestamp + XORIN_REGISTER_READS + 2 * num_blocks + i
-        );
-        XORIN_WRITE_ARRAY(
-            mem_oc.buffer_bytes_write_aux_cols[i].prev_data, buffer_write_previous[i].value
         );
     }
     range_checker.add_count(

--- a/extensions/keccak256/circuit/cuda/rvr/xorin.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/xorin.cu
@@ -255,9 +255,6 @@ __global__ void xorin_replay_tracegen(
     XORIN_WRITE(instruction.buffer_reg_ptr, buffer_reg_ptr);
     XORIN_WRITE(instruction.input_reg_ptr, input_reg_ptr);
     XORIN_WRITE(instruction.len_reg_ptr, len_reg_ptr);
-    XORIN_WRITE(instruction.buffer_ptr, buffer_ptr);
-    XORIN_WRITE(instruction.input_ptr, input_ptr);
-    XORIN_WRITE(instruction.len, len);
     XORIN_WRITE(instruction.start_timestamp, from.timestamp);
     uint16_t buffer_ptr_limbs[RV64_PTR_U16_LIMBS];
     uint16_t input_ptr_limbs[RV64_PTR_U16_LIMBS];
@@ -265,7 +262,6 @@ __global__ void xorin_replay_tracegen(
     ptr_to_u16_limbs(input_ptr_limbs, input_ptr);
     XORIN_WRITE_ARRAY(instruction.buffer_ptr_limbs, buffer_ptr_limbs);
     XORIN_WRITE_ARRAY(instruction.input_ptr_limbs, input_ptr_limbs);
-    XORIN_WRITE(instruction.len_limb, static_cast<uint8_t>(len));
 
     for (uint32_t i = 0; i < keccak256::KECCAK_RATE_MEM_OPS; i++) {
         XORIN_WRITE(sponge.is_padding_bytes[i], i >= num_blocks);

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -107,13 +107,13 @@ impl XorinVmAir {
         ];
 
         let mut timestamp_change = AB::Expr::from_u32(3);
-        let mut not_padding_sum = AB::Expr::ZERO;
+        let mut num_used_blocks = AB::Expr::ZERO;
         let is_padding_bytes = local.sponge.is_padding_bytes;
 
         // Check that is_padding_bytes is of the form 0...01...1
         for (i, &is_padding) in is_padding_bytes.iter().enumerate() {
             builder.assert_bool(is_padding);
-            not_padding_sum += not(is_padding);
+            num_used_blocks += not(is_padding);
             if i > 0 {
                 builder
                     .when(is_enabled)
@@ -122,11 +122,6 @@ impl XorinVmAir {
             // Each 8-byte memory block has 3 ops (buffer read + input read + buffer write).
             timestamp_change += AB::Expr::from_u32(3) * not(is_padding);
         }
-
-        not_padding_sum *= AB::Expr::from_usize(MEMORY_BLOCK_BYTES);
-        builder
-            .when(is_enabled)
-            .assert_eq(not_padding_sum, instruction.len);
 
         self.execution_bridge
             .execute_and_increment_pc(
@@ -150,7 +145,8 @@ impl XorinVmAir {
             expand_to_rv64_block(&instruction.buffer_ptr_limbs);
         let input_ptr_data: [AB::Expr; BLOCK_FE_WIDTH] =
             expand_to_rv64_block(&instruction.input_ptr_limbs);
-        let len_data: [AB::Expr; BLOCK_FE_WIDTH] = expand_to_rv64_block(&[instruction.len_limb]);
+        let len_in_bytes = num_used_blocks * AB::Expr::from_usize(MEMORY_BLOCK_BYTES);
+        let len_data: [AB::Expr; BLOCK_FE_WIDTH] = expand_to_rv64_block(&[len_in_bytes]);
 
         // Increases timestamp by 3
         for (ptr, value, aux) in izip!(
@@ -185,17 +181,6 @@ impl XorinVmAir {
                 .eval(builder, is_enabled);
         }
 
-        builder.assert_eq(
-            instruction.buffer_ptr,
-            u16_limbs_to_ptr(&instruction.buffer_ptr_limbs),
-        );
-        builder.assert_eq(
-            instruction.input_ptr,
-            u16_limbs_to_ptr(&instruction.input_ptr_limbs),
-        );
-
-        builder.assert_eq(instruction.len, instruction.len_limb);
-
         timestamp
     }
 
@@ -212,6 +197,9 @@ impl XorinVmAir {
         let is_enabled = local.instruction.is_enabled;
         let mut timestamp = start_read_timestamp;
 
+        let buffer_ptr = u16_limbs_to_ptr(&local.instruction.buffer_ptr_limbs);
+        let input_ptr = u16_limbs_to_ptr(&local.instruction.input_ptr_limbs);
+
         // Constrain read of buffer bytes
         // Timestamp increases by <= (136/8) = 17
         for (i, (input, mem_aux)) in izip!(
@@ -223,7 +211,7 @@ impl XorinVmAir {
         )
         .enumerate()
         {
-            let ptr = local.instruction.buffer_ptr + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
+            let ptr = buffer_ptr.clone() + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
             let is_padding = local.sponge.is_padding_bytes[i];
             let should_read = is_enabled * not(is_padding);
 
@@ -259,7 +247,7 @@ impl XorinVmAir {
         )
         .enumerate()
         {
-            let ptr = local.instruction.input_ptr + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
+            let ptr = input_ptr.clone() + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
             let is_padding = local.sponge.is_padding_bytes[i];
             let should_read = is_enabled * not(is_padding);
 
@@ -327,6 +315,7 @@ impl XorinVmAir {
     ) {
         let mut timestamp = start_write_timestamp;
         let is_enabled = local.instruction.is_enabled;
+        let buffer_ptr = u16_limbs_to_ptr(&local.instruction.buffer_ptr_limbs);
 
         // Constrain write of buffer bytes
         // Each block is written back to the address its buffer read came from,
@@ -346,7 +335,7 @@ impl XorinVmAir {
         {
             let is_padding = local.sponge.is_padding_bytes[i];
             let should_write = is_enabled * not(is_padding);
-            let ptr = local.instruction.buffer_ptr + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
+            let ptr = buffer_ptr.clone() + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
 
             let prev_data = pack_u8_block::<AB>(&std::array::from_fn(|j| prev[j].into()));
             let data = pack_u8_block::<AB>(&std::array::from_fn(|j| output[j].into()));

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -202,7 +202,7 @@ impl XorinVmAir {
 
         // Constrain read of buffer bytes
         // Timestamp increases by <= (136/8) = 17
-        for (i, (input, mem_aux)) in izip!(
+        for (i, (buffer_block, mem_aux)) in izip!(
             local
                 .sponge
                 .preimage_buffer_bytes
@@ -222,14 +222,14 @@ impl XorinVmAir {
                         byte_ptr_to_u16_ptr::<AB>(ptr),
                     ),
                     pack_u8_block::<AB>(&[
-                        input[0].into(),
-                        input[1].into(),
-                        input[2].into(),
-                        input[3].into(),
-                        input[4].into(),
-                        input[5].into(),
-                        input[6].into(),
-                        input[7].into(),
+                        buffer_block[0].into(),
+                        buffer_block[1].into(),
+                        buffer_block[2].into(),
+                        buffer_block[3].into(),
+                        buffer_block[4].into(),
+                        buffer_block[5].into(),
+                        buffer_block[6].into(),
+                        buffer_block[7].into(),
                     ]),
                     timestamp.clone(),
                     mem_aux,

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -4,7 +4,9 @@ use itertools::izip;
 use openvm_circuit::{
     arch::{ExecutionBridge, ExecutionState, BLOCK_FE_WIDTH, MEMORY_BLOCK_BYTES},
     system::memory::{
-        offline_checker::{pack_u8_block, MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxCols},
+        offline_checker::{
+            pack_u8_block, MemoryBaseAuxCols, MemoryBridge, MemoryReadAuxCols, MemoryWriteAuxInput,
+        },
         MemoryAddress,
     },
 };
@@ -79,7 +81,7 @@ impl<AB: InteractionBuilder> Air<AB> for XorinVmAir {
             builder,
             local,
             start_write_timestamp,
-            &mem.buffer_bytes_write_aux_cols,
+            &mem.buffer_bytes_write_base_aux,
         );
     }
 }
@@ -321,18 +323,24 @@ impl XorinVmAir {
         builder: &mut AB,
         local: &XorinVmCols<AB::Var>,
         start_write_timestamp: AB::Expr,
-        mem_aux: &[MemoryWriteAuxCols<AB::Var, BLOCK_FE_WIDTH>; KECCAK_RATE_MEM_OPS],
+        write_base_aux: &[MemoryBaseAuxCols<AB::Var>; KECCAK_RATE_MEM_OPS],
     ) {
         let mut timestamp = start_write_timestamp;
         let is_enabled = local.instruction.is_enabled;
 
         // Constrain write of buffer bytes
-        for (i, (output, mem_aux)) in izip!(
+        // Each block is written back to the address its buffer read came from,
+        // so preimage_buffer_bytes can act as the previous data.
+        for (i, (prev, output, base_aux)) in izip!(
+            local
+                .sponge
+                .preimage_buffer_bytes
+                .chunks_exact(MEMORY_BLOCK_BYTES),
             local
                 .sponge
                 .postimage_buffer_bytes
                 .chunks_exact(MEMORY_BLOCK_BYTES),
-            mem_aux
+            write_base_aux
         )
         .enumerate()
         {
@@ -340,24 +348,18 @@ impl XorinVmAir {
             let should_write = is_enabled * not(is_padding);
             let ptr = local.instruction.buffer_ptr + AB::F::from_usize(i * MEMORY_BLOCK_BYTES);
 
+            let prev_data = pack_u8_block::<AB>(&std::array::from_fn(|j| prev[j].into()));
+            let data = pack_u8_block::<AB>(&std::array::from_fn(|j| output[j].into()));
+
             self.memory_bridge
                 .write(
                     MemoryAddress::new(
                         AB::Expr::from_u32(RV64_MEMORY_AS),
                         byte_ptr_to_u16_ptr::<AB>(ptr),
                     ),
-                    pack_u8_block::<AB>(&[
-                        output[0].into(),
-                        output[1].into(),
-                        output[2].into(),
-                        output[3].into(),
-                        output[4].into(),
-                        output[5].into(),
-                        output[6].into(),
-                        output[7].into(),
-                    ]),
+                    data,
                     timestamp.clone(),
-                    mem_aux,
+                    MemoryWriteAuxInput::from_prev_data_exprs(base_aux, prev_data),
                 )
                 .eval(builder, should_write);
 

--- a/extensions/keccak256/circuit/src/xorin/columns.rs
+++ b/extensions/keccak256/circuit/src/xorin/columns.rs
@@ -22,9 +22,9 @@ pub struct XorinInstructionCols<T> {
     pub buffer_reg_ptr: T,
     pub input_reg_ptr: T,
     pub len_reg_ptr: T,
-    /// Low 32 bits of the `rs0` register as u16 cells.
+    /// Low 32 bits of the buffer register as u16 cells.
     pub buffer_ptr_limbs: [T; RV64_PTR_U16_LIMBS],
-    /// Low 32 bits of the `rs1` register as u16 cells.
+    /// Low 32 bits of the input register as u16 cells.
     pub input_ptr_limbs: [T; RV64_PTR_U16_LIMBS],
     pub start_timestamp: T,
 }

--- a/extensions/keccak256/circuit/src/xorin/columns.rs
+++ b/extensions/keccak256/circuit/src/xorin/columns.rs
@@ -1,7 +1,4 @@
-use openvm_circuit::{
-    arch::BLOCK_FE_WIDTH,
-    system::memory::offline_checker::{MemoryReadAuxCols, MemoryWriteAuxCols},
-};
+use openvm_circuit::system::memory::offline_checker::{MemoryBaseAuxCols, MemoryReadAuxCols};
 use openvm_circuit_primitives::{StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_riscv_circuit::adapters::RV64_PTR_U16_LIMBS;
@@ -53,7 +50,8 @@ pub struct XorinMemoryCols<T> {
     pub register_aux_cols: [MemoryReadAuxCols<T>; 3],
     pub input_bytes_read_aux_cols: [MemoryReadAuxCols<T>; KECCAK_RATE_MEM_OPS],
     pub buffer_bytes_read_aux_cols: [MemoryReadAuxCols<T>; KECCAK_RATE_MEM_OPS],
-    pub buffer_bytes_write_aux_cols: [MemoryWriteAuxCols<T, BLOCK_FE_WIDTH>; KECCAK_RATE_MEM_OPS],
+    // Only store timestamp for write. preimage_buffer_bytes contains previous data.
+    pub buffer_bytes_write_base_aux: [MemoryBaseAuxCols<T>; KECCAK_RATE_MEM_OPS],
 }
 
 pub const NUM_XORIN_VM_COLS: usize = size_of::<XorinVmCols<u8>>();

--- a/extensions/keccak256/circuit/src/xorin/columns.rs
+++ b/extensions/keccak256/circuit/src/xorin/columns.rs
@@ -46,7 +46,7 @@ pub struct XorinMemoryCols<T> {
     pub register_aux_cols: [MemoryReadAuxCols<T>; 3],
     pub input_bytes_read_aux_cols: [MemoryReadAuxCols<T>; KECCAK_RATE_MEM_OPS],
     pub buffer_bytes_read_aux_cols: [MemoryReadAuxCols<T>; KECCAK_RATE_MEM_OPS],
-    // Only store timestamp for write. preimage_buffer_bytes contains previous data.
+    // Only store write timestamp auxiliaries; previous data comes from preimage_buffer_bytes.
     pub buffer_bytes_write_base_aux: [MemoryBaseAuxCols<T>; KECCAK_RATE_MEM_OPS],
 }
 

--- a/extensions/keccak256/circuit/src/xorin/columns.rs
+++ b/extensions/keccak256/circuit/src/xorin/columns.rs
@@ -22,14 +22,10 @@ pub struct XorinInstructionCols<T> {
     pub buffer_reg_ptr: T,
     pub input_reg_ptr: T,
     pub len_reg_ptr: T,
-    pub buffer_ptr: T,
     /// Low 32 bits of the `rs0` register as u16 cells.
     pub buffer_ptr_limbs: [T; RV64_PTR_U16_LIMBS],
-    pub input_ptr: T,
     /// Low 32 bits of the `rs1` register as u16 cells.
     pub input_ptr_limbs: [T; RV64_PTR_U16_LIMBS],
-    pub len: T,
-    pub len_limb: T,
     pub start_timestamp: T,
 }
 

--- a/extensions/keccak256/circuit/src/xorin/tests.rs
+++ b/extensions/keccak256/circuit/src/xorin/tests.rs
@@ -305,6 +305,22 @@ fn xorin_wrong_len_limb_negative_test() {
     });
 }
 
+#[test]
+fn xorin_wrong_preimage_negative_test() {
+    run_xorin_chip_negative_test(|cols| {
+        cols.sponge.preimage_buffer_bytes[0] += F::ONE;
+    });
+}
+
+#[test]
+fn xorin_wrong_write_timestamp_negative_test() {
+    run_xorin_chip_negative_test(|cols| {
+        cols.mem_oc.buffer_bytes_write_base_aux[0]
+            .timestamp_lt_aux
+            .diff_decomp[0] += F::ONE;
+    });
+}
+
 fn xorin_postflight_fixture() -> Harness {
     const LEN: usize = 16;
 

--- a/extensions/keccak256/circuit/src/xorin/tests.rs
+++ b/extensions/keccak256/circuit/src/xorin/tests.rs
@@ -299,9 +299,28 @@ fn xorin_wrong_output_negative_test() {
 }
 
 #[test]
-fn xorin_wrong_len_limb_negative_test() {
+fn xorin_wrong_len_negative_test() {
     run_xorin_chip_negative_test(|cols| {
-        cols.instruction.len_limb += F::ONE;
+        // is_padding_bytes has the form 0...01...1; turn the last active block into padding.
+        let last_active = (0..KECCAK_RATE_MEM_OPS)
+            .rev()
+            .find(|&i| cols.sponge.is_padding_bytes[i] == F::ZERO)
+            .expect("at least one active block");
+        cols.sponge.is_padding_bytes[last_active] = F::ONE;
+    });
+}
+
+#[test]
+fn xorin_wrong_buffer_ptr_limb_negative_test() {
+    run_xorin_chip_negative_test(|cols| {
+        cols.instruction.buffer_ptr_limbs[0] += F::ONE;
+    });
+}
+
+#[test]
+fn xorin_wrong_input_ptr_limb_negative_test() {
+    run_xorin_chip_negative_test(|cols| {
+        cols.instruction.input_ptr_limbs[0] += F::ONE;
     });
 }
 

--- a/extensions/keccak256/circuit/src/xorin/tests.rs
+++ b/extensions/keccak256/circuit/src/xorin/tests.rs
@@ -116,6 +116,24 @@ fn create_test_harness(
     (harness, (bitwise_chip.air, bitwise_chip))
 }
 
+fn xorin_test_pointers(
+    rng: &mut StdRng,
+    len: usize,
+    input_ptr_offset: Option<usize>,
+) -> (usize, usize) {
+    if len == 0 {
+        // Main-memory pointers are unused for an all-padding row and need not be aligned.
+        return (1, 3);
+    }
+    if let Some(offset) = input_ptr_offset {
+        assert!(offset.is_multiple_of(MEMORY_BLOCK_BYTES));
+        let buffer_ptr = gen_pointer(rng, len + offset);
+        (buffer_ptr, buffer_ptr + offset)
+    } else {
+        (gen_pointer(rng, len), gen_pointer(rng, len))
+    }
+}
+
 fn set_and_execute<E: Executor<F> + Clone>(
     tester: &mut impl TestBuilder<F>,
     executor: &mut E,
@@ -123,6 +141,7 @@ fn set_and_execute<E: Executor<F> + Clone>(
     rng: &mut StdRng,
     opcode: XorinOpcode,
     buffer_length: Option<usize>,
+    input_ptr_offset: Option<usize>,
 ) {
     const MAX_LEN: usize = KECCAK_RATE_BYTES;
 
@@ -143,16 +162,13 @@ fn set_and_execute<E: Executor<F> + Clone>(
 
     let [rd, rs1, rs2] = gen_distinct_register_pointers(rng, RV64_REGISTER_NUM_LIMBS);
 
-    // Align buffer/input pointers to MEMORY_BLOCK_BYTES-byte blocks for memory bus compatibility
-    let num_blocks = buffer_length.div_ceil(MEMORY_BLOCK_BYTES);
-    let aligned_len = num_blocks * MEMORY_BLOCK_BYTES;
-    let buffer_ptr = gen_pointer(rng, aligned_len);
-    let input_ptr = gen_pointer(rng, aligned_len);
+    let num_blocks = buffer_length / MEMORY_BLOCK_BYTES;
+    let (buffer_ptr, input_ptr) = xorin_test_pointers(rng, buffer_length, input_ptr_offset);
 
     let rand_buffer_arr_f = rand_buffer_arr.map(F::from_u8);
     let rand_input_arr_f = rand_input_arr.map(F::from_u8);
 
-    // Write memory in MEMORY_BLOCK_BYTES-byte blocks; for the last partial block, pad with zeros
+    // Initialize buffer before input so overlapping ranges have a deterministic final image.
     for i in 0..num_blocks {
         let start = MEMORY_BLOCK_BYTES * i;
         let end = std::cmp::min(start + MEMORY_BLOCK_BYTES, MAX_LEN);
@@ -165,7 +181,11 @@ fn set_and_execute<E: Executor<F> + Clone>(
             buffer_ptr + MEMORY_BLOCK_BYTES * i,
             buffer_chunk,
         );
+    }
 
+    for i in 0..num_blocks {
+        let start = MEMORY_BLOCK_BYTES * i;
+        let end = std::cmp::min(start + MEMORY_BLOCK_BYTES, MAX_LEN);
         let mut input_chunk = [F::ZERO; MEMORY_BLOCK_BYTES];
         for (j, &v) in rand_input_arr_f[start..end].iter().enumerate() {
             input_chunk[j] = v;
@@ -207,9 +227,20 @@ fn set_and_execute<E: Executor<F> + Clone>(
         ),
     );
 
+    // Input initialization happens after buffer initialization and may overlap it.
+    let mut preimage_buffer = rand_buffer_arr;
+    for (input_index, &byte) in rand_input_arr[..buffer_length].iter().enumerate() {
+        if let Some(buffer_index) = (input_ptr + input_index)
+            .checked_sub(buffer_ptr)
+            .filter(|&index| index < buffer_length)
+        {
+            preimage_buffer[buffer_index] = byte;
+        }
+    }
+
     let mut expected_output = [0u8; MAX_LEN];
     for i in 0..buffer_length {
-        expected_output[i] = rand_buffer_arr[i] ^ rand_input_arr[i];
+        expected_output[i] = preimage_buffer[i] ^ rand_input_arr[i];
     }
 
     let mut output_buffer = [F::from_u8(0); MAX_LEN];
@@ -244,8 +275,31 @@ fn xorin_chip_positive_tests() {
             &mut rng,
             XorinOpcode::XORIN,
             buffer_length,
+            None,
         );
     }
+
+    for input_ptr_offset in [0, MEMORY_BLOCK_BYTES] {
+        set_and_execute(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.preflight,
+            &mut rng,
+            XorinOpcode::XORIN,
+            Some(3 * MEMORY_BLOCK_BYTES),
+            Some(input_ptr_offset),
+        );
+    }
+
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        XorinOpcode::XORIN,
+        Some(0),
+        None,
+    );
 
     let tester = tester
         .build()
@@ -269,6 +323,7 @@ fn run_xorin_chip_negative_test(prank: impl Fn(&mut XorinVmCols<F>)) {
         &mut rng,
         XorinOpcode::XORIN,
         buffer_length,
+        None,
     );
 
     let modify_trace = |trace: &mut DenseMatrix<F>| {
@@ -479,17 +534,14 @@ fn cuda_set_and_execute(
     preflight: &mut TestPreflight<F>,
     rng: &mut StdRng,
     len: Option<usize>,
+    input_ptr_offset: Option<usize>,
 ) {
     let len = len.unwrap_or_else(|| rng.random_range(1..=KECCAK_RATE_MEM_OPS) * MEMORY_BLOCK_BYTES);
-    if len == 0 {
-        return;
-    }
 
     let [buffer_reg, input_reg, len_reg] =
         gen_distinct_register_pointers(rng, RV64_REGISTER_NUM_LIMBS);
 
-    let buffer_ptr = gen_pointer(rng, len);
-    let input_ptr = gen_pointer(rng, len);
+    let (buffer_ptr, input_ptr) = xorin_test_pointers(rng, len, input_ptr_offset);
 
     tester.write_bytes(
         1,
@@ -546,6 +598,7 @@ fn test_xorin_cuda_tracegen() {
             &mut harness.preflight,
             &mut rng,
             None,
+            None,
         );
     }
 
@@ -556,8 +609,29 @@ fn test_xorin_cuda_tracegen() {
             &mut harness.preflight,
             &mut rng,
             Some(len),
+            None,
         );
     }
+
+    for input_ptr_offset in [0, MEMORY_BLOCK_BYTES] {
+        cuda_set_and_execute(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.preflight,
+            &mut rng,
+            Some(3 * MEMORY_BLOCK_BYTES),
+            Some(input_ptr_offset),
+        );
+    }
+
+    cuda_set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        Some(0),
+        None,
+    );
 
     tester
         .build()
@@ -582,6 +656,7 @@ fn test_xorin_cuda_tracegen_single() {
         &mut harness.preflight,
         &mut rng,
         Some(16),
+        None,
     );
 
     tester

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -70,7 +70,7 @@ impl XorinVmFiller {
 
         let mut timestamp = input.timestamp;
         let input_len = input.len as usize;
-        let num_reads = input_len.div_ceil(MEMORY_BLOCK_BYTES);
+        let num_reads = input_len / MEMORY_BLOCK_BYTES;
 
         for t in 0..3 {
             mem_helper.fill(
@@ -100,8 +100,6 @@ impl XorinVmFiller {
             timestamp += 1;
         }
 
-        // Fill all bytes that are covered by active 8-byte memory blocks.
-        let bytes_covered = num_reads * MEMORY_BLOCK_BYTES;
         for i in 0..input_len {
             trace_row.sponge.preimage_buffer_bytes[i] = F::from_u8(input.buffer_limbs[i]);
             trace_row.sponge.input_bytes[i] = F::from_u8(input.input_limbs[i]);
@@ -110,11 +108,6 @@ impl XorinVmFiller {
             let b_val = input.buffer_limbs[i] as u32;
             let c_val = input.input_limbs[i] as u32;
             self.bitwise_lookup_chip.request_xor(b_val, c_val);
-        }
-        for i in input_len..bytes_covered {
-            trace_row.sponge.preimage_buffer_bytes[i] = F::from_u8(input.buffer_limbs[i]);
-            trace_row.sponge.input_bytes[i] = F::from_u8(input.input_limbs[i]);
-            trace_row.sponge.postimage_buffer_bytes[i] = F::from_u8(input.buffer_limbs[i]);
         }
 
         for t in 0..num_reads {

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -59,12 +59,8 @@ impl XorinVmFiller {
         trace_row.instruction.buffer_reg_ptr = F::from_u32(input.rd_ptr);
         trace_row.instruction.input_reg_ptr = F::from_u32(input.rs1_ptr);
         trace_row.instruction.len_reg_ptr = F::from_u32(input.rs2_ptr);
-        trace_row.instruction.buffer_ptr = F::from_u32(input.buffer);
         trace_row.instruction.buffer_ptr_limbs = ptr_to_field_u16_limbs(input.buffer);
-        trace_row.instruction.input_ptr = F::from_u32(input.input);
         trace_row.instruction.input_ptr_limbs = ptr_to_field_u16_limbs(input.input);
-        trace_row.instruction.len = F::from_u32(input.len);
-        trace_row.instruction.len_limb = F::from_u8(input.len as u8);
         trace_row.instruction.start_timestamp = F::from_u32(input.timestamp);
 
         for i in 0..(input.len as usize / MEMORY_BLOCK_BYTES) {

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -1,9 +1,7 @@
 use std::borrow::BorrowMut;
 
 use openvm_circuit::{
-    arch::*,
-    system::memory::{offline_checker::MemoryReadAuxRecord, MemoryAuxColsFactory},
-    utils::next_power_of_two_or_zero,
+    arch::*, system::memory::MemoryAuxColsFactory, utils::next_power_of_two_or_zero,
 };
 use openvm_circuit_primitives::U16_BITS;
 use openvm_instructions::{
@@ -16,113 +14,192 @@ use openvm_riscv_circuit::adapters::{
     byte_ptr_to_u16_ptr_value, ptr_bound_from_ptr, ptr_to_field_u16_limbs, rv64_bytes_to_u16_block,
     rv64_u16_block_to_bytes, try_rv64_bytes_to_u32,
 };
-use openvm_stark_backend::{
-    p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix, p3_maybe_rayon::prelude::*,
-};
+use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix};
 
 use crate::{
     xorin::{columns::XorinVmCols, XorinVmChip, XorinVmFiller},
     KECCAK_RATE_BYTES, KECCAK_RATE_MEM_OPS,
 };
 
-struct XorinTraceInput {
-    from_pc: u32,
-    timestamp: u32,
-    rd_ptr: u32,
-    rs1_ptr: u32,
-    rs2_ptr: u32,
-    buffer: u32,
-    input: u32,
-    len: u32,
-    buffer_limbs: [u8; KECCAK_RATE_BYTES],
-    input_limbs: [u8; KECCAK_RATE_BYTES],
-    register_aux_cols: [MemoryReadAuxRecord; 3],
-    input_read_aux_cols: [MemoryReadAuxRecord; KECCAK_RATE_MEM_OPS],
-    buffer_read_aux_cols: [MemoryReadAuxRecord; KECCAK_RATE_MEM_OPS],
-    buffer_write_prev_timestamps: [u32; KECCAK_RATE_MEM_OPS],
-}
-
 impl XorinVmFiller {
-    fn fill_trace_input<F: PrimeField32>(
+    fn replay_and_fill_trace_row<F: PrimeField32>(
         &self,
+        postflight: &Postflight<'_, F>,
+        step: PostflightStep,
         mem_helper: &MemoryAuxColsFactory<F>,
-        input: &XorinTraceInput,
         row_slice: &mut [F],
-    ) {
+    ) -> Result<(), PostflightError> {
+        let instruction = postflight.instruction(step);
+        if instruction.d.as_canonical_u32() != RV64_REGISTER_AS
+            || instruction.e.as_canonical_u32() != RV64_MEMORY_AS
+        {
+            return Err(PostflightError::new(
+                "XORIN instruction has invalid address spaces",
+            ));
+        }
+
+        let from_pc = postflight.pc(step);
+        let start_timestamp = postflight.timestamp(step);
+        let rd_ptr = instruction.a.as_canonical_u32();
+        let rs1_ptr = instruction.b.as_canonical_u32();
+        let rs2_ptr = instruction.c.as_canonical_u32();
+        for pointer in [rd_ptr, rs1_ptr, rs2_ptr] {
+            if pointer & 1 != 0 {
+                return Err(PostflightError::new(
+                    "XORIN register pointer must be two-byte aligned",
+                ));
+            }
+        }
+
+        let mut replay = postflight.replay(step);
+        let register_reads = [
+            replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(rd_ptr))?,
+            replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(rs1_ptr))?,
+            replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(rs2_ptr))?,
+        ];
+        let [Some(buffer), Some(input), Some(len)] = register_reads
+            .each_ref()
+            .map(|access| try_rv64_bytes_to_u32(rv64_u16_block_to_bytes(access.value)))
+        else {
+            return Err(PostflightError::new("XORIN register value exceeds 32 bits"));
+        };
+        let len_usize = len as usize;
+        if len_usize > KECCAK_RATE_BYTES || !len_usize.is_multiple_of(MEMORY_BLOCK_BYTES) {
+            return Err(PostflightError::new(
+                "XORIN length must be an aligned rate-sized byte count",
+            ));
+        }
+        let num_reads = len_usize / MEMORY_BLOCK_BYTES;
+        if num_reads != 0 && (buffer & 1 != 0 || input & 1 != 0) {
+            return Err(PostflightError::new(
+                "XORIN memory pointer must be two-byte aligned",
+            ));
+        }
+        let domain_end = if self.pointer_max_bits < 32 {
+            1u64 << self.pointer_max_bits
+        } else {
+            1u64 << 32
+        };
+        if u64::from(buffer) >= domain_end
+            || u64::from(input) >= domain_end
+            || u64::from(buffer) + u64::from(len) > domain_end
+            || u64::from(input) + u64::from(len) > domain_end
+        {
+            return Err(PostflightError::new(
+                "XORIN memory range exceeds the pointer domain",
+            ));
+        }
+
+        let mut buffer_limbs = [0u8; KECCAK_RATE_BYTES];
+        let mut input_limbs = [0u8; KECCAK_RATE_BYTES];
+        let mut buffer_read_prev_timestamps = [0; KECCAK_RATE_MEM_OPS];
+        let mut input_read_prev_timestamps = [0; KECCAK_RATE_MEM_OPS];
+        for index in 0..num_reads {
+            let access = replay.read_u16(
+                RV64_MEMORY_AS,
+                byte_ptr_to_u16_ptr_value(buffer) + (index * BLOCK_FE_WIDTH) as u32,
+            )?;
+            buffer_limbs[index * MEMORY_BLOCK_BYTES..(index + 1) * MEMORY_BLOCK_BYTES]
+                .copy_from_slice(&rv64_u16_block_to_bytes(access.value));
+            buffer_read_prev_timestamps[index] = access.previous_timestamp;
+        }
+        for index in 0..num_reads {
+            let access = replay.read_u16(
+                RV64_MEMORY_AS,
+                byte_ptr_to_u16_ptr_value(input) + (index * BLOCK_FE_WIDTH) as u32,
+            )?;
+            input_limbs[index * MEMORY_BLOCK_BYTES..(index + 1) * MEMORY_BLOCK_BYTES]
+                .copy_from_slice(&rv64_u16_block_to_bytes(access.value));
+            input_read_prev_timestamps[index] = access.previous_timestamp;
+        }
+
+        let mut buffer_write_prev_timestamps = [0; KECCAK_RATE_MEM_OPS];
+        for (index, prev_timestamp) in buffer_write_prev_timestamps
+            .iter_mut()
+            .enumerate()
+            .take(num_reads)
+        {
+            let mut output = [0u8; MEMORY_BLOCK_BYTES];
+            for (byte, output_byte) in output.iter_mut().enumerate() {
+                let offset = index * MEMORY_BLOCK_BYTES + byte;
+                *output_byte = buffer_limbs[offset] ^ input_limbs[offset];
+            }
+            let access = replay.write_u16(
+                RV64_MEMORY_AS,
+                byte_ptr_to_u16_ptr_value(buffer) + (index * BLOCK_FE_WIDTH) as u32,
+                rv64_bytes_to_u16_block(output),
+            )?;
+            *prev_timestamp = access.previous_timestamp;
+        }
+        let next_pc = from_pc
+            .checked_add(DEFAULT_PC_STEP)
+            .ok_or_else(|| PostflightError::new("XORIN program counter overflow"))?;
+        replay.finish(next_pc)?;
+
         row_slice.fill(F::ZERO);
         let trace_row: &mut XorinVmCols<F> = row_slice.borrow_mut();
 
-        trace_row.instruction.pc = F::from_u32(input.from_pc);
+        trace_row.instruction.pc = F::from_u32(from_pc);
         trace_row.instruction.is_enabled = F::ONE;
-        trace_row.instruction.buffer_reg_ptr = F::from_u32(input.rd_ptr);
-        trace_row.instruction.input_reg_ptr = F::from_u32(input.rs1_ptr);
-        trace_row.instruction.len_reg_ptr = F::from_u32(input.rs2_ptr);
-        trace_row.instruction.buffer_ptr_limbs = ptr_to_field_u16_limbs(input.buffer);
-        trace_row.instruction.input_ptr_limbs = ptr_to_field_u16_limbs(input.input);
-        trace_row.instruction.start_timestamp = F::from_u32(input.timestamp);
+        trace_row.instruction.buffer_reg_ptr = F::from_u32(rd_ptr);
+        trace_row.instruction.input_reg_ptr = F::from_u32(rs1_ptr);
+        trace_row.instruction.len_reg_ptr = F::from_u32(rs2_ptr);
+        trace_row.instruction.buffer_ptr_limbs = ptr_to_field_u16_limbs(buffer);
+        trace_row.instruction.input_ptr_limbs = ptr_to_field_u16_limbs(input);
+        trace_row.instruction.start_timestamp = F::from_u32(start_timestamp);
 
-        for i in 0..(input.len as usize / MEMORY_BLOCK_BYTES) {
-            trace_row.sponge.is_padding_bytes[i] = F::ZERO;
+        for flag in &mut trace_row.sponge.is_padding_bytes[..num_reads] {
+            *flag = F::ZERO;
         }
-        for i in (input.len as usize / MEMORY_BLOCK_BYTES)..(KECCAK_RATE_MEM_OPS) {
-            trace_row.sponge.is_padding_bytes[i] = F::ONE;
+        for flag in &mut trace_row.sponge.is_padding_bytes[num_reads..] {
+            *flag = F::ONE;
         }
 
-        let mut timestamp = input.timestamp;
-        let input_len = input.len as usize;
-        let num_reads = input_len / MEMORY_BLOCK_BYTES;
-
-        for t in 0..3 {
-            mem_helper.fill(
-                input.register_aux_cols[t].prev_timestamp,
-                timestamp,
-                trace_row.mem_oc.register_aux_cols[t].as_mut(),
-            );
-
+        let mut timestamp = start_timestamp;
+        for (access, aux) in register_reads
+            .iter()
+            .zip(&mut trace_row.mem_oc.register_aux_cols)
+        {
+            mem_helper.fill(access.previous_timestamp, timestamp, aux.as_mut());
+            timestamp += 1;
+        }
+        for (&previous_timestamp, aux) in buffer_read_prev_timestamps[..num_reads]
+            .iter()
+            .zip(&mut trace_row.mem_oc.buffer_bytes_read_aux_cols)
+        {
+            mem_helper.fill(previous_timestamp, timestamp, aux.as_mut());
+            timestamp += 1;
+        }
+        for (&previous_timestamp, aux) in input_read_prev_timestamps[..num_reads]
+            .iter()
+            .zip(&mut trace_row.mem_oc.input_bytes_read_aux_cols)
+        {
+            mem_helper.fill(previous_timestamp, timestamp, aux.as_mut());
             timestamp += 1;
         }
 
-        for t in 0..num_reads {
-            mem_helper.fill(
-                input.buffer_read_aux_cols[t].prev_timestamp,
-                timestamp,
-                trace_row.mem_oc.buffer_bytes_read_aux_cols[t].as_mut(),
-            );
-            timestamp += 1;
-        }
-
-        for t in 0..num_reads {
-            mem_helper.fill(
-                input.input_read_aux_cols[t].prev_timestamp,
-                timestamp,
-                trace_row.mem_oc.input_bytes_read_aux_cols[t].as_mut(),
-            );
-            timestamp += 1;
-        }
-
-        for i in 0..input_len {
-            trace_row.sponge.preimage_buffer_bytes[i] = F::from_u8(input.buffer_limbs[i]);
-            trace_row.sponge.input_bytes[i] = F::from_u8(input.input_limbs[i]);
+        for i in 0..len_usize {
+            trace_row.sponge.preimage_buffer_bytes[i] = F::from_u8(buffer_limbs[i]);
+            trace_row.sponge.input_bytes[i] = F::from_u8(input_limbs[i]);
             trace_row.sponge.postimage_buffer_bytes[i] =
-                F::from_u8(input.buffer_limbs[i] ^ input.input_limbs[i]);
-            let b_val = input.buffer_limbs[i] as u32;
-            let c_val = input.input_limbs[i] as u32;
-            self.bitwise_lookup_chip.request_xor(b_val, c_val);
+                F::from_u8(buffer_limbs[i] ^ input_limbs[i]);
+            self.bitwise_lookup_chip
+                .request_xor(buffer_limbs[i] as u32, input_limbs[i] as u32);
         }
 
-        for t in 0..num_reads {
-            mem_helper.fill(
-                input.buffer_write_prev_timestamps[t],
-                timestamp,
-                &mut trace_row.mem_oc.buffer_bytes_write_base_aux[t],
-            );
+        for (&previous_timestamp, aux) in buffer_write_prev_timestamps[..num_reads]
+            .iter()
+            .zip(&mut trace_row.mem_oc.buffer_bytes_write_base_aux)
+        {
+            mem_helper.fill(previous_timestamp, timestamp, aux);
             timestamp += 1;
         }
 
-        for ptr in [input.buffer, input.input] {
+        for ptr in [buffer, input] {
             self.range_checker_chip
                 .add_count(ptr_bound_from_ptr(ptr, self.pointer_max_bits), U16_BITS);
         }
+        Ok(())
     }
 }
 
@@ -134,150 +211,11 @@ pub(crate) fn generate_trace_from_postflight<F: PrimeField32>(
     let steps = postflight.steps(XorinOpcode::XORIN.global_opcode());
     let width = XorinVmCols::<F>::width();
     let height = next_power_of_two_or_zero(steps.len());
-    let inputs = steps
-        .par_iter()
-        .map(|&step| replay_input(postflight, step, chip.inner.pointer_max_bits))
-        .collect::<Result<Vec<_>, _>>()?;
     let mut trace = RowMajorMatrix::new(F::zero_vec(height * width), width);
     let mem_helper = chip.mem_helper.as_borrowed();
-    trace
-        .values
-        .par_chunks_exact_mut(width)
-        .zip(inputs.par_iter())
-        .for_each(|(row, input)| chip.inner.fill_trace_input(&mem_helper, input, row));
+    fill_trace_rows(&mut trace, 0, steps, |row, step| {
+        chip.inner
+            .replay_and_fill_trace_row(postflight, step, &mem_helper, row)
+    })?;
     Ok(trace)
-}
-
-fn replay_input<F: PrimeField32>(
-    postflight: &Postflight<'_, F>,
-    step: PostflightStep,
-    pointer_max_bits: usize,
-) -> Result<XorinTraceInput, PostflightError> {
-    let instruction = postflight.instruction(step);
-    if instruction.d.as_canonical_u32() != RV64_REGISTER_AS
-        || instruction.e.as_canonical_u32() != RV64_MEMORY_AS
-    {
-        return Err(PostflightError::new(
-            "XORIN instruction has invalid address spaces",
-        ));
-    }
-
-    let from_pc = postflight.pc(step);
-    let timestamp = postflight.timestamp(step);
-    let rd_ptr = instruction.a.as_canonical_u32();
-    let rs1_ptr = instruction.b.as_canonical_u32();
-    let rs2_ptr = instruction.c.as_canonical_u32();
-    for pointer in [rd_ptr, rs1_ptr, rs2_ptr] {
-        if pointer & 1 != 0 {
-            return Err(PostflightError::new(
-                "XORIN register pointer must be two-byte aligned",
-            ));
-        }
-    }
-
-    let mut replay = postflight.replay(step);
-    let register_reads = [
-        replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(rd_ptr))?,
-        replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(rs1_ptr))?,
-        replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(rs2_ptr))?,
-    ];
-    let [Some(buffer), Some(input), Some(len)] = register_reads
-        .each_ref()
-        .map(|access| try_rv64_bytes_to_u32(rv64_u16_block_to_bytes(access.value)))
-    else {
-        return Err(PostflightError::new("XORIN register value exceeds 32 bits"));
-    };
-    let len_usize = len as usize;
-    if len_usize > KECCAK_RATE_BYTES || !len_usize.is_multiple_of(MEMORY_BLOCK_BYTES) {
-        return Err(PostflightError::new(
-            "XORIN length must be an aligned rate-sized byte count",
-        ));
-    }
-    let num_reads = len_usize / MEMORY_BLOCK_BYTES;
-    if num_reads != 0 && (buffer & 1 != 0 || input & 1 != 0) {
-        return Err(PostflightError::new(
-            "XORIN memory pointer must be two-byte aligned",
-        ));
-    }
-    let domain_end = if pointer_max_bits < 32 {
-        1u64 << pointer_max_bits
-    } else {
-        1u64 << 32
-    };
-    if u64::from(buffer) >= domain_end
-        || u64::from(input) >= domain_end
-        || u64::from(buffer) + u64::from(len) > domain_end
-        || u64::from(input) + u64::from(len) > domain_end
-    {
-        return Err(PostflightError::new(
-            "XORIN memory range exceeds the pointer domain",
-        ));
-    }
-
-    let mut buffer_limbs = [0u8; KECCAK_RATE_BYTES];
-    let mut input_limbs = [0u8; KECCAK_RATE_BYTES];
-    let mut buffer_read_aux_cols =
-        std::array::from_fn(|_| MemoryReadAuxRecord { prev_timestamp: 0 });
-    let mut input_read_aux_cols =
-        std::array::from_fn(|_| MemoryReadAuxRecord { prev_timestamp: 0 });
-    for index in 0..num_reads {
-        let access = replay.read_u16(
-            RV64_MEMORY_AS,
-            byte_ptr_to_u16_ptr_value(buffer) + (index * BLOCK_FE_WIDTH) as u32,
-        )?;
-        buffer_limbs[index * MEMORY_BLOCK_BYTES..(index + 1) * MEMORY_BLOCK_BYTES]
-            .copy_from_slice(&rv64_u16_block_to_bytes(access.value));
-        buffer_read_aux_cols[index].prev_timestamp = access.previous_timestamp;
-    }
-    for index in 0..num_reads {
-        let access = replay.read_u16(
-            RV64_MEMORY_AS,
-            byte_ptr_to_u16_ptr_value(input) + (index * BLOCK_FE_WIDTH) as u32,
-        )?;
-        input_limbs[index * MEMORY_BLOCK_BYTES..(index + 1) * MEMORY_BLOCK_BYTES]
-            .copy_from_slice(&rv64_u16_block_to_bytes(access.value));
-        input_read_aux_cols[index].prev_timestamp = access.previous_timestamp;
-    }
-
-    let mut buffer_write_prev_timestamps = [0; KECCAK_RATE_MEM_OPS];
-    for (index, prev_timestamp) in buffer_write_prev_timestamps
-        .iter_mut()
-        .enumerate()
-        .take(num_reads)
-    {
-        let mut output = [0u8; MEMORY_BLOCK_BYTES];
-        for (byte, output_byte) in output.iter_mut().enumerate() {
-            let offset = index * MEMORY_BLOCK_BYTES + byte;
-            *output_byte = buffer_limbs[offset] ^ input_limbs[offset];
-        }
-        let access = replay.write_u16(
-            RV64_MEMORY_AS,
-            byte_ptr_to_u16_ptr_value(buffer) + (index * BLOCK_FE_WIDTH) as u32,
-            rv64_bytes_to_u16_block(output),
-        )?;
-        *prev_timestamp = access.previous_timestamp;
-    }
-    let next_pc = from_pc
-        .checked_add(DEFAULT_PC_STEP)
-        .ok_or_else(|| PostflightError::new("XORIN program counter overflow"))?;
-    replay.finish(next_pc)?;
-
-    Ok(XorinTraceInput {
-        from_pc,
-        timestamp,
-        rd_ptr,
-        rs1_ptr,
-        rs2_ptr,
-        buffer,
-        input,
-        len,
-        buffer_limbs,
-        input_limbs,
-        register_aux_cols: register_reads.map(|access| MemoryReadAuxRecord {
-            prev_timestamp: access.previous_timestamp,
-        }),
-        input_read_aux_cols,
-        buffer_read_aux_cols,
-        buffer_write_prev_timestamps,
-    })
 }

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -2,9 +2,7 @@ use std::borrow::BorrowMut;
 
 use openvm_circuit::{
     arch::*,
-    system::memory::{
-        offline_checker::MemoryReadAuxRecord, MemoryAuxColsFactory,
-    },
+    system::memory::{offline_checker::MemoryReadAuxRecord, MemoryAuxColsFactory},
     utils::next_power_of_two_or_zero,
 };
 use openvm_circuit_primitives::U16_BITS;

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -3,8 +3,7 @@ use std::borrow::BorrowMut;
 use openvm_circuit::{
     arch::*,
     system::memory::{
-        offline_checker::{pack_u8_block_bytes, MemoryReadAuxRecord, MemoryWriteBytesAuxRecord},
-        MemoryAuxColsFactory,
+        offline_checker::MemoryReadAuxRecord, MemoryAuxColsFactory,
     },
     utils::next_power_of_two_or_zero,
 };
@@ -42,7 +41,7 @@ struct XorinTraceInput {
     register_aux_cols: [MemoryReadAuxRecord; 3],
     input_read_aux_cols: [MemoryReadAuxRecord; KECCAK_RATE_MEM_OPS],
     buffer_read_aux_cols: [MemoryReadAuxRecord; KECCAK_RATE_MEM_OPS],
-    buffer_write_aux_cols: [MemoryWriteBytesAuxRecord<MEMORY_BLOCK_BYTES>; KECCAK_RATE_MEM_OPS],
+    buffer_write_prev_timestamps: [u32; KECCAK_RATE_MEM_OPS],
 }
 
 impl XorinVmFiller {
@@ -126,13 +125,10 @@ impl XorinVmFiller {
 
         for t in 0..num_reads {
             mem_helper.fill(
-                input.buffer_write_aux_cols[t].prev_timestamp,
+                input.buffer_write_prev_timestamps[t],
                 timestamp,
-                trace_row.mem_oc.buffer_bytes_write_aux_cols[t].as_mut(),
+                &mut trace_row.mem_oc.buffer_bytes_write_base_aux[t],
             );
-            trace_row.mem_oc.buffer_bytes_write_aux_cols[t].set_prev_data(pack_u8_block_bytes(
-                &input.buffer_write_aux_cols[t].prev_data,
-            ));
             timestamp += 1;
         }
 
@@ -256,9 +252,12 @@ fn replay_input<F: PrimeField32>(
         input_read_aux_cols[index].prev_timestamp = access.previous_timestamp;
     }
 
-    let mut buffer_write_aux_cols =
-        [MemoryWriteBytesAuxRecord::<MEMORY_BLOCK_BYTES>::default(); KECCAK_RATE_MEM_OPS];
-    for (index, write_aux) in buffer_write_aux_cols.iter_mut().enumerate().take(num_reads) {
+    let mut buffer_write_prev_timestamps = [0; KECCAK_RATE_MEM_OPS];
+    for (index, prev_timestamp) in buffer_write_prev_timestamps
+        .iter_mut()
+        .enumerate()
+        .take(num_reads)
+    {
         let mut output = [0u8; MEMORY_BLOCK_BYTES];
         for (byte, output_byte) in output.iter_mut().enumerate() {
             let offset = index * MEMORY_BLOCK_BYTES + byte;
@@ -269,8 +268,7 @@ fn replay_input<F: PrimeField32>(
             byte_ptr_to_u16_ptr_value(buffer) + (index * BLOCK_FE_WIDTH) as u32,
             rv64_bytes_to_u16_block(output),
         )?;
-        write_aux.prev_timestamp = access.previous_timestamp;
-        write_aux.prev_data = rv64_u16_block_to_bytes(access.previous_value);
+        *prev_timestamp = access.previous_timestamp;
     }
     let next_pc = from_pc
         .checked_add(DEFAULT_PC_STEP)
@@ -293,6 +291,6 @@ fn replay_input<F: PrimeField32>(
         }),
         input_read_aux_cols,
         buffer_read_aux_cols,
-        buffer_write_aux_cols,
+        buffer_write_prev_timestamps,
     })
 }


### PR DESCRIPTION
This PR removes redundant columns from XorinVmAir. The PR:

1. Updates auxiliary columns for writing `buffer`. This is possible because XORIN is in-place operation, so `preimage_buffer_bytes` already contains the `prev_data`.  Since `MemoryWriteAuxCols` and `preimage_buffer_bytes` contain the same `prev_data`, we can switch `MemoryWriteAuxCols` to `MemoryBaseAuxCols`. Saves 68 columns.
2. Removes `buffer_ptr` and `input_ptr` columns. Their values are derivable from `buffer_ptr_limbs` and `input_ptr_limbs` respectively.
3. Removes `len` and `len_limb` columns. `len_limb` is redundant because `len` already fits into a single limb. Furthermore, `is_padding_bytes` tells us -> which input blocks are for padding -> which input blocks are non-padding -> the number of non-padding blocks -> `len`.

benchmark: https://github.com/axiom-crypto/openvm-eth/actions/runs/30663251548 (Proof time is little bit slower, not sure why, need to understand)
With paragraph 1 only: https://github.com/axiom-crypto/openvm-eth/actions/runs/30665208225 (Also seems little bit slower in proving, not sure if it is system noise)

benchmark after rebase: https://github.com/axiom-crypto/openvm-eth/actions/runs/30822416379 (improvements in proof time)

resolves INT-8976