### PR TITLE
refactor(v2.1): remove remaining tracegen records

### DIFF
--- a/extensions/deferral/circuit/cuda/rvr/output.cu
+++ b/extensions/deferral/circuit/cuda/rvr/output.cu
@@ -385,10 +385,11 @@ __global__ void deferral_output_replay_tracegen(
         return;
     }
 
-    ReplayPreviousValue key_previous[OUTPUT_TOTAL_MEMORY_OPS];
+    uint32_t key_previous_timestamps[OUTPUT_TOTAL_MEMORY_OPS];
     uint8_t output_key[OUTPUT_TOTAL_BYTES];
 #pragma unroll
     for (size_t i = 0; i < OUTPUT_TOTAL_MEMORY_OPS; i++) {
+        ReplayPreviousValue previous;
         if (!deferral_output_replay_event(
                 event_start + 2 + i,
                 from.timestamp + 2 + i,
@@ -398,9 +399,10 @@ __global__ void deferral_output_replay_tracegen(
                 memory,
                 seeds,
                 predecessors,
-                key_previous[i],
+                previous,
                 error
             )) return;
+        key_previous_timestamps[i] = previous.timestamp;
         deferral_output_replay_bytes(
             memory[event_start + 2 + i].value, output_key + i * MEMORY_BLOCK_BYTES
         );
@@ -469,7 +471,7 @@ __global__ void deferral_output_replay_tracegen(
         for (size_t i = 0; i < OUTPUT_TOTAL_MEMORY_OPS; i++)
             mem_helper.fill(row.slice_from(COL_INDEX(DeferralOutputCols,
                                                      output_commit_and_len_aux) + i * read_stride),
-                            key_previous[i].timestamp, from.timestamp + 2 + i);
+                            key_previous_timestamps[i], from.timestamp + 2 + i);
         uint32_t output_commit_rcs[DIGEST_SIZE];
 #pragma unroll
         for (size_t i = 0; i < DIGEST_SIZE; i++) {

--- a/extensions/ecc/circuit/src/weierstrass_chip/trace.rs
+++ b/extensions/ecc/circuit/src/weierstrass_chip/trace.rs
@@ -194,8 +194,8 @@ fn generate_trace_from_postflights<
     local_opcodes: &[Rv64WeierstrassOpcode],
 ) -> Result<RowMajorMatrix<F>, PostflightError> {
     let pointer_max_bits = chip.inner.adapter().pointer_max_bits();
-    let mut projection = Vec::new();
-    for postflight in postflights {
+    let mut selected_steps = Vec::new();
+    for (postflight_index, postflight) in postflights.iter().enumerate() {
         let mut selected = Vec::new();
         for &local_opcode in local_opcodes {
             let local_opcode = local_opcode as usize;
@@ -207,33 +207,21 @@ fn generate_trace_from_postflights<
                     .steps(VmOpcode::from_usize(global_opcode))
                     .iter()
                     .copied()
-                    .map(|step| (step, local_opcode)),
+                    .map(|step| (postflight_index, step, local_opcode)),
             );
         }
-        selected.sort_unstable_by_key(|&(step, _)| postflight.timestamp(step));
-        projection.extend(
-            selected
-                .par_iter()
-                .map(|&(step, local_opcode)| {
-                    project_step::<F, NUM_READS, BLOCKS>(
-                        postflight,
-                        step,
-                        local_opcode,
-                        pointer_max_bits,
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        );
+        selected.sort_unstable_by_key(|&(_, step, _)| postflight.timestamp(step));
+        selected_steps.extend(selected);
     }
 
     let adapter_width = Rv64VecHeapAdapterCols::<F, NUM_READS, BLOCKS, BLOCKS>::width();
     let width = adapter_width
         .checked_add(BaseAir::<F>::width(&chip.inner.expr))
         .ok_or_else(|| PostflightError::new("Weierstrass trace width overflow"))?;
-    let height = if projection.is_empty() {
+    let height = if selected_steps.is_empty() {
         0
     } else {
-        projection
+        selected_steps
             .len()
             .checked_next_power_of_two()
             .ok_or_else(|| PostflightError::new("Weierstrass trace height overflow"))?
@@ -251,10 +239,16 @@ fn generate_trace_from_postflights<
         chip.mem_helper.timestamp_max_bits(),
     );
     let mem_helper = temporary_mem_helper.as_borrowed();
-    trace.values[..projection.len() * width]
+    trace.values[..selected_steps.len() * width]
         .par_chunks_exact_mut(width)
-        .zip(projection.par_iter())
-        .try_for_each(|(row, input)| {
+        .zip(selected_steps.par_iter().copied())
+        .try_for_each(|(row, (postflight_index, step, local_opcode))| {
+            let input = project_step::<F, NUM_READS, BLOCKS>(
+                &postflights[postflight_index],
+                step,
+                local_opcode,
+                pointer_max_bits,
+            )?;
             let (adapter_row, core_row) = row.split_at_mut(adapter_width);
             let read_bytes =
                 vec_heap_u16_blocks_to_bytes(input.heap_reads.iter().flatten().flatten());
@@ -262,7 +256,7 @@ fn generate_trace_from_postflights<
             chip.inner
                 .fill_trace_row_from_execution_data(
                     temporary_range_checker.as_ref(),
-                    input.local_opcode as usize,
+                    local_opcode,
                     &read_bytes,
                     Some(&write_bytes),
                     core_row,
@@ -276,15 +270,15 @@ fn generate_trace_from_postflights<
                 temporary_range_checker.as_ref(),
                 &mem_helper,
                 adapter_row,
-                input,
+                &input,
             );
             Ok::<_, PostflightError>(())
         })?;
-    if projection.len() < height {
+    if selected_steps.len() < height {
         let mut dummy_row = F::zero_vec(width);
         chip.inner
             .fill_dummy_core_row(&mut dummy_row[adapter_width..]);
-        trace.values[projection.len() * width..]
+        trace.values[selected_steps.len() * width..]
             .par_chunks_exact_mut(width)
             .for_each(|row| row.copy_from_slice(&dummy_row));
     }

--- a/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
+++ b/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
@@ -13,18 +13,6 @@ using namespace keccak256;
 
 inline constexpr size_t NUM_OP_ROWS_PER_INS = 1; // 1 row per instruction
 
-// Record structure matching Rust KeccakfRecord (from trace.rs)
-// Must match exact layout with #[repr(C)]
-struct KeccakfOpRecord {
-    uint32_t pc;
-    uint32_t timestamp;
-    uint32_t rd_ptr;
-    uint32_t buffer_ptr;
-    MemoryReadAuxRecord rd_aux;
-    MemoryReadAuxRecord buffer_word_aux[KECCAK_WIDTH_MEM_OPS];
-    uint8_t preimage_buffer_bytes[KECCAK_WIDTH_BYTES];
-};
-
 // Column structure matching Rust KeccakfOpCols (from columns.rs)
 template <typename T> struct KeccakfOpCols {
     T pc;

--- a/extensions/keccak256/circuit/cuda/rvr/keccakf_op.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/keccakf_op.cu
@@ -115,7 +115,7 @@ __global__ void keccakf_op_replay_tracegen(
         return;
     }
 
-    ReplayPreviousValue write_previous[KECCAK_WIDTH_MEM_OPS];
+    uint32_t write_previous_timestamps[KECCAK_WIDTH_MEM_OPS];
     uint64_t state[KECCAK_WIDTH_MEM_OPS];
     for (uint32_t i = 0; i < KECCAK_WIDTH_MEM_OPS; i++) {
         size_t write_idx = rd_idx + 1 + i;
@@ -124,6 +124,7 @@ __global__ void keccakf_op_replay_tracegen(
             return;
         }
         auto const &write = memory[write_idx];
+        ReplayPreviousValue previous;
         if (write.timestamp != from.timestamp + 1 + i || !preflight_is_write(write) ||
             preflight_address_space(write) != memory_as ||
             write.pointer != buffer_ptr / 2 + i * BLOCK_FE_WIDTH ||
@@ -133,12 +134,13 @@ __global__ void keccakf_op_replay_tracegen(
                 predecessors[write_idx],
                 memory,
                 seeds,
-                write_previous[i]
+                previous
             )) {
             preflight_set_error(error, KECCAKF_REPLAY_ERROR);
             return;
         }
-        state[i] = keccakf_replay_u64(write_previous[i].value);
+        write_previous_timestamps[i] = previous.timestamp;
+        state[i] = keccakf_replay_u64(previous.value);
         preimages[idx * KECCAK_WIDTH_MEM_OPS + i] = state[i];
     }
     size_t event_end = rd_idx + 1 + KECCAK_WIDTH_MEM_OPS;
@@ -173,7 +175,7 @@ __global__ void keccakf_op_replay_tracegen(
     for (uint32_t i = 0; i < KECCAK_WIDTH_MEM_OPS; i++) {
         mem_helper.fill(
             KECCAKF_OP_SLICE(buffer_word_aux[i]),
-            write_previous[i].timestamp,
+            write_previous_timestamps[i],
             from.timestamp + 1 + i
         );
     }

--- a/extensions/keccak256/circuit/src/keccakf_op/trace.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/trace.rs
@@ -1,7 +1,7 @@
 use core::convert::TryInto;
 use std::{
     borrow::BorrowMut,
-    sync::{Arc, Mutex},
+    sync::{atomic::Ordering, Arc, Mutex},
 };
 
 use openvm_circuit::{
@@ -9,7 +9,10 @@ use openvm_circuit::{
     system::memory::{MemoryAuxColsFactory, SharedMemoryHelper},
     utils::next_power_of_two_or_zero,
 };
-use openvm_circuit_primitives::{var_range::SharedVariableRangeCheckerChip, U16_BITS};
+use openvm_circuit_primitives::{
+    var_range::{SharedVariableRangeCheckerChip, VariableRangeCheckerChip},
+    U16_BITS,
+};
 use openvm_instructions::{
     program::DEFAULT_PC_STEP,
     riscv::{RV64_MEMORY_AS, RV64_REGISTER_AS},
@@ -38,7 +41,7 @@ pub struct KeccakfOpChip<F> {
     pub(crate) shared_preimages: Arc<Mutex<Vec<KeccakfPreimage>>>,
 }
 
-struct KeccakfTraceInput {
+struct KeccakfReplay {
     pc: u32,
     timestamp: u32,
     rd_ptr: u32,
@@ -56,64 +59,58 @@ pub(crate) struct KeccakfPreimage {
 }
 
 impl<F: PrimeField32> KeccakfOpChip<F> {
-    fn fill_trace_inputs(
+    fn fill_trace_row(
         &self,
+        range_checker: &VariableRangeCheckerChip,
         mem_helper: &MemoryAuxColsFactory<F>,
-        trace: &mut [F],
-        inputs: &[KeccakfTraceInput],
+        row: &mut [F],
+        replay: &KeccakfReplay,
     ) {
-        let width = KeccakfOpCols::<F>::width();
-        trace
-            .par_chunks_exact_mut(width * NUM_OP_ROWS_PER_INS)
-            .zip(inputs.par_iter())
-            .for_each(|(row, input)| {
-                row.fill(F::ZERO);
+        row.fill(F::ZERO);
+        let local: &mut KeccakfOpCols<F> = row.borrow_mut();
 
-                let local: &mut KeccakfOpCols<F> = row.borrow_mut();
+        local.pc = F::from_u32(replay.pc);
+        local.is_valid = F::ONE;
+        local.timestamp = F::from_u32(replay.timestamp);
+        local.rd_ptr = F::from_u32(replay.rd_ptr);
+        local.buffer_ptr_limbs = ptr_to_field_u16_limbs(replay.buffer_ptr);
 
-                local.pc = F::from_u32(input.pc);
-                local.is_valid = F::ONE;
-                local.timestamp = F::from_u32(input.timestamp);
-                local.rd_ptr = F::from_u32(input.rd_ptr);
-                local.buffer_ptr_limbs = ptr_to_field_u16_limbs(input.buffer_ptr);
+        // Pack consecutive pairs of state bytes into u16 cells.
+        for (dst, bytes) in local
+            .preimage
+            .iter_mut()
+            .zip(replay.preimage_buffer_bytes.chunks_exact(2))
+        {
+            *dst = F::from_u16(u16::from_le_bytes([bytes[0], bytes[1]]));
+        }
+        for (dst, bytes) in local
+            .postimage
+            .iter_mut()
+            .zip(replay.postimage_buffer_bytes.chunks_exact(2))
+        {
+            *dst = F::from_u16(u16::from_le_bytes([bytes[0], bytes[1]]));
+        }
 
-                // Pack consecutive pairs of state bytes into u16 cells.
-                for (dst, bytes) in local
-                    .preimage
-                    .iter_mut()
-                    .zip(input.preimage_buffer_bytes.chunks_exact(2))
-                {
-                    *dst = F::from_u16(u16::from_le_bytes([bytes[0], bytes[1]]));
-                }
-                for (dst, bytes) in local
-                    .postimage
-                    .iter_mut()
-                    .zip(input.postimage_buffer_bytes.chunks_exact(2))
-                {
-                    *dst = F::from_u16(u16::from_le_bytes([bytes[0], bytes[1]]));
-                }
+        let mut timestamp = replay.timestamp;
+        mem_helper.fill(
+            replay.rd_prev_timestamp,
+            replay.timestamp,
+            local.rd_aux.as_mut(),
+        );
+        timestamp += 1;
+        for (aux, &previous_timestamp) in local
+            .buffer_word_aux
+            .iter_mut()
+            .zip(&replay.buffer_prev_timestamps)
+        {
+            mem_helper.fill(previous_timestamp, timestamp, aux);
+            timestamp += 1;
+        }
 
-                let mut timestamp = input.timestamp;
-                mem_helper.fill(
-                    input.rd_prev_timestamp,
-                    input.timestamp,
-                    local.rd_aux.as_mut(),
-                );
-                timestamp += 1;
-                for (aux, &previous_timestamp) in local
-                    .buffer_word_aux
-                    .iter_mut()
-                    .zip(&input.buffer_prev_timestamps)
-                {
-                    mem_helper.fill(previous_timestamp, timestamp, aux);
-                    timestamp += 1;
-                }
-
-                self.range_checker_chip.add_count(
-                    ptr_bound_from_ptr(input.buffer_ptr, self.pointer_max_bits),
-                    U16_BITS,
-                );
-            });
+        range_checker.add_count(
+            ptr_bound_from_ptr(replay.buffer_ptr, self.pointer_max_bits),
+            U16_BITS,
+        );
     }
 }
 
@@ -123,29 +120,48 @@ pub(crate) fn generate_trace_from_postflight<F: PrimeField32>(
     postflight: &Postflight<'_, F>,
 ) -> Result<RowMajorMatrix<F>, PostflightError> {
     let steps = postflight.steps(KeccakfOpcode::KECCAKF.global_opcode());
-    let inputs = steps
-        .par_iter()
-        .map(|&step| replay_input(postflight, step, chip.pointer_max_bits))
-        .collect::<Result<Vec<_>, _>>()?;
     let width = KeccakfOpCols::<F>::width();
-    let height = next_power_of_two_or_zero(inputs.len() * NUM_OP_ROWS_PER_INS);
+    let height = next_power_of_two_or_zero(steps.len() * NUM_OP_ROWS_PER_INS);
     let mut trace = RowMajorMatrix::new(F::zero_vec(height * width), width);
-    chip.fill_trace_inputs(&chip.mem_helper.as_borrowed(), &mut trace.values, &inputs);
-    *chip.shared_preimages.lock().unwrap() = inputs
-        .iter()
-        .map(|input| KeccakfPreimage {
-            timestamp: input.timestamp,
-            bytes: input.preimage_buffer_bytes,
+    let temporary_range_checker =
+        Arc::new(VariableRangeCheckerChip::new(chip.range_checker_chip.bus()));
+    let temporary_mem_helper = SharedMemoryHelper::new(
+        temporary_range_checker.clone(),
+        chip.mem_helper.timestamp_max_bits(),
+    );
+    let mem_helper = temporary_mem_helper.as_borrowed();
+    let preimages = trace.values[..steps.len() * width * NUM_OP_ROWS_PER_INS]
+        .par_chunks_exact_mut(width * NUM_OP_ROWS_PER_INS)
+        .zip(steps.par_iter().copied())
+        .map(|(row, step)| {
+            let replay = replay_step(postflight, step, chip.pointer_max_bits)?;
+            chip.fill_trace_row(temporary_range_checker.as_ref(), &mem_helper, row, &replay);
+            Ok(KeccakfPreimage {
+                timestamp: replay.timestamp,
+                bytes: replay.preimage_buffer_bytes,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, PostflightError>>()?;
+    if chip.range_checker_chip.count.len() != temporary_range_checker.count.len() {
+        return Err(PostflightError::new("KECCAKF range-checker shape mismatch"));
+    }
+    for (destination, source) in chip
+        .range_checker_chip
+        .count
+        .iter()
+        .zip(&temporary_range_checker.count)
+    {
+        destination.fetch_add(source.load(Ordering::Relaxed), Ordering::Relaxed);
+    }
+    *chip.shared_preimages.lock().unwrap() = preimages;
     Ok(trace)
 }
 
-fn replay_input<F: PrimeField32>(
+fn replay_step<F: PrimeField32>(
     postflight: &Postflight<'_, F>,
     step: PostflightStep,
     pointer_max_bits: usize,
-) -> Result<KeccakfTraceInput, PostflightError> {
+) -> Result<KeccakfReplay, PostflightError> {
     let instruction = postflight.instruction(step);
     if instruction.b != F::ZERO
         || instruction.c != F::ZERO
@@ -218,7 +234,7 @@ fn replay_input<F: PrimeField32>(
         .ok_or_else(|| PostflightError::new("KECCAKF program counter overflow"))?;
     replay.finish(next_pc)?;
 
-    Ok(KeccakfTraceInput {
+    Ok(KeccakfReplay {
         pc,
         timestamp,
         rd_ptr,

--- a/extensions/riscv/circuit/src/hintstore/trace.rs
+++ b/extensions/riscv/circuit/src/hintstore/trace.rs
@@ -30,8 +30,8 @@ struct HintStoreReplayInput {
     mem_ptr_ptr: u32,
     num_words_ptr: Option<u32>,
     mem_ptr: u32,
-    mem_ptr_read: U16Access,
-    num_words_read: Option<U16Access>,
+    mem_ptr_prev_timestamp: u32,
+    num_words_prev_timestamp: Option<u32>,
 }
 
 /// Generates the RV64 hint-store trace directly from immutable preflight history.
@@ -152,13 +152,13 @@ fn replay_header<'postflight, 'history, F: PrimeField32>(
             )
         })?;
 
-    let (num_words, num_words_read) = if let Some(num_words_ptr) = num_words_ptr {
+    let (num_words, num_words_prev_timestamp) = if let Some(num_words_ptr) = num_words_ptr {
         let access = replay.read_u16(RV64_REGISTER_AS, byte_ptr_to_u16_ptr_value(num_words_ptr))?;
         let count = u16_block_to_u64(access.value);
         let count = validate_hint_buffer_num_words(from_pc, count)
             .map(u32::from)
             .map_err(|error| PostflightError::new(error.to_string()))?;
-        (count, Some(access))
+        (count, Some(access.previous_timestamp))
     } else {
         replay.advance_timestamp(1)?;
         (1, None)
@@ -185,8 +185,8 @@ fn replay_header<'postflight, 'history, F: PrimeField32>(
             mem_ptr_ptr,
             num_words_ptr,
             mem_ptr,
-            mem_ptr_read,
-            num_words_read,
+            mem_ptr_prev_timestamp: mem_ptr_read.previous_timestamp,
+            num_words_prev_timestamp,
         },
     ))
 }
@@ -203,18 +203,18 @@ fn fill_row<F: PrimeField32>(
     let timestamp = input.from_timestamp + 3 * local_index;
     if local_index == 0 {
         mem_helper.fill(
-            input.mem_ptr_read.previous_timestamp,
-            input.mem_ptr_read.timestamp,
+            input.mem_ptr_prev_timestamp,
+            input.from_timestamp,
             cols.mem_ptr_aux_cols.as_mut(),
         );
     } else {
         mem_helper.fill_zero(cols.mem_ptr_aux_cols.as_mut());
     }
     if local_index == 0 {
-        if let Some(num_words_read) = &input.num_words_read {
+        if let Some(previous_timestamp) = input.num_words_prev_timestamp {
             mem_helper.fill(
-                num_words_read.previous_timestamp,
-                num_words_read.timestamp,
+                previous_timestamp,
+                input.from_timestamp + 1,
                 cols.num_words_aux_cols.as_mut(),
             );
             cols.num_words_ptr = F::from_u32(input.num_words_ptr.unwrap());

--- a/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/trace.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/block_hasher_chip/trace.rs
@@ -13,9 +13,18 @@ use crate::{
     INNER_OFFSET,
 };
 
-struct Sha2BlockTraceInput<'a> {
-    message_bytes: &'a [u8],
-    prev_state: &'a [u8],
+struct Sha2BlockReplay {
+    message_bytes: Vec<u8>,
+    prev_state: Vec<u8>,
+}
+
+impl From<crate::Sha2ReplayRow> for Sha2BlockReplay {
+    fn from(replay: crate::Sha2ReplayRow) -> Self {
+        Self {
+            message_bytes: replay.message_bytes,
+            prev_state: replay.prev_state,
+        }
+    }
 }
 
 pub(crate) fn generate_trace_from_postflight<F, C>(
@@ -31,6 +40,7 @@ where
         .par_iter()
         .map(|&step| {
             crate::replay_sha2_from_postflight::<F, C>(postflight, step, chip.pointer_max_bits)
+                .map(Sha2BlockReplay::from)
         })
         .collect::<Result<Vec<_>, _>>()?;
     chip.generate_trace_from_replays(&replay_rows)
@@ -48,11 +58,14 @@ where
     let mut replay_rows = Vec::new();
     for postflight in postflights {
         for &step in postflight.steps(C::OPCODE.global_opcode()) {
-            replay_rows.push(crate::replay_sha2_from_postflight::<F, C>(
+            replay_rows.push(Sha2BlockReplay::from(crate::replay_sha2_from_postflight::<
+                F,
+                C,
+            >(
                 postflight,
                 step,
                 chip.pointer_max_bits,
-            )?);
+            )?));
         }
     }
     chip.generate_trace_from_replays(&replay_rows)
@@ -65,7 +78,7 @@ where
 {
     fn generate_trace_from_replays(
         &self,
-        replay_rows: &[crate::Sha2ReplayRow],
+        replay_rows: &[Sha2BlockReplay],
     ) -> Result<RowMajorMatrix<F>, PostflightError> {
         let rows_used = replay_rows
             .len()
@@ -76,65 +89,58 @@ where
             F::zero_vec(height * C::BLOCK_HASHER_WIDTH),
             C::BLOCK_HASHER_WIDTH,
         );
-        let inputs = replay_rows
-            .iter()
-            .map(|replay| Sha2BlockTraceInput {
-                message_bytes: &replay.message_bytes,
-                prev_state: &replay.prev_state,
-            })
-            .collect::<Vec<_>>();
-        self.fill_trace_from_inputs(&mut trace, &inputs);
+        self.fill_trace_from_replays(&mut trace, replay_rows);
         Ok(trace)
     }
 
-    fn fill_trace_from_inputs(
+    fn fill_trace_from_replays(
         &self,
         trace_matrix: &mut RowMajorMatrix<F>,
-        inputs: &[Sha2BlockTraceInput<'_>],
+        replay_rows: &[Sha2BlockReplay],
     ) {
-        if inputs.is_empty() {
+        if replay_rows.is_empty() {
             return;
         }
 
-        let rows_used = inputs.len() * C::ROWS_PER_BLOCK;
+        let rows_used = replay_rows.len() * C::ROWS_PER_BLOCK;
         let trace = &mut trace_matrix.values[..];
-        let prev_hashes = inputs
-            .par_iter()
-            .map(|input| {
-                (0..C::HASH_WORDS)
-                    .map(|i| {
-                        input.prev_state[i * C::WORD_U8S..(i + 1) * C::WORD_U8S]
-                            .iter()
-                            .rev()
-                            .fold(C::Word::from(0), |word, &byte| {
-                                (word << 8) | u32::from(byte).into()
-                            })
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
+        let mut prev_hashes = vec![C::Word::from(0); replay_rows.len() * C::HASH_WORDS];
+        prev_hashes
+            .par_chunks_exact_mut(C::HASH_WORDS)
+            .zip(replay_rows.par_iter())
+            .for_each(|(prev_hash, replay)| {
+                for (i, word) in prev_hash.iter_mut().enumerate() {
+                    *word = replay.prev_state[i * C::WORD_U8S..(i + 1) * C::WORD_U8S]
+                        .iter()
+                        .rev()
+                        .fold(C::Word::from(0), |word, &byte| {
+                            (word << 8) | u32::from(byte).into()
+                        });
+                }
+            });
 
         // zip the prev_hashes with the next block's prev_hash
-        let prev_hashes_and_next_block_prev_hashes = prev_hashes.par_iter().zip(
-            prev_hashes[1..]
-                .par_iter()
-                .chain(prev_hashes[..1].par_iter()),
-        );
+        let prev_hashes_and_next_block_prev_hashes =
+            prev_hashes.par_chunks_exact(C::HASH_WORDS).zip(
+                prev_hashes[C::HASH_WORDS..]
+                    .par_chunks_exact(C::HASH_WORDS)
+                    .chain(prev_hashes[..C::HASH_WORDS].par_chunks_exact(C::HASH_WORDS)),
+            );
 
         // fill in used rows
         trace[..rows_used * C::BLOCK_HASHER_WIDTH]
             .par_chunks_exact_mut(C::BLOCK_HASHER_WIDTH * C::ROWS_PER_BLOCK)
             .zip(
-                inputs
+                replay_rows
                     .par_iter()
                     .zip(prev_hashes_and_next_block_prev_hashes),
             )
             .enumerate()
             .for_each(
-                |(block_idx, (block_slice, (input, (prev_hash, next_block_prev_hash))))| {
+                |(block_idx, (block_slice, (replay, (prev_hash, next_block_prev_hash))))| {
                     self.fill_block_trace(
                         block_slice,
-                        input.message_bytes,
+                        &replay.message_bytes,
                         block_idx + 1, // 1-indexed
                         prev_hash,
                         next_block_prev_hash,
@@ -150,7 +156,7 @@ where
         let num_blocks = rows_used / C::ROWS_PER_BLOCK;
         let first_dummy_row_cols_const = self.fill_first_dummy_row(
             &mut trace[rows_used * C::BLOCK_HASHER_WIDTH..(rows_used + 1) * C::BLOCK_HASHER_WIDTH],
-            &prev_hashes[0],
+            &prev_hashes[..C::HASH_WORDS],
             num_blocks,
         );
 
@@ -164,7 +170,7 @@ where
                     &mut Sha2RoundColsRefMut::from::<C>(
                         &mut row[INNER_OFFSET..INNER_OFFSET + C::SUBAIR_ROUND_WIDTH],
                     ),
-                    &prev_hashes[0],
+                    &prev_hashes[..C::HASH_WORDS],
                     Some(
                         first_dummy_row_cols_const
                             .work_vars

--- a/extensions/sha2/circuit/src/sha2_chips/main_chip/trace.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/main_chip/trace.rs
@@ -1,9 +1,13 @@
+use std::sync::{atomic::Ordering, Arc};
+
 use openvm_circuit::{
     arch::{Postflight, PostflightError},
-    system::memory::{offline_checker::pack_u8_block_bytes, MemoryAuxColsFactory},
+    system::memory::{
+        offline_checker::pack_u8_block_bytes, MemoryAuxColsFactory, SharedMemoryHelper,
+    },
     utils::next_power_of_two_or_zero,
 };
-use openvm_circuit_primitives::U16_BITS;
+use openvm_circuit_primitives::{var_range::VariableRangeCheckerChip, U16_BITS};
 use openvm_instructions::LocalOpcode;
 use openvm_riscv_circuit::adapters::{ptr_bound_from_ptr, ptr_to_u16_limbs};
 use openvm_sha2_air::{set_arrayview_from_u16_le_bytes, set_arrayview_from_u16_slice};
@@ -22,13 +26,47 @@ where
     C: Sha2Config,
 {
     let steps = postflight.steps(C::OPCODE.global_opcode());
-    let replay_rows = steps
-        .par_iter()
-        .map(|&step| {
-            crate::replay_sha2_from_postflight::<F, C>(postflight, step, chip.pointer_max_bits)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(chip.generate_trace_from_replays(&replay_rows))
+    let height = next_power_of_two_or_zero(steps.len());
+    let mut trace =
+        RowMajorMatrix::new(F::zero_vec(height * C::MAIN_CHIP_WIDTH), C::MAIN_CHIP_WIDTH);
+    let temporary_range_checker =
+        Arc::new(VariableRangeCheckerChip::new(chip.range_checker_chip.bus()));
+    let temporary_mem_helper = SharedMemoryHelper::new(
+        temporary_range_checker.clone(),
+        chip.mem_helper.timestamp_max_bits(),
+    );
+    let mem_helper = temporary_mem_helper.as_borrowed();
+    trace.values[..steps.len() * C::MAIN_CHIP_WIDTH]
+        .par_chunks_exact_mut(C::MAIN_CHIP_WIDTH)
+        .zip(steps.par_iter().copied())
+        .enumerate()
+        .try_for_each(|(row_index, (row, step))| {
+            let replay = crate::replay_sha2_from_postflight::<F, C>(
+                postflight,
+                step,
+                chip.pointer_max_bits,
+            )?;
+            chip.fill_trace_row_from_replay(
+                temporary_range_checker.as_ref(),
+                &mem_helper,
+                row,
+                row_index,
+                &replay,
+            );
+            Ok::<(), PostflightError>(())
+        })?;
+    if chip.range_checker_chip.count.len() != temporary_range_checker.count.len() {
+        return Err(PostflightError::new("SHA-2 range-checker shape mismatch"));
+    }
+    for (destination, source) in chip
+        .range_checker_chip
+        .count
+        .iter()
+        .zip(&temporary_range_checker.count)
+    {
+        destination.fetch_add(source.load(Ordering::Relaxed), Ordering::Relaxed);
+    }
+    Ok(trace)
 }
 
 #[cfg(test)]
@@ -53,6 +91,7 @@ where
     Ok(chip.generate_trace_from_replays(&replay_rows))
 }
 
+#[cfg(test)]
 impl<F: PrimeField32, C: Sha2Config> Sha2MainChip<F, C> {
     fn generate_trace_from_replays(&self, replay_rows: &[Sha2ReplayRow]) -> RowMajorMatrix<F> {
         let height = next_power_of_two_or_zero(replay_rows.len());
@@ -64,7 +103,13 @@ impl<F: PrimeField32, C: Sha2Config> Sha2MainChip<F, C> {
             .zip(replay_rows.par_iter())
             .enumerate()
             .for_each(|(row_index, (row, replay))| {
-                self.fill_trace_row_from_replay(&mem_helper, row, row_index, replay);
+                self.fill_trace_row_from_replay(
+                    self.range_checker_chip.as_ref(),
+                    &mem_helper,
+                    row,
+                    row_index,
+                    replay,
+                );
             });
         trace
     }
@@ -73,6 +118,7 @@ impl<F: PrimeField32, C: Sha2Config> Sha2MainChip<F, C> {
 impl<F: PrimeField32, C: Sha2Config> Sha2MainChip<F, C> {
     fn fill_trace_row_from_replay(
         &self,
+        range_checker: &VariableRangeCheckerChip,
         mem_helper: &MemoryAuxColsFactory<F>,
         row_slice: &mut [F],
         row_idx: usize,
@@ -107,8 +153,7 @@ impl<F: PrimeField32, C: Sha2Config> Sha2MainChip<F, C> {
         );
 
         for ptr in [replay.dst_ptr, replay.state_ptr, replay.input_ptr] {
-            self.range_checker_chip
-                .add_count(ptr_bound_from_ptr(ptr, self.pointer_max_bits), U16_BITS);
+            range_checker.add_count(ptr_bound_from_ptr(ptr, self.pointer_max_bits), U16_BITS);
         }
 
         // fill in the register reads aux


### PR DESCRIPTION
## Summary

- fills fixed-height ECC, SHA-2 main, and KeccakF operation traces directly from postflight replay
- retains only the minimal ordered data required by multi-row SHA-2 block hashing and variable-height hint-store tracegen
- reduces CUDA KeccakF/deferral predecessor scratch to timestamps and removes a dead KeccakF record declaration

The SHA-2 block hasher deliberately keeps a compact `(message_bytes, prev_state)` projection because adjacent block rows are linked; the full replay row is dropped immediately.

## Testing

- targeted formatting, checks, clippy, and CPU postflight tests
- CUDA/RVR suites for Keccak, SHA-2, and deferral: 72 tests passed
