### PR TITLE
fix: add query_idx to merkle verify

### DIFF
--- a/crates/recursion/cuda/include/types.h
+++ b/crates/recursion/cuda/include/types.h
@@ -44,6 +44,7 @@ typedef struct {
     uint32_t start_row;
     uint32_t num_rows;
     uint16_t depth;
+    uint16_t query_idx;
     uint32_t merkle_idx;
     uint16_t commit_major;
     uint16_t commit_minor;

--- a/crates/recursion/cuda/src/transcript/merkle_verify.cu
+++ b/crates/recursion/cuda/src/transcript/merkle_verify.cu
@@ -11,6 +11,7 @@
 
 template <typename T> struct MerkleVerifyCols {
     T proof_idx;
+    T query_idx;
     T is_valid;
     T is_last_merkle;
 
@@ -118,6 +119,9 @@ __global__ void cukernel_merkle_verify_tracegen(
         RowSlice row(d_trace + global_row, trace_height);
         COL_WRITE_VALUE(
             row, MerkleVerifyCols, proof_idx, Fp(static_cast<uint32_t>(record.proof_idx))
+        );
+        COL_WRITE_VALUE(
+            row, MerkleVerifyCols, query_idx, Fp(static_cast<uint32_t>(record.query_idx))
         );
         COL_WRITE_VALUE(row, MerkleVerifyCols, is_valid, Fp::one());
         COL_WRITE_VALUE(

--- a/crates/recursion/src/bus.rs
+++ b/crates/recursion/src/bus.rs
@@ -415,6 +415,8 @@ pub struct MerkleVerifyBusMessage<T> {
     /// The idx of the merkle proof in the proof, might have additional bits (so not 0 at the root)
     /// It will be the same for all the rows in the hashing leaves part.
     pub merkle_idx_bit_src: T,
+    /// The query occurrence within the WHIR round.
+    pub query_idx: T,
     /// Merkle idx suffix after shifting right max(0, height - k) bits
     pub current_idx_bit_src: T,
     /// The total depth of the merkle proof including the leaves part, equal to merkle_proof.len()

--- a/crates/recursion/src/cuda/types.rs
+++ b/crates/recursion/src/cuda/types.rs
@@ -43,6 +43,7 @@ pub struct MerkleVerifyRecord {
     pub start_row: u32,
     pub num_rows: u32,
     pub depth: u16,
+    pub query_idx: u16,
     pub merkle_idx: u32,
     pub commit_major: u16,
     pub commit_minor: u16,

--- a/crates/recursion/src/transcript/merkle_verify/air.rs
+++ b/crates/recursion/src/transcript/merkle_verify/air.rs
@@ -43,6 +43,8 @@ use crate::{
 pub struct MerkleVerifyCols<T> {
     /// Index of the proof this row is for
     pub proof_idx: T,
+    /// Query occurrence within the WHIR round
+    pub query_idx: T,
     /// Indicator: whether this row is valid
     pub is_valid: T,
     /// Indicator: whether this is the last row of a merkle proof
@@ -189,6 +191,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             MerkleVerifyBusMessage {
                 value: local.left.map(Into::into),
                 merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                query_idx: local.query_idx.into(),
                 current_idx_bit_src: left_child_current_idx,
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
@@ -205,6 +208,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             MerkleVerifyBusMessage {
                 value: local.right.map(Into::into),
                 merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                query_idx: local.query_idx.into(),
                 current_idx_bit_src: right_child_current_idx,
                 total_depth: local.total_depth.into(),
                 height: local.height.into(),
@@ -222,6 +226,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for MerkleVerifyAir {
             MerkleVerifyBusMessage {
                 value: local.compression_output.map(Into::into),
                 merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                query_idx: local.query_idx.into(),
                 current_idx_bit_src: local.current_idx_bit_src.into(),
                 total_depth: local.total_depth.into(),
                 height: local.height + AB::Expr::ONE,

--- a/crates/recursion/src/transcript/merkle_verify/trace.rs
+++ b/crates/recursion/src/transcript/merkle_verify/trace.rs
@@ -133,6 +133,7 @@ pub fn generate_trace(
 
         cols.is_valid = F::ONE;
         cols.proof_idx = F::from_usize(proof_idx);
+        cols.query_idx = F::from_usize(query_idx);
         cols.commit_major = F::from_usize(commit_major);
         cols.commit_minor = F::from_usize(commit_minor);
         cols.total_depth = F::from_usize(depth + k + 1);
@@ -425,6 +426,7 @@ pub mod cuda {
                         start_row: total_rows as u32,
                         num_rows: num_rows as u32,
                         depth: log.depth as u16,
+                        query_idx: log.query_idx as u16,
                         merkle_idx: log.merkle_idx as u32,
                         commit_major: log.commit_major as u16,
                         commit_minor: log.commit_minor as u16,

--- a/crates/recursion/src/whir/initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/initial_opened_values/air.rs
@@ -311,6 +311,7 @@ where
             local.proof_idx,
             MerkleVerifyBusMessage {
                 merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                query_idx: local.query_idx.into(),
                 current_idx_bit_src: local.merkle_idx_bit_src.into(),
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1),
                 height: AB::Expr::ZERO,

--- a/crates/recursion/src/whir/non_initial_opened_values/air.rs
+++ b/crates/recursion/src/whir/non_initial_opened_values/air.rs
@@ -200,6 +200,7 @@ where
             MerkleVerifyBusMessage {
                 value: local.value_hash.map(Into::into),
                 merkle_idx_bit_src: local.merkle_idx_bit_src.into(),
+                query_idx: local.query_idx.into(),
                 current_idx_bit_src: local.merkle_idx_bit_src.into(),
                 // There are two parts: hashing leaves (depth k) and merkle proof
                 total_depth: AB::Expr::from_usize(self.initial_log_domain_size + 1)


### PR DESCRIPTION
This keeps different queries disjoint in the interaction multiset
namespace. Both implementations are sound up to Merkle collisions,
but this version ensures equivalence with our canonical verifier
implementation.