### PR TITLE
perf: remove redundant column from JAL/LUI

### DIFF
--- a/extensions/riscv/circuit/cuda/src/jal_lui.cu
+++ b/extensions/riscv/circuit/cuda/src/jal_lui.cu
@@ -13,7 +13,6 @@ constexpr uint32_t PC_HIGH_U16_SHIFT = 2 * U16_BITS - PC_BITS;
 template <typename T> struct Rv64JalLuiCoreCols {
     T imm;                             // core_row.imm
     T rd_data[RV64_PTR_U16_LIMBS];     // low-32 bits of rd_data as u16 cells
-    T imm_low_4;                       // low 4 bits of imm for LUI
     T is_jal;                          // core_row.is_jal
     T is_lui;                          // core_row.is_lui
     T is_sign_extend;                  // 1 if upper cells are 0xFFFF, 0 if 0x0000
@@ -31,6 +30,7 @@ struct Rv64JalLuiCore {
         uint32_t rd_hi = rd_data[1];
 
         bool is_sign_extend = (rd_hi >> (U16_BITS - 1)) & 1;
+        // Bump the range-checker multiplicity for the LUI 4-bit check.
         uint32_t imm_low_4 = is_jal ? 0u : (imm & 0xfu);
 
         range_checker.add_count(rd_lo, U16_BITS);
@@ -49,7 +49,6 @@ struct Rv64JalLuiCore {
         COL_WRITE_VALUE(row, Rv64JalLuiCoreCols, is_sign_extend, is_sign_extend);
         COL_WRITE_VALUE(row, Rv64JalLuiCoreCols, is_lui, !is_jal);
         COL_WRITE_VALUE(row, Rv64JalLuiCoreCols, is_jal, is_jal);
-        COL_WRITE_VALUE(row, Rv64JalLuiCoreCols, imm_low_4, imm_low_4);
         COL_WRITE_ARRAY(row, Rv64JalLuiCoreCols, rd_data, rd_u16);
         COL_WRITE_VALUE(row, Rv64JalLuiCoreCols, imm, imm);
     }

--- a/extensions/riscv/circuit/src/jal_lui/core.rs
+++ b/extensions/riscv/circuit/src/jal_lui/core.rs
@@ -32,7 +32,6 @@ pub struct Rv64JalLuiCoreCols<T> {
     pub imm: T,
     // Low 32 bits of rd as u16 cells. Upper register cells are sign extension.
     pub rd_data: [T; RV64_PTR_U16_LIMBS],
-    pub imm_low_4: T,
     pub is_jal: T,
     pub is_lui: T,
     pub is_sign_extend: T,
@@ -70,7 +69,6 @@ where
         let Rv64JalLuiCoreCols::<AB::Var> {
             imm,
             rd_data: rd,
-            imm_low_4,
             is_jal,
             is_lui,
             is_sign_extend,
@@ -83,14 +81,17 @@ where
         builder.assert_bool(is_sign_extend);
 
         // LUI: constrain rd = imm << RV_IS_TYPE_IMM_BITS.
-        builder
-            .when(is_lui)
-            .assert_eq(rd[0], imm_low_4 * AB::F::from_u32(1 << RV_IS_TYPE_IMM_BITS));
+        //
+        // Derive the low LUI_IMM_LOW_BITS bits of imm.
+        //   imm_low_4 * 2^12 = rd[0]                    // definition of the low cell
+        //   imm * 2^12       = rd[0] + rd[1] * 2^16     // rd[0..2] read as one 32-bit value
+        //   imm_low_4 * 2^12 = imm * 2^12 - rd[1] * 2^16
+        //   imm_low_4        = imm - rd[1] * 2^4
+        let imm_low_4 = imm - rd[1] * AB::F::from_u32(1 << LUI_IMM_LOW_BITS);
         builder.when(is_lui).assert_eq(
-            imm,
-            imm_low_4 + rd[1] * AB::F::from_u32(1 << LUI_IMM_LOW_BITS),
+            rd[0],
+            imm_low_4.clone() * AB::F::from_u32(1 << RV_IS_TYPE_IMM_BITS),
         );
-        builder.when(is_jal).assert_zero(imm_low_4);
 
         // Range-check the low LUI_IMM_LOW_BITS bits of imm.
         self.range_bus

--- a/extensions/riscv/circuit/src/jal_lui/tests.rs
+++ b/extensions/riscv/circuit/src/jal_lui/tests.rs
@@ -40,7 +40,7 @@ use super::trace::generate_trace_from_postflight;
 use crate::{
     adapters::{
         rv64_u16_block_to_bytes, Rv64CondRdWriteAdapterAir, Rv64CondRdWriteAdapterCols,
-        RV64_BYTE_BITS, RV64_PTR_U16_LIMBS, RV_J_TYPE_IMM_BITS,
+        RV64_BYTE_BITS, RV64_PTR_U16_LIMBS, RV_IS_TYPE_IMM_BITS, RV_J_TYPE_IMM_BITS, U16_BITS,
     },
     jal_lui::{get_signed_imm, run_jal_lui, Rv64JalLuiCoreCols},
     Rv64JalLuiAir, Rv64JalLuiChip, Rv64JalLuiCoreAir, Rv64JalLuiExecutor, Rv64JalLuiFiller,
@@ -205,7 +205,6 @@ fn rand_jal_lui_test(opcode: Rv64JalLuiOpcode, num_ops: usize) {
 struct JalLuiPrankValues {
     pub rd_data: Option<[u32; RV64_PTR_U16_LIMBS]>,
     pub imm: Option<i32>,
-    pub imm_low_4: Option<u32>,
     pub is_jal: Option<bool>,
     pub is_lui: Option<bool>,
     pub is_sign_extend: Option<bool>,
@@ -253,9 +252,6 @@ fn run_negative_jal_lui_test_with_rd_ptr(
             } else {
                 F::from_u32(imm.unsigned_abs())
             };
-        }
-        if let Some(imm_low_4) = prank_vals.imm_low_4 {
-            core_cols.imm_low_4 = F::from_u32(imm_low_4);
         }
         if let Some(is_jal) = prank_vals.is_jal {
             core_cols.is_jal = F::from_bool(is_jal);
@@ -517,6 +513,37 @@ fn overflow_negative_tests() {
             ..Default::default()
         },
         true,
+    );
+}
+
+#[test]
+fn lui_low_bits_negative_tests() {
+    // rd = imm << 12, split at the u16 cell boundary: rd[0] = (imm & 0xf) << 12, rd[1] = imm >> 4.
+    const IMM: i32 = 0x12345;
+    const RD_LOW: u32 = ((IMM as u32) & 0xf) << RV_IS_TYPE_IMM_BITS;
+    const RD_HIGH: u32 = (IMM as u32) >> (U16_BITS - RV_IS_TYPE_IMM_BITS);
+
+    // Raising the high cell drops the derived remainder to -16, which fails the 4-bit check.
+    run_negative_jal_lui_test(
+        LUI,
+        Some(IMM),
+        None,
+        JalLuiPrankValues {
+            rd_data: Some([RD_LOW, RD_HIGH + 1]),
+            ..Default::default()
+        },
+        false,
+    );
+    // Raising the low cell breaks `rd[0] == r * 2^12` directly.
+    run_negative_jal_lui_test(
+        LUI,
+        Some(IMM),
+        None,
+        JalLuiPrankValues {
+            rd_data: Some([RD_LOW + 1, RD_HIGH]),
+            ..Default::default()
+        },
+        false,
     );
 }
 

--- a/extensions/riscv/circuit/src/jal_lui/trace.rs
+++ b/extensions/riscv/circuit/src/jal_lui/trace.rs
@@ -53,6 +53,7 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             let rd_hi = rd_data[1];
             let is_sign_extend = (rd_hi >> (U16_BITS - 1)) & 1;
             let sign_check = 2u32 * (rd_hi as u32) - (is_sign_extend as u32) * (1 << U16_BITS);
+            // Bump the range-checker multiplicity for the LUI 4-bit check.
             let imm_low_4 = if is_jal {
                 0
             } else {
@@ -80,7 +81,6 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
 
             core_row.imm = instruction.c;
             core_row.rd_data = [F::from_u16(rd_lo), F::from_u16(rd_hi)];
-            core_row.imm_low_4 = F::from_u8(imm_low_4);
             core_row.is_jal = F::from_bool(is_jal);
             core_row.is_lui = F::from_bool(!is_jal);
             core_row.is_sign_extend = F::from_bool(is_sign_extend != 0);


### PR DESCRIPTION
This PR removes `imm_low_4` column from `Rv64JalLuiCoreAir`. This is possible because we can derive `imm_low_4` column using other columns: `imm` and `rd`.
```
//   imm_low_4 * 2^12 = rd[0]                    // definition of the low cell
//   imm * 2^12       = rd[0] + rd[1] * 2^16     // rd[0..2] read as one 32-bit value
//   imm_low_4 * 2^12 = imm * 2^12 - rd[1] * 2^16
//   imm_low_4        = imm - rd[1] * 2^4
```

Benchmark result: https://github.com/axiom-crypto/openvm-eth/actions/runs/30920144175 (baseline and target are with and without `imm_low_4` respectively).

resolves INT-8997