### PR TITLE
perf(v2.1): cache field expression kernel config

### DIFF
--- a/crates/vm/src/arch/cuda/postflight.rs
+++ b/crates/vm/src/arch/cuda/postflight.rs
@@ -183,6 +183,16 @@ pub enum GpuPostflightError {
     OpcodeTooLarge(usize),
     #[error("invalid GPU postflight memory configuration: {0}")]
     InvalidMemoryConfig(String),
+    #[error("invalid GPU postflight configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error(
+        "GPU postflight resource limit exceeded for {resource}: requested {requested}, limit {limit}"
+    )]
+    ResourceLimitExceeded {
+        resource: &'static str,
+        requested: usize,
+        limit: usize,
+    },
     #[error("invalid GPU postflight access schedule: {0}")]
     InvalidAccessSchedule(String),
     #[error("{0}")]

--- a/crates/vm/src/arch/extensions.rs
+++ b/crates/vm/src/arch/extensions.rs
@@ -796,6 +796,40 @@ pub enum ChipInventoryError {
     MissingChip { actual: usize, expected: usize },
     #[error("Missing executor chip. Number of executors with associated chips is {actual}, expected number is {expected}")]
     MissingExecutor { actual: usize, expected: usize },
+    #[error("Failed to initialize prover chip `{name}`: {source}")]
+    ProverChipInitialization {
+        name: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+impl ChipInventoryError {
+    pub fn prover_chip_initialization(
+        name: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::ProverChipInitialization {
+            name: name.into(),
+            source: Box::new(source),
+        }
+    }
+}
+
+#[cfg(test)]
+mod chip_inventory_error_tests {
+    use super::ChipInventoryError;
+
+    #[test]
+    fn prover_chip_initialization_preserves_source() {
+        let error = ChipInventoryError::prover_chip_initialization(
+            "test chip",
+            std::io::Error::other("setup failed"),
+        );
+        let source = std::error::Error::source(&error).unwrap();
+        let source = source.downcast_ref::<std::io::Error>().unwrap();
+        assert_eq!(source.to_string(), "setup failed");
+    }
 }
 
 // ======================= VM Chip Complex Implementation =============================

--- a/extensions/algebra/circuit/cuda/src/field_expr_replay.cu
+++ b/extensions/algebra/circuit/cuda/src/field_expr_replay.cu
@@ -929,22 +929,18 @@ static __global__ void field_expr_replay_tracegen(
 }
 
 template <size_t NUM_READS, size_t BLOCKS>
-static int field_expr_launch_config(
-    size_t height,
-    size_t aux_words,
-    size_t max_scratch_words,
-    size_t *grid_blocks,
+static int field_expr_kernel_config(
+    size_t *max_grid_blocks,
     size_t *block_threads,
-    size_t *scratch_words,
-    size_t *active_threads,
     size_t *local_bytes_per_thread
 ) {
-    if (height == 0 || aux_words == 0 || grid_blocks == nullptr ||
-        block_threads == nullptr || scratch_words == nullptr ||
-        active_threads == nullptr || local_bytes_per_thread == nullptr) {
+    if (max_grid_blocks == nullptr || block_threads == nullptr ||
+        local_bytes_per_thread == nullptr) {
         return cudaErrorInvalidValue;
     }
     static constexpr int THREADS = 128;
+    // These properties depend only on the selected device and kernel variant. The host caches
+    // them with the chip and derives height/scratch-limited launch dimensions per trace.
     int blocks_per_multiprocessor;
     cudaError_t result = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
         &blocks_per_multiprocessor,
@@ -965,64 +961,45 @@ static int field_expr_launch_config(
         &attributes, field_expr_replay_tracegen<NUM_READS, BLOCKS>
     );
     if (result != cudaSuccess) return result;
-
-    size_t row_blocks = (height + THREADS - 1) / THREADS;
     size_t resident_blocks =
         static_cast<size_t>(blocks_per_multiprocessor) * multiprocessors;
-    size_t scratch_limited_blocks =
-        max_scratch_words / (static_cast<size_t>(THREADS) * aux_words);
-    size_t blocks = row_blocks < resident_blocks ? row_blocks : resident_blocks;
-    blocks = blocks < scratch_limited_blocks ? blocks : scratch_limited_blocks;
-    if (blocks == 0) return cudaErrorMemoryAllocation;
-    *grid_blocks = blocks;
+    if (resident_blocks == 0) return cudaErrorInvalidValue;
+    *max_grid_blocks = resident_blocks;
     *block_threads = THREADS;
-    *active_threads = blocks * THREADS;
-    *scratch_words = *active_threads * aux_words;
     *local_bytes_per_thread = attributes.localSizeBytes;
     return cudaSuccess;
 }
 
-extern "C" int _field_expr_replay_launch_config(
+extern "C" int _field_expr_replay_kernel_config(
     size_t num_reads,
     size_t blocks,
-    size_t height,
-    size_t aux_words,
-    size_t max_scratch_words,
-    size_t *grid_blocks,
+    size_t *max_grid_blocks,
     size_t *block_threads,
-    size_t *scratch_words,
-    size_t *active_threads,
     size_t *local_bytes_per_thread
 ) {
     if (num_reads == 2 && blocks == 4)
-        return field_expr_launch_config<2, 4>(
-            height, aux_words, max_scratch_words, grid_blocks, block_threads,
-            scratch_words, active_threads, local_bytes_per_thread
+        return field_expr_kernel_config<2, 4>(
+            max_grid_blocks, block_threads, local_bytes_per_thread
         );
     if (num_reads == 2 && blocks == 6)
-        return field_expr_launch_config<2, 6>(
-            height, aux_words, max_scratch_words, grid_blocks, block_threads,
-            scratch_words, active_threads, local_bytes_per_thread
+        return field_expr_kernel_config<2, 6>(
+            max_grid_blocks, block_threads, local_bytes_per_thread
         );
     if (num_reads == 2 && blocks == 8)
-        return field_expr_launch_config<2, 8>(
-            height, aux_words, max_scratch_words, grid_blocks, block_threads,
-            scratch_words, active_threads, local_bytes_per_thread
+        return field_expr_kernel_config<2, 8>(
+            max_grid_blocks, block_threads, local_bytes_per_thread
         );
     if (num_reads == 2 && blocks == 12)
-        return field_expr_launch_config<2, 12>(
-            height, aux_words, max_scratch_words, grid_blocks, block_threads,
-            scratch_words, active_threads, local_bytes_per_thread
+        return field_expr_kernel_config<2, 12>(
+            max_grid_blocks, block_threads, local_bytes_per_thread
         );
     if (num_reads == 1 && blocks == 8)
-        return field_expr_launch_config<1, 8>(
-            height, aux_words, max_scratch_words, grid_blocks, block_threads,
-            scratch_words, active_threads, local_bytes_per_thread
+        return field_expr_kernel_config<1, 8>(
+            max_grid_blocks, block_threads, local_bytes_per_thread
         );
     if (num_reads == 1 && blocks == 12)
-        return field_expr_launch_config<1, 12>(
-            height, aux_words, max_scratch_words, grid_blocks, block_threads,
-            scratch_words, active_threads, local_bytes_per_thread
+        return field_expr_kernel_config<1, 12>(
+            max_grid_blocks, block_threads, local_bytes_per_thread
         );
     return cudaErrorInvalidValue;
 }

--- a/extensions/algebra/circuit/src/cuda/cuda_abi.rs
+++ b/extensions/algebra/circuit/src/cuda/cuda_abi.rs
@@ -43,16 +43,11 @@ declare_replay_launcher!(_modular_is_eq_replay_tracegen_l4);
 declare_replay_launcher!(_modular_is_eq_replay_tracegen_l6);
 
 unsafe extern "C" {
-    fn _field_expr_replay_launch_config(
+    fn _field_expr_replay_kernel_config(
         num_reads: usize,
         blocks: usize,
-        height: usize,
-        aux_words_per_thread: usize,
-        max_scratch_words: usize,
-        grid_blocks: *mut usize,
+        max_grid_blocks: *mut usize,
         block_threads: *mut usize,
-        scratch_words: *mut usize,
-        active_threads: *mut usize,
         local_bytes_per_thread: *mut usize,
     ) -> i32;
 
@@ -131,6 +126,13 @@ unsafe extern "C" {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FieldExprReplayKernelConfig {
+    pub max_grid_blocks: usize,
+    pub block_threads: usize,
+    pub local_bytes_per_thread: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FieldExprReplayLaunchConfig {
     pub grid_blocks: usize,
     pub block_threads: usize,
@@ -139,30 +141,23 @@ pub struct FieldExprReplayLaunchConfig {
     pub local_bytes_per_thread: usize,
 }
 
-pub unsafe fn field_expr_replay_launch_config<const NUM_READS: usize, const BLOCKS: usize>(
-    height: usize,
-    aux_words_per_thread: usize,
-    max_scratch_words: usize,
-) -> Result<FieldExprReplayLaunchConfig, CudaError> {
-    let mut config = FieldExprReplayLaunchConfig {
-        grid_blocks: 0,
+/// Queries the device-dependent occupancy cap and kernel attributes once for this chip variant.
+pub fn field_expr_replay_kernel_config<const NUM_READS: usize, const BLOCKS: usize>(
+) -> Result<FieldExprReplayKernelConfig, CudaError> {
+    let mut config = FieldExprReplayKernelConfig {
+        max_grid_blocks: 0,
         block_threads: 0,
-        scratch_words: 0,
-        active_threads: 0,
         local_bytes_per_thread: 0,
     };
-    CudaError::from_result(_field_expr_replay_launch_config(
-        NUM_READS,
-        BLOCKS,
-        height,
-        aux_words_per_thread,
-        max_scratch_words,
-        &mut config.grid_blocks,
-        &mut config.block_threads,
-        &mut config.scratch_words,
-        &mut config.active_threads,
-        &mut config.local_bytes_per_thread,
-    ))?;
+    unsafe {
+        CudaError::from_result(_field_expr_replay_kernel_config(
+            NUM_READS,
+            BLOCKS,
+            &mut config.max_grid_blocks,
+            &mut config.block_threads,
+            &mut config.local_bytes_per_thread,
+        ))?;
+    }
     Ok(config)
 }
 

--- a/extensions/algebra/circuit/src/cuda/field_expr.rs
+++ b/extensions/algebra/circuit/src/cuda/field_expr.rs
@@ -34,6 +34,36 @@ fn supports_device_modulus(modulus: &BigUint) -> bool {
     get_field_type(modulus).is_some()
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ValidatedFieldExprKernelConfig(cuda_abi::FieldExprReplayKernelConfig);
+
+fn resource_limit(resource: &'static str, requested: usize, limit: usize) -> GpuPostflightError {
+    GpuPostflightError::ResourceLimitExceeded {
+        resource,
+        requested,
+        limit,
+    }
+}
+
+fn validate_kernel_config(
+    kernel: cuda_abi::FieldExprReplayKernelConfig,
+) -> Result<ValidatedFieldExprKernelConfig, GpuPostflightError> {
+    if kernel.max_grid_blocks == 0 || kernel.block_threads == 0 || kernel.block_threads > 1024 {
+        return Err(GpuPostflightError::InvalidConfiguration(format!(
+            "field-expression kernel returned max_grid={} and block={}",
+            kernel.max_grid_blocks, kernel.block_threads,
+        )));
+    }
+    if kernel.local_bytes_per_thread > MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD {
+        return Err(resource_limit(
+            "field-expression local bytes per thread",
+            kernel.local_bytes_per_thread,
+            MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD,
+        ));
+    }
+    Ok(ValidatedFieldExprKernelConfig(kernel))
+}
+
 fn validate_launch_config(
     launch: cuda_abi::FieldExprReplayLaunchConfig,
     aux_words_per_thread: usize,
@@ -43,14 +73,14 @@ fn validate_launch_config(
         .grid_blocks
         .checked_mul(launch.block_threads)
         .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression launch thread count overflow".to_string(),
             )
         })?;
     let expected_scratch_words = expected_active_threads
         .checked_mul(aux_words_per_thread)
         .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression launch scratch size overflow".to_string(),
             )
         })?;
@@ -58,7 +88,7 @@ fn validate_launch_config(
         .scratch_words
         .checked_mul(size_of::<u32>())
         .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression launch scratch byte size overflow".to_string(),
             )
         })?;
@@ -66,7 +96,7 @@ fn validate_launch_config(
         .active_threads
         .checked_mul(launch.local_bytes_per_thread)
         .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression launch local-memory size overflow".to_string(),
             )
         })?;
@@ -75,65 +105,92 @@ fn validate_launch_config(
         || launch.active_threads != expected_active_threads
         || launch.scratch_words == 0
         || launch.scratch_words != expected_scratch_words
-        || launch.scratch_words > max_scratch_words
-        || scratch_bytes > MAX_FIELD_EXPR_SCRATCH_BYTES
-        || launch.local_bytes_per_thread > MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD
-        || local_bytes > MAX_FIELD_EXPR_LOCAL_BYTES
     {
-        return Err(GpuPostflightError::InvalidTranscript(format!(
-            "invalid field-expression launch: grid={}, block={}, active={}, scratch={} words/{} bytes, local={} bytes/thread/{} bytes total",
-            launch.grid_blocks,
-            launch.block_threads,
-            launch.active_threads,
-            launch.scratch_words,
-            scratch_bytes,
-            launch.local_bytes_per_thread,
-            local_bytes,
+        return Err(GpuPostflightError::InvalidConfiguration(format!(
+            "inconsistent field-expression launch: grid={}, block={}, active={}, scratch={} words",
+            launch.grid_blocks, launch.block_threads, launch.active_threads, launch.scratch_words,
         )));
+    }
+    if launch.scratch_words > max_scratch_words {
+        return Err(resource_limit(
+            "field-expression scratch words",
+            launch.scratch_words,
+            max_scratch_words,
+        ));
+    }
+    if scratch_bytes > MAX_FIELD_EXPR_SCRATCH_BYTES {
+        return Err(resource_limit(
+            "field-expression scratch bytes",
+            scratch_bytes,
+            MAX_FIELD_EXPR_SCRATCH_BYTES,
+        ));
+    }
+    if launch.local_bytes_per_thread > MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD {
+        return Err(resource_limit(
+            "field-expression local bytes per thread",
+            launch.local_bytes_per_thread,
+            MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD,
+        ));
+    }
+    if local_bytes > MAX_FIELD_EXPR_LOCAL_BYTES {
+        return Err(resource_limit(
+            "field-expression total local bytes",
+            local_bytes,
+            MAX_FIELD_EXPR_LOCAL_BYTES,
+        ));
     }
     Ok(launch)
 }
 
 fn field_expr_launch_config(
-    kernel: cuda_abi::FieldExprReplayKernelConfig,
+    kernel: ValidatedFieldExprKernelConfig,
     height: usize,
     aux_words_per_thread: usize,
     max_scratch_words: usize,
 ) -> Result<cuda_abi::FieldExprReplayLaunchConfig, GpuPostflightError> {
-    if height == 0
-        || aux_words_per_thread == 0
-        || kernel.max_grid_blocks == 0
-        || kernel.block_threads == 0
-    {
+    if height == 0 {
         return Err(GpuPostflightError::InvalidTranscript(format!(
-            "invalid field-expression kernel config: height={height}, aux={aux_words_per_thread}, max_grid={}, block={}",
-            kernel.max_grid_blocks, kernel.block_threads,
+            "invalid field-expression trace height {height}",
         )));
     }
-    let scratch_words_per_block = kernel
-        .block_threads
-        .checked_mul(aux_words_per_thread)
-        .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
-                "field-expression launch scratch size overflow".to_string(),
-            )
-        })?;
+    if aux_words_per_thread == 0 {
+        return Err(GpuPostflightError::InvalidConfiguration(
+            "field-expression kernel requires nonzero scratch words per thread".to_string(),
+        ));
+    }
+    let kernel = kernel.0;
+    let max_aux_words_per_thread = max_scratch_words / kernel.block_threads;
+    if aux_words_per_thread > max_aux_words_per_thread {
+        return Err(resource_limit(
+            "field-expression scratch words per thread",
+            aux_words_per_thread,
+            max_aux_words_per_thread,
+        ));
+    }
+    let scratch_words_per_block = kernel.block_threads * aux_words_per_thread;
     let row_blocks = height.div_ceil(kernel.block_threads);
     let scratch_limited_blocks = max_scratch_words / scratch_words_per_block;
+    let local_limited_blocks = if kernel.local_bytes_per_thread == 0 {
+        usize::MAX
+    } else {
+        let local_bytes_per_block = kernel.block_threads * kernel.local_bytes_per_thread;
+        MAX_FIELD_EXPR_LOCAL_BYTES / local_bytes_per_block
+    };
     let grid_blocks = row_blocks
         .min(kernel.max_grid_blocks)
-        .min(scratch_limited_blocks);
+        .min(scratch_limited_blocks)
+        .min(local_limited_blocks);
     let active_threads = grid_blocks
         .checked_mul(kernel.block_threads)
         .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression launch thread count overflow".to_string(),
             )
         })?;
     let scratch_words = active_threads
         .checked_mul(aux_words_per_thread)
         .ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression launch scratch size overflow".to_string(),
             )
         })?;
@@ -175,12 +232,22 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChip<NUM_READS,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
     ) -> Result<Self, GpuPostflightError> {
         if range_checker.count.len() != chip.inner.range_checker.count.len() {
-            return Err(GpuPostflightError::InvalidTranscript(
+            return Err(GpuPostflightError::InvalidConfiguration(
                 "field-expression range-count shape mismatch".to_string(),
             ));
         }
         let pointer_max_bits = chip.inner.adapter().pointer_max_bits();
         let timestamp_max_bits = chip.mem_helper.timestamp_max_bits();
+        let pointer_max_bits_u32 = u32::try_from(pointer_max_bits).map_err(|_| {
+            GpuPostflightError::InvalidConfiguration(
+                "field-expression pointer width does not fit u32".to_string(),
+            )
+        })?;
+        let timestamp_max_bits_u32 = u32::try_from(timestamp_max_bits).map_err(|_| {
+            GpuPostflightError::InvalidConfiguration(
+                "field-expression timestamp width does not fit u32".to_string(),
+            )
+        })?;
         let modulus = chip.inner.expr.program().prime();
         // The device interpreter uses Fermat inversion. Only the field implementations in this
         // crate are trusted prime moduli; all other moduli preserve the CPU executor's extended-
@@ -191,7 +258,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChip<NUM_READS,
                 .as_ref()
                 .is_some_and(|cpu_chip| Arc::ptr_eq(cpu_chip, &chip.inner.range_checker))
             {
-                return Err(GpuPostflightError::InvalidTranscript(
+                return Err(GpuPostflightError::InvalidConfiguration(
                     "field-expression CPU fallback range checker is not hybrid-wired".to_string(),
                 ));
             }
@@ -206,7 +273,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChip<NUM_READS,
             });
         }
         let serialized = serialize_field_expr(&chip.inner).map_err(|error| {
-            GpuPostflightError::InvalidTranscript(format!(
+            GpuPostflightError::InvalidConfiguration(format!(
                 "unsupported device field expression: {error:?}"
             ))
         })?;
@@ -215,8 +282,8 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChip<NUM_READS,
                 chip,
                 serialized,
                 opcode_base,
-                pointer_max_bits,
-                timestamp_max_bits,
+                pointer_max_bits_u32,
+                timestamp_max_bits_u32,
                 range_checker,
             )?),
         })
@@ -282,12 +349,12 @@ struct FieldExprReplayChipGpu<const NUM_READS: usize, const BLOCKS: usize> {
     program: DeviceBuffer<u32>,
     local_opcodes: Vec<usize>,
     opcode_base: usize,
-    pointer_max_bits: usize,
-    timestamp_max_bits: usize,
+    pointer_max_bits: u32,
+    timestamp_max_bits: u32,
     width: usize,
     aux_words_per_thread: usize,
     /// Device-dependent occupancy and kernel attributes, queried once at construction.
-    kernel_config: cuda_abi::FieldExprReplayKernelConfig,
+    kernel_config: ValidatedFieldExprKernelConfig,
 }
 
 impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_READS, BLOCKS> {
@@ -298,8 +365,8 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
         >,
         serialized: openvm_mod_circuit_builder::device_program::SerializedFieldExpr,
         opcode_base: usize,
-        pointer_max_bits: usize,
-        timestamp_max_bits: usize,
+        pointer_max_bits: u32,
+        timestamp_max_bits: u32,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
     ) -> Result<Self, GpuPostflightError> {
         let num_input_bytes = chip
@@ -307,7 +374,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
             .num_inputs()
             .checked_mul(chip.inner.expr.program().canonical_num_limbs())
             .ok_or_else(|| {
-                GpuPostflightError::InvalidTranscript(
+                GpuPostflightError::InvalidConfiguration(
                     "field-expression input width overflow".to_string(),
                 )
             })?;
@@ -315,10 +382,10 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
             .checked_mul(BLOCKS)
             .and_then(|blocks| blocks.checked_mul(openvm_circuit::arch::MEMORY_BLOCK_BYTES))
             .ok_or_else(|| {
-                GpuPostflightError::InvalidTranscript("VecHeap input width overflow".to_string())
+                GpuPostflightError::InvalidConfiguration("VecHeap input width overflow".to_string())
             })?;
         if num_input_bytes != expected_input_bytes {
-            return Err(GpuPostflightError::InvalidTranscript(format!(
+            return Err(GpuPostflightError::InvalidConfiguration(format!(
                 "field-expression input width {num_input_bytes} does not match VecHeap width {expected_input_bytes}"
             )));
         }
@@ -330,30 +397,32 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
             .len()
             .checked_mul(chip.inner.expr.program().canonical_num_limbs())
             .ok_or_else(|| {
-                GpuPostflightError::InvalidTranscript(
+                GpuPostflightError::InvalidConfiguration(
                     "field-expression output width overflow".to_string(),
                 )
             })?;
         let expected_output_bytes = BLOCKS
             .checked_mul(openvm_circuit::arch::MEMORY_BLOCK_BYTES)
             .ok_or_else(|| {
-                GpuPostflightError::InvalidTranscript("VecHeap output width overflow".to_string())
+                GpuPostflightError::InvalidConfiguration(
+                    "VecHeap output width overflow".to_string(),
+                )
             })?;
         if num_output_bytes != expected_output_bytes {
-            return Err(GpuPostflightError::InvalidTranscript(format!(
+            return Err(GpuPostflightError::InvalidConfiguration(format!(
                 "field-expression output width {num_output_bytes} does not match VecHeap width {expected_output_bytes}"
             )));
         }
         let adapter_width = Rv64VecHeapAdapterCols::<F, NUM_READS, BLOCKS, BLOCKS>::width();
         let core_width = BaseAir::<F>::width(&chip.inner.expr);
         if serialized.core_width != core_width {
-            return Err(GpuPostflightError::InvalidTranscript(format!(
+            return Err(GpuPostflightError::InvalidConfiguration(format!(
                 "serialized field-expression width {} does not match AIR width {core_width}",
                 serialized.core_width
             )));
         }
         let width = adapter_width.checked_add(core_width).ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "field-expression trace width overflow".to_string(),
             )
         })?;
@@ -362,7 +431,10 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
             .blob
             .as_slice()
             .to_device_on(&range_checker.device_ctx)?;
-        let kernel_config = cuda_abi::field_expr_replay_kernel_config::<NUM_READS, BLOCKS>()?;
+        let kernel_config = validate_kernel_config(cuda_abi::field_expr_replay_kernel_config::<
+            NUM_READS,
+            BLOCKS,
+        >()?)?;
         Ok(Self {
             range_checker,
             program,
@@ -397,7 +469,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
             replay_plan,
             self.opcode_base,
             &self.local_opcodes,
-            self.pointer_max_bits,
+            self.pointer_max_bits as usize,
             device_ctx,
         )?;
         if projection.is_empty() {
@@ -412,18 +484,11 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
         projection: DeviceVecHeapProjection<NUM_READS, BLOCKS>,
     ) -> Result<AirProvingContext<GpuBackend>, GpuPostflightError> {
         let device_ctx = &self.range_checker.device_ctx;
-        let pointer_max_bits = u32::try_from(self.pointer_max_bits).map_err(|_| {
-            GpuPostflightError::InvalidTranscript(
-                "field-expression pointer width does not fit u32".to_string(),
-            )
-        })?;
-        let timestamp_max_bits = u32::try_from(self.timestamp_max_bits).map_err(|_| {
-            GpuPostflightError::InvalidTranscript(
-                "field-expression timestamp width does not fit u32".to_string(),
-            )
-        })?;
-        let (height, _) =
-            checked_trace_shape(projection.len(), self.width, self.timestamp_max_bits)?;
+        let (height, _) = checked_trace_shape(
+            projection.len(),
+            self.width,
+            self.timestamp_max_bits as usize,
+        )?;
         let trace = DeviceMatrix::<F>::with_capacity_on(height, self.width, device_ctx);
         let delta = DeviceBuffer::with_capacity_on(self.range_checker.count.len(), device_ctx);
         delta.fill_zero_on(device_ctx)?;
@@ -445,8 +510,8 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
                 &scratch,
                 self.aux_words_per_thread,
                 launch,
-                pointer_max_bits,
-                timestamp_max_bits,
+                self.pointer_max_bits,
+                self.timestamp_max_bits,
                 transcript.error_ptr(),
                 device_ctx.stream.as_raw(),
             )?;
@@ -479,9 +544,13 @@ mod tests {
         local_bytes_per_thread: 32,
     };
 
+    fn kernel() -> ValidatedFieldExprKernelConfig {
+        validate_kernel_config(KERNEL).unwrap()
+    }
+
     #[test]
     fn launch_config_caps_grid_by_rows() {
-        let launch = field_expr_launch_config(KERNEL, 129, 4, 4096).unwrap();
+        let launch = field_expr_launch_config(kernel(), 129, 4, 4096).unwrap();
         assert_eq!(launch.grid_blocks, 2);
         assert_eq!(launch.active_threads, 256);
         assert_eq!(launch.scratch_words, 1024);
@@ -489,7 +558,7 @@ mod tests {
 
     #[test]
     fn launch_config_caps_grid_by_scratch() {
-        let launch = field_expr_launch_config(KERNEL, 4096, 4, 1536).unwrap();
+        let launch = field_expr_launch_config(kernel(), 4096, 4, 1536).unwrap();
         assert_eq!(launch.grid_blocks, 3);
         assert_eq!(launch.active_threads, 384);
         assert_eq!(launch.scratch_words, 1536);
@@ -497,7 +566,7 @@ mod tests {
 
     #[test]
     fn launch_config_caps_grid_by_occupancy() {
-        let launch = field_expr_launch_config(KERNEL, 4096, 4, 4096).unwrap();
+        let launch = field_expr_launch_config(kernel(), 4096, 4, 4096).unwrap();
         assert_eq!(launch.grid_blocks, 8);
         assert_eq!(launch.active_threads, 1024);
         assert_eq!(launch.scratch_words, 4096);
@@ -505,6 +574,63 @@ mod tests {
 
     #[test]
     fn launch_config_rejects_insufficient_scratch() {
-        assert!(field_expr_launch_config(KERNEL, 1, 4, 0).is_err());
+        assert!(matches!(
+            field_expr_launch_config(kernel(), 1, 4, 0),
+            Err(GpuPostflightError::ResourceLimitExceeded {
+                resource: "field-expression scratch words per thread",
+                requested: 4,
+                limit: 0,
+            })
+        ));
+    }
+
+    #[test]
+    fn launch_config_caps_grid_by_total_local_memory() {
+        let kernel = validate_kernel_config(cuda_abi::FieldExprReplayKernelConfig {
+            max_grid_blocks: 1024,
+            block_threads: 128,
+            local_bytes_per_thread: MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD,
+        })
+        .unwrap();
+        let launch = field_expr_launch_config(
+            kernel,
+            1 << 20,
+            1,
+            MAX_FIELD_EXPR_SCRATCH_BYTES / size_of::<u32>(),
+        )
+        .unwrap();
+        assert_eq!(launch.grid_blocks, 512);
+        assert_eq!(
+            launch.active_threads * launch.local_bytes_per_thread,
+            MAX_FIELD_EXPR_LOCAL_BYTES
+        );
+    }
+
+    #[test]
+    fn kernel_config_rejects_invalid_block_size() {
+        assert!(matches!(
+            validate_kernel_config(cuda_abi::FieldExprReplayKernelConfig {
+                max_grid_blocks: 8,
+                block_threads: 0,
+                local_bytes_per_thread: 32,
+            }),
+            Err(GpuPostflightError::InvalidConfiguration(_))
+        ));
+    }
+
+    #[test]
+    fn kernel_config_rejects_excessive_local_memory() {
+        assert!(matches!(
+            validate_kernel_config(cuda_abi::FieldExprReplayKernelConfig {
+                max_grid_blocks: 8,
+                block_threads: 128,
+                local_bytes_per_thread: MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD + 1,
+            }),
+            Err(GpuPostflightError::ResourceLimitExceeded {
+                resource: "field-expression local bytes per thread",
+                requested,
+                limit: MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD,
+            }) if requested == MAX_FIELD_EXPR_LOCAL_BYTES_PER_THREAD + 1
+        ));
     }
 }

--- a/extensions/algebra/circuit/src/cuda/field_expr.rs
+++ b/extensions/algebra/circuit/src/cuda/field_expr.rs
@@ -9,7 +9,9 @@ use openvm_circuit::arch::{
 };
 use openvm_circuit_primitives::var_range::VariableRangeCheckerChipGPU;
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
-use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
+use openvm_cuda_common::{
+    common::set_device_by_id, copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx,
+};
 use openvm_mod_circuit_builder::{device_program::serialize_field_expr, FieldExpressionFiller};
 use openvm_riscv_adapters::{Rv64VecHeapAdapterCols, Rv64VecHeapAdapterFiller};
 use openvm_stark_backend::{p3_air::BaseAir, prover::AirProvingContext};
@@ -90,6 +92,62 @@ fn validate_launch_config(
         )));
     }
     Ok(launch)
+}
+
+fn field_expr_launch_config(
+    kernel: cuda_abi::FieldExprReplayKernelConfig,
+    height: usize,
+    aux_words_per_thread: usize,
+    max_scratch_words: usize,
+) -> Result<cuda_abi::FieldExprReplayLaunchConfig, GpuPostflightError> {
+    if height == 0
+        || aux_words_per_thread == 0
+        || kernel.max_grid_blocks == 0
+        || kernel.block_threads == 0
+    {
+        return Err(GpuPostflightError::InvalidTranscript(format!(
+            "invalid field-expression kernel config: height={height}, aux={aux_words_per_thread}, max_grid={}, block={}",
+            kernel.max_grid_blocks, kernel.block_threads,
+        )));
+    }
+    let scratch_words_per_block = kernel
+        .block_threads
+        .checked_mul(aux_words_per_thread)
+        .ok_or_else(|| {
+            GpuPostflightError::InvalidTranscript(
+                "field-expression launch scratch size overflow".to_string(),
+            )
+        })?;
+    let row_blocks = height.div_ceil(kernel.block_threads);
+    let scratch_limited_blocks = max_scratch_words / scratch_words_per_block;
+    let grid_blocks = row_blocks
+        .min(kernel.max_grid_blocks)
+        .min(scratch_limited_blocks);
+    let active_threads = grid_blocks
+        .checked_mul(kernel.block_threads)
+        .ok_or_else(|| {
+            GpuPostflightError::InvalidTranscript(
+                "field-expression launch thread count overflow".to_string(),
+            )
+        })?;
+    let scratch_words = active_threads
+        .checked_mul(aux_words_per_thread)
+        .ok_or_else(|| {
+            GpuPostflightError::InvalidTranscript(
+                "field-expression launch scratch size overflow".to_string(),
+            )
+        })?;
+    validate_launch_config(
+        cuda_abi::FieldExprReplayLaunchConfig {
+            grid_blocks,
+            block_threads: kernel.block_threads,
+            scratch_words,
+            active_threads,
+            local_bytes_per_thread: kernel.local_bytes_per_thread,
+        },
+        aux_words_per_thread,
+        max_scratch_words,
+    )
 }
 
 pub struct FieldExprReplayChip<const NUM_READS: usize, const BLOCKS: usize> {
@@ -228,6 +286,8 @@ struct FieldExprReplayChipGpu<const NUM_READS: usize, const BLOCKS: usize> {
     timestamp_max_bits: usize,
     width: usize,
     aux_words_per_thread: usize,
+    /// Device-dependent occupancy and kernel attributes, queried once at construction.
+    kernel_config: cuda_abi::FieldExprReplayKernelConfig,
 }
 
 impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_READS, BLOCKS> {
@@ -297,10 +357,12 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
                 "field-expression trace width overflow".to_string(),
             )
         })?;
+        set_device_by_id(range_checker.device_ctx.device_id as i32)?;
         let program = serialized
             .blob
             .as_slice()
             .to_device_on(&range_checker.device_ctx)?;
+        let kernel_config = cuda_abi::field_expr_replay_kernel_config::<NUM_READS, BLOCKS>()?;
         Ok(Self {
             range_checker,
             program,
@@ -310,6 +372,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
             timestamp_max_bits,
             width,
             aux_words_per_thread: serialized.aux_words_per_thread,
+            kernel_config,
         })
     }
 
@@ -365,14 +428,9 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
         let delta = DeviceBuffer::with_capacity_on(self.range_checker.count.len(), device_ctx);
         delta.fill_zero_on(device_ctx)?;
         let max_scratch_words = MAX_FIELD_EXPR_SCRATCH_BYTES / size_of::<u32>();
-        let launch = validate_launch_config(
-            unsafe {
-                cuda_abi::field_expr_replay_launch_config::<NUM_READS, BLOCKS>(
-                    height,
-                    self.aux_words_per_thread,
-                    max_scratch_words,
-                )?
-            },
+        let launch = field_expr_launch_config(
+            self.kernel_config,
+            height,
             self.aux_words_per_thread,
             max_scratch_words,
         )?;
@@ -408,5 +466,45 @@ impl<const NUM_READS: usize, const BLOCKS: usize> FieldExprReplayChipGpu<NUM_REA
         }
         .commit()?;
         Ok(AirProvingContext::simple_no_pis(trace))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KERNEL: cuda_abi::FieldExprReplayKernelConfig = cuda_abi::FieldExprReplayKernelConfig {
+        max_grid_blocks: 8,
+        block_threads: 128,
+        local_bytes_per_thread: 32,
+    };
+
+    #[test]
+    fn launch_config_caps_grid_by_rows() {
+        let launch = field_expr_launch_config(KERNEL, 129, 4, 4096).unwrap();
+        assert_eq!(launch.grid_blocks, 2);
+        assert_eq!(launch.active_threads, 256);
+        assert_eq!(launch.scratch_words, 1024);
+    }
+
+    #[test]
+    fn launch_config_caps_grid_by_scratch() {
+        let launch = field_expr_launch_config(KERNEL, 4096, 4, 1536).unwrap();
+        assert_eq!(launch.grid_blocks, 3);
+        assert_eq!(launch.active_threads, 384);
+        assert_eq!(launch.scratch_words, 1536);
+    }
+
+    #[test]
+    fn launch_config_caps_grid_by_occupancy() {
+        let launch = field_expr_launch_config(KERNEL, 4096, 4, 4096).unwrap();
+        assert_eq!(launch.grid_blocks, 8);
+        assert_eq!(launch.active_threads, 1024);
+        assert_eq!(launch.scratch_words, 4096);
+    }
+
+    #[test]
+    fn launch_config_rejects_insufficient_scratch() {
+        assert!(field_expr_launch_config(KERNEL, 1, 4, 0).is_err());
     }
 }

--- a/extensions/algebra/circuit/src/cuda/mod.rs
+++ b/extensions/algebra/circuit/src/cuda/mod.rs
@@ -83,8 +83,8 @@ pub struct ModularIsEqualReplayChipGpu<const NUM_LANES: usize, const TOTAL_LIMBS
     range_checker: Arc<VariableRangeCheckerChipGPU>,
     d_modulus: DeviceBuffer<u16>,
     opcode_base: usize,
-    pointer_max_bits: usize,
-    timestamp_max_bits: usize,
+    pointer_max_bits: u32,
+    timestamp_max_bits: u32,
 }
 
 impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
@@ -96,18 +96,27 @@ impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
         pointer_max_bits: usize,
         timestamp_max_bits: usize,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
-    ) -> Self {
+    ) -> Result<Self, GpuPostflightError> {
+        let pointer_max_bits = u32::try_from(pointer_max_bits).map_err(|_| {
+            GpuPostflightError::InvalidConfiguration(
+                "ModularIsEqual pointer width does not fit u32".to_string(),
+            )
+        })?;
+        let timestamp_max_bits = u32::try_from(timestamp_max_bits).map_err(|_| {
+            GpuPostflightError::InvalidConfiguration(
+                "ModularIsEqual timestamp width does not fit u32".to_string(),
+            )
+        })?;
         let d_modulus = modulus_limbs
             .as_slice()
-            .to_device_on(&range_checker.device_ctx)
-            .unwrap();
-        Self {
+            .to_device_on(&range_checker.device_ctx)?;
+        Ok(Self {
             range_checker,
             d_modulus,
             opcode_base,
             pointer_max_bits,
             timestamp_max_bits,
-        }
+        })
     }
 
     pub fn generate_proving_ctx_from_postflight(
@@ -143,17 +152,11 @@ impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
                 "ModularIsEqual trace height overflow".to_string(),
             )
         })?;
-        let timestamp_limit = 1usize
-            .checked_shl(u32::try_from(self.timestamp_max_bits).map_err(|_| {
-                GpuPostflightError::InvalidTranscript(
-                    "timestamp width cannot be represented as a trace height".to_string(),
-                )
-            })?)
-            .ok_or_else(|| {
-                GpuPostflightError::InvalidTranscript(
-                    "timestamp width cannot be represented as a trace height".to_string(),
-                )
-            })?;
+        let timestamp_limit = 1usize.checked_shl(self.timestamp_max_bits).ok_or_else(|| {
+            GpuPostflightError::InvalidTranscript(
+                "timestamp width cannot be represented as a trace height".to_string(),
+            )
+        })?;
         let max_height = timestamp_limit.min(MAX_ALGEBRA_TRACE_HEIGHT);
         if height > max_height || height.checked_mul(width).is_none() {
             return Err(GpuPostflightError::InvalidTranscript(format!(
@@ -165,16 +168,6 @@ impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
         delta.fill_zero_on(device_ctx)?;
         let opcode_base = u32::try_from(self.opcode_base)
             .map_err(|_| GpuPostflightError::OpcodeTooLarge(self.opcode_base))?;
-        let pointer_max_bits = u32::try_from(self.pointer_max_bits).map_err(|_| {
-            GpuPostflightError::InvalidTranscript(
-                "ModularIsEqual pointer width does not fit u32".to_string(),
-            )
-        })?;
-        let timestamp_max_bits = u32::try_from(self.timestamp_max_bits).map_err(|_| {
-            GpuPostflightError::InvalidTranscript(
-                "ModularIsEqual timestamp width does not fit u32".to_string(),
-            )
-        })?;
         unsafe {
             cuda_abi::replay_tracegen(
                 trace.buffer(),
@@ -195,8 +188,8 @@ impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
                 &self.d_modulus,
                 &delta,
                 NUM_LANES,
-                pointer_max_bits,
-                timestamp_max_bits,
+                self.pointer_max_bits,
+                self.timestamp_max_bits,
                 device_ctx.stream.as_raw(),
             )?;
         }

--- a/extensions/algebra/circuit/src/cuda/modular_addsub.rs
+++ b/extensions/algebra/circuit/src/cuda/modular_addsub.rs
@@ -22,8 +22,8 @@ pub struct ModularAddSubReplayChipGpu<const BLOCKS: usize> {
     range_checker: Arc<VariableRangeCheckerChipGPU>,
     modulus: DeviceBuffer<u8>,
     opcode_base: usize,
-    pointer_max_bits: usize,
-    timestamp_max_bits: usize,
+    pointer_max_bits: u32,
+    timestamp_max_bits: u32,
     width: usize,
 }
 
@@ -37,14 +37,14 @@ impl<const BLOCKS: usize> ModularAddSubReplayChipGpu<BLOCKS> {
         range_checker: Arc<VariableRangeCheckerChipGPU>,
     ) -> Result<Option<Self>, GpuPostflightError> {
         if !matches!(BLOCKS, 4 | 6) {
-            return Err(GpuPostflightError::InvalidTranscript(format!(
+            return Err(GpuPostflightError::InvalidConfiguration(format!(
                 "unsupported modular add/sub block count {BLOCKS}"
             )));
         }
         let num_bytes = BLOCKS * openvm_circuit::arch::MEMORY_BLOCK_BYTES;
         let mut modulus_bytes = modulus.to_bytes_le();
         if modulus_bytes.is_empty() || modulus_bytes.len() > num_bytes {
-            return Err(GpuPostflightError::InvalidTranscript(
+            return Err(GpuPostflightError::InvalidConfiguration(
                 "modular add/sub replay requires a nonzero modulus fitting its heap layout"
                     .to_string(),
             ));
@@ -57,7 +57,7 @@ impl<const BLOCKS: usize> ModularAddSubReplayChipGpu<BLOCKS> {
             .checked_mul(num_bytes)
             .and_then(|width| width.checked_add(4))
             .ok_or_else(|| {
-                GpuPostflightError::InvalidTranscript(
+                GpuPostflightError::InvalidConfiguration(
                     "modular add/sub replay trace width overflow".to_string(),
                 )
             })?;
@@ -65,8 +65,18 @@ impl<const BLOCKS: usize> ModularAddSubReplayChipGpu<BLOCKS> {
             return Ok(None);
         }
         let width = adapter_width.checked_add(core_width).ok_or_else(|| {
-            GpuPostflightError::InvalidTranscript(
+            GpuPostflightError::InvalidConfiguration(
                 "modular add/sub replay trace width overflow".to_string(),
+            )
+        })?;
+        let pointer_max_bits = u32::try_from(pointer_max_bits).map_err(|_| {
+            GpuPostflightError::InvalidConfiguration(
+                "modular add/sub pointer width does not fit u32".to_string(),
+            )
+        })?;
+        let timestamp_max_bits = u32::try_from(timestamp_max_bits).map_err(|_| {
+            GpuPostflightError::InvalidConfiguration(
+                "modular add/sub timestamp width does not fit u32".to_string(),
             )
         })?;
         let modulus = modulus_bytes
@@ -99,14 +109,17 @@ impl<const BLOCKS: usize> ModularAddSubReplayChipGpu<BLOCKS> {
             replay_plan,
             self.opcode_base,
             &local_opcodes,
-            self.pointer_max_bits,
+            self.pointer_max_bits as usize,
             &self.range_checker.device_ctx,
         )?;
         if projection.is_empty() {
             return Ok(AirProvingContext::simple_no_pis(DeviceMatrix::dummy()));
         }
-        let (height, _) =
-            checked_trace_shape(projection.len(), self.width, self.timestamp_max_bits)?;
+        let (height, _) = checked_trace_shape(
+            projection.len(),
+            self.width,
+            self.timestamp_max_bits as usize,
+        )?;
         let device_ctx = &self.range_checker.device_ctx;
         let trace = DeviceMatrix::<F>::with_capacity_on(height, self.width, device_ctx);
         let delta = DeviceBuffer::with_capacity_on(self.range_checker.count.len(), device_ctx);
@@ -121,16 +134,8 @@ impl<const BLOCKS: usize> ModularAddSubReplayChipGpu<BLOCKS> {
                 Rv64ModularArithmeticOpcode::SUB as u32,
                 Rv64ModularArithmeticOpcode::SETUP_ADDSUB as u32,
                 &delta,
-                u32::try_from(self.pointer_max_bits).map_err(|_| {
-                    GpuPostflightError::InvalidTranscript(
-                        "modular add/sub pointer width does not fit u32".to_string(),
-                    )
-                })?,
-                u32::try_from(self.timestamp_max_bits).map_err(|_| {
-                    GpuPostflightError::InvalidTranscript(
-                        "modular add/sub timestamp width does not fit u32".to_string(),
-                    )
-                })?,
+                self.pointer_max_bits,
+                self.timestamp_max_bits,
                 transcript.error_ptr(),
                 device_ctx.stream.as_raw(),
             )?;

--- a/extensions/algebra/circuit/src/cuda/vec_heap.rs
+++ b/extensions/algebra/circuit/src/cuda/vec_heap.rs
@@ -47,12 +47,12 @@ pub(crate) fn checked_trace_shape(
     timestamp_max_bits: usize,
 ) -> Result<(usize, usize), GpuPostflightError> {
     let timestamp_bits = u32::try_from(timestamp_max_bits).map_err(|_| {
-        GpuPostflightError::InvalidTranscript(
+        GpuPostflightError::InvalidConfiguration(
             "timestamp width cannot be represented as a host trace height".to_string(),
         )
     })?;
     let timestamp_row_limit = 1usize.checked_shl(timestamp_bits).ok_or_else(|| {
-        GpuPostflightError::InvalidTranscript(
+        GpuPostflightError::InvalidConfiguration(
             "timestamp width cannot be represented as a host trace height".to_string(),
         )
     })?;

--- a/extensions/algebra/circuit/src/extension/hybrid.rs
+++ b/extensions/algebra/circuit/src/extension/hybrid.rs
@@ -106,14 +106,13 @@ impl<const BLOCKS: usize> HybridModularChip<F, BLOCKS> {
         device_ctx: GpuDeviceCtx,
         opcode_base: usize,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
-    ) -> Self {
-        let field_expr_replay = FieldExprReplayChip::new(&cpu, opcode_base, range_checker)
-            .expect("valid modular field-expression replay configuration");
-        Self {
+    ) -> Result<Self, GpuPostflightError> {
+        let field_expr_replay = FieldExprReplayChip::new(&cpu, opcode_base, range_checker)?;
+        Ok(Self {
             cpu,
             device_ctx,
             replay: Some(ModularReplay::FieldExpr(field_expr_replay)),
-        }
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -127,7 +126,7 @@ impl<const BLOCKS: usize> HybridModularChip<F, BLOCKS> {
         range_checker: std::sync::Arc<
             openvm_circuit_primitives::var_range::VariableRangeCheckerChipGPU,
         >,
-    ) -> Self {
+    ) -> Result<Self, GpuPostflightError> {
         let direct_addsub = crate::cuda::modular_addsub::ModularAddSubReplayChipGpu::new(
             &cpu,
             modulus,
@@ -135,20 +134,20 @@ impl<const BLOCKS: usize> HybridModularChip<F, BLOCKS> {
             pointer_max_bits,
             timestamp_max_bits,
             range_checker.clone(),
-        )
-        .expect("valid modular add/sub replay configuration");
+        )?;
         let replay = match direct_addsub {
             Some(replay) => ModularReplay::AddSub(replay),
-            None => ModularReplay::FieldExpr(
-                FieldExprReplayChip::new(&cpu, opcode_base, range_checker)
-                    .expect("valid modular field-expression replay configuration"),
-            ),
+            None => ModularReplay::FieldExpr(FieldExprReplayChip::new(
+                &cpu,
+                opcode_base,
+                range_checker,
+            )?),
         };
-        Self {
+        Ok(Self {
             cpu,
             device_ctx,
             replay: Some(replay),
-        }
+        })
     }
 
     pub fn generate_proving_ctx_from_postflight(
@@ -217,8 +216,8 @@ impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
         pointer_max_bits: usize,
         timestamp_max_bits: usize,
         range_checker_gpu: Arc<VariableRangeCheckerChipGPU>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, GpuPostflightError> {
+        Ok(Self {
             cpu,
             device_ctx,
             replay: Some(ModularIsEqualReplayChipGpu::new(
@@ -227,8 +226,8 @@ impl<const NUM_LANES: usize, const TOTAL_LIMBS: usize>
                 pointer_max_bits,
                 timestamp_max_bits,
                 range_checker_gpu,
-            )),
-        }
+            )?),
+        })
     }
 
     pub fn generate_proving_ctx_from_postflight(
@@ -305,7 +304,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, ModularExtension> for Algebra
                     byte_ptr_max_bits,
                     timestamp_max_bits,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("modular add/sub replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(addsub, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -331,7 +333,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, ModularExtension> for Algebra
                     device_ctx.clone(),
                     start_offset,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("modular mul/div replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(muldiv, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -370,7 +375,13 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, ModularExtension> for Algebra
                     byte_ptr_max_bits,
                     timestamp_max_bits,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization(
+                        "ModularIsEqual replay",
+                        source,
+                    )
+                })?;
                 inventory.add_executor_chip_with_tracegen(is_eq, move |chip, postflight| {
                     let trace = generate_modular_is_equal_trace_from_postflight::<
                         _,
@@ -406,7 +417,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, ModularExtension> for Algebra
                     byte_ptr_max_bits,
                     timestamp_max_bits,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("modular add/sub replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(addsub, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -432,7 +446,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, ModularExtension> for Algebra
                     device_ctx.clone(),
                     start_offset,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("modular mul/div replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(muldiv, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -471,7 +488,13 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, ModularExtension> for Algebra
                     byte_ptr_max_bits,
                     timestamp_max_bits,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization(
+                        "ModularIsEqual replay",
+                        source,
+                    )
+                })?;
                 inventory.add_executor_chip_with_tracegen(is_eq, move |chip, postflight| {
                     let trace = generate_modular_is_equal_trace_from_postflight::<
                         _,
@@ -514,14 +537,13 @@ impl<const BLOCKS: usize> HybridFp2Chip<F, BLOCKS> {
         device_ctx: GpuDeviceCtx,
         opcode_base: usize,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
-    ) -> Self {
-        let replay = FieldExprReplayChip::new(&cpu, opcode_base, range_checker)
-            .expect("valid Fp2 field-expression replay configuration");
-        Self {
+    ) -> Result<Self, GpuPostflightError> {
+        let replay = FieldExprReplayChip::new(&cpu, opcode_base, range_checker)?;
+        Ok(Self {
             cpu,
             device_ctx,
             replay: Some(replay),
-        }
+        })
     }
 
     pub fn generate_proving_ctx_from_postflight(
@@ -1037,7 +1059,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, Fp2Extension> for AlgebraHybr
                     device_ctx.clone(),
                     start_offset,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("Fp2 add/sub replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(addsub, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -1063,7 +1088,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, Fp2Extension> for AlgebraHybr
                     device_ctx.clone(),
                     start_offset,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("Fp2 mul/div replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(muldiv, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -1095,7 +1123,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, Fp2Extension> for AlgebraHybr
                     device_ctx.clone(),
                     start_offset,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("Fp2 add/sub replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(addsub, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,
@@ -1121,7 +1152,10 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, Fp2Extension> for AlgebraHybr
                     device_ctx.clone(),
                     start_offset,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization("Fp2 mul/div replay", source)
+                })?;
                 inventory.add_executor_chip_with_tracegen(muldiv, move |chip, postflight| {
                     let trace = generate_field_expression_trace_from_postflight(
                         &chip.cpu,

--- a/extensions/algebra/circuit/src/fp2_chip/tests.rs
+++ b/extensions/algebra/circuit/src/fp2_chip/tests.rs
@@ -393,7 +393,8 @@ mod cuda_tests {
             tester.range_checker().device_ctx.clone(),
             offset,
             tester.range_checker(),
-        );
+        )
+        .unwrap();
 
         let address_bits = tester.address_bits();
         GpuTestChipHarness::with_capacity(executor, air, hybrid_chip, cpu_chip, MAX_INS_CAPACITY)
@@ -448,7 +449,8 @@ mod cuda_tests {
             tester.range_checker().device_ctx.clone(),
             offset,
             tester.range_checker(),
-        );
+        )
+        .unwrap();
 
         let address_bits = tester.address_bits();
         GpuTestChipHarness::with_capacity(executor, air, hybrid_chip, cpu_chip, MAX_INS_CAPACITY)

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -164,7 +164,8 @@ mod addsub_tests {
             tester.address_bits(),
             tester.timestamp_max_bits(),
             tester.range_checker(),
-        );
+        )
+        .unwrap();
         let address_bits = tester.address_bits();
         GpuHarness::with_capacity(executor, air, hybrid_chip, cpu_chip, MAX_INS_CAPACITY)
             .with_trace_generators(
@@ -602,7 +603,8 @@ mod muldiv_tests {
             tester.range_checker().device_ctx.clone(),
             offset,
             tester.range_checker(),
-        );
+        )
+        .unwrap();
         let address_bits = tester.address_bits();
         GpuHarness::with_capacity(executor, air, hybrid_chip, cpu_chip, MAX_INS_CAPACITY)
             .with_trace_generators(
@@ -1151,7 +1153,8 @@ mod is_equal_tests {
             tester.address_bits(),
             tester.timestamp_max_bits(),
             tester.range_checker(),
-        );
+        )
+        .unwrap();
         let address_bits = tester.address_bits();
         GpuHarness::with_capacity(executor, air, hybrid_chip, cpu_chip, MAX_INS_CAPACITY)
             .with_trace_generators(

--- a/extensions/ecc/circuit/src/extension/hybrid.rs
+++ b/extensions/ecc/circuit/src/extension/hybrid.rs
@@ -129,14 +129,13 @@ impl<const NUM_READS: usize, const BLOCKS: usize> HybridWeierstrassChip<F, NUM_R
         device_ctx: GpuDeviceCtx,
         opcode_base: usize,
         range_checker: Arc<VariableRangeCheckerChipGPU>,
-    ) -> Self {
-        let replay = FieldExprReplayChip::new(&cpu, opcode_base, range_checker)
-            .expect("valid Weierstrass field-expression replay configuration");
-        Self {
+    ) -> Result<Self, GpuPostflightError> {
+        let replay = FieldExprReplayChip::new(&cpu, opcode_base, range_checker)?;
+        Ok(Self {
             cpu,
             device_ctx,
             replay: Some(replay),
-        }
+        })
     }
 
     fn local_opcodes() -> Result<[usize; 2], GpuPostflightError> {
@@ -531,7 +530,13 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, WeierstrassExtension> for Ecc
                     device_ctx.clone(),
                     opcode_base,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization(
+                        "Weierstrass add-ne replay",
+                        source,
+                    )
+                })?;
                 inventory.add_executor_chip_with_tracegen(addne, move |chip, postflight| {
                     let trace =
                         generate_add_ne_trace_from_postflight(&chip.cpu, postflight, opcode_base)?;
@@ -554,7 +559,13 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, WeierstrassExtension> for Ecc
                     device_ctx.clone(),
                     opcode_base,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization(
+                        "Weierstrass double replay",
+                        source,
+                    )
+                })?;
                 inventory.add_executor_chip_with_tracegen(double, move |chip, postflight| {
                     let trace =
                         generate_double_trace_from_postflight(&chip.cpu, postflight, opcode_base)?;
@@ -582,7 +593,13 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, WeierstrassExtension> for Ecc
                     device_ctx.clone(),
                     opcode_base,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization(
+                        "Weierstrass add-ne replay",
+                        source,
+                    )
+                })?;
                 inventory.add_executor_chip_with_tracegen(addne, move |chip, postflight| {
                     let trace =
                         generate_add_ne_trace_from_postflight(&chip.cpu, postflight, opcode_base)?;
@@ -605,7 +622,13 @@ impl VmProverExtension<GpuBabyBearPoseidon2Engine, WeierstrassExtension> for Ecc
                     device_ctx.clone(),
                     opcode_base,
                     range_checker_gpu.clone(),
-                );
+                )
+                .map_err(|source| {
+                    ChipInventoryError::prover_chip_initialization(
+                        "Weierstrass double replay",
+                        source,
+                    )
+                })?;
                 inventory.add_executor_chip_with_tracegen(double, move |chip, postflight| {
                     let trace =
                         generate_double_trace_from_postflight(&chip.cpu, postflight, opcode_base)?;

--- a/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/tests.rs
@@ -506,7 +506,8 @@ mod ec_addne_tests {
             tester.range_checker().device_ctx.clone(),
             offset,
             tester.range_checker(),
-        );
+        )
+        .unwrap();
         #[cfg(not(feature = "rvr"))]
         let hybrid_chip =
             HybridWeierstrassChip::new(gpu_cpu_chip, tester.range_checker().device_ctx.clone());
@@ -1459,7 +1460,8 @@ mod ec_double_tests {
             tester.range_checker().device_ctx.clone(),
             offset,
             tester.range_checker(),
-        );
+        )
+        .unwrap();
         #[cfg(not(feature = "rvr"))]
         let hybrid_chip =
             HybridWeierstrassChip::new(gpu_cpu_chip, tester.range_checker().device_ctx.clone());


### PR DESCRIPTION
Query the device-dependent occupancy cap and kernel attributes once when constructing the GPU replay chip. Derive row- and scratch-limited launch dimensions in Rust for each trace while retaining the RVR path’s existing validation.

Supersedes #2984 