### PR TITLE
perf: encode SLT and SLTU flags into a single column for LessThan

### DIFF
--- a/extensions/bigint/circuit/src/trace.rs
+++ b/extensions/bigint/circuit/src/trace.rs
@@ -648,8 +648,8 @@ fn fill_less_than<F: PrimeField32>(
     }
     core.b_msb_f = b_msb_f;
     core.c_msb_f = c_msb_f;
-    core.opcode_slt_flag = F::from_bool(signed);
-    core.opcode_sltu_flag = F::from_bool(!signed);
+    // 1 = unsigned, 2 = signed; 0 is reserved for padding rows.
+    core.opcode_mode = if signed { F::TWO } else { F::ONE };
     core.cmp_result = F::from_bool(cmp_result);
     core.b = b.map(F::from_u16);
     core.c = c.map(F::from_u16);

--- a/extensions/riscv/circuit/cuda/include/riscv/cores/less_than.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/less_than.cuh
@@ -39,8 +39,8 @@ template <typename T, size_t NUM_LIMBS, size_t LIMB_BITS> struct LessThanCoreCol
     T c[NUM_LIMBS];
     T cmp_result;
 
-    T opcode_slt_flag;
-    T opcode_sltu_flag;
+    // 0 = padding, 1 = SLTU (unsigned), 2 = SLT (signed).
+    T opcode_mode;
 
     T b_msb_f;
     T c_msb_f;
@@ -115,8 +115,7 @@ template <size_t NUM_LIMBS, size_t LIMB_BITS> struct LessThanCore {
         COL_WRITE_VALUE(row, Cols, b_msb_f, b_msb_f);
         COL_WRITE_VALUE(row, Cols, c_msb_f, c_msb_f);
         COL_WRITE_VALUE(row, Cols, diff_val, diff_val);
-        COL_WRITE_VALUE(row, Cols, opcode_slt_flag, is_slt);
-        COL_WRITE_VALUE(row, Cols, opcode_sltu_flag, !is_slt);
+        COL_WRITE_VALUE(row, Cols, opcode_mode, is_slt ? 2 : 1);
     }
 
     __device__ void

--- a/extensions/riscv/circuit/src/less_than/core.rs
+++ b/extensions/riscv/circuit/src/less_than/core.rs
@@ -14,7 +14,6 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing},
     BaseAirWithPublicValues,
 };
-use strum::IntoEnumIterator;
 
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Debug)]
@@ -23,8 +22,9 @@ pub struct LessThanCoreCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     pub c: [T; NUM_LIMBS],
     pub cmp_result: T,
 
-    pub opcode_slt_flag: T,
-    pub opcode_sltu_flag: T,
+    /// Packs the opcode flags into one column:
+    /// 0 = padding, 1 = SLTU (unsigned), 2 = SLT (signed).
+    pub opcode_mode: T,
 
     // Most significant limb of b and c respectively as a field element, will be range
     // checked to be within [-2^(LIMB_BITS - 1), 2^(LIMB_BITS - 1)) if signed,
@@ -73,13 +73,18 @@ where
         _from_pc: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LessThanCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
-        let flags = [cols.opcode_slt_flag, cols.opcode_sltu_flag];
 
-        let is_valid = flags.iter().fold(AB::Expr::ZERO, |acc, &flag| {
-            builder.assert_bool(flag);
-            acc + flag.into()
-        });
-        builder.assert_bool(is_valid.clone());
+        // opcode_mode is 0 (padding), 1 (SLTU) or 2 (SLT).
+        let mode = cols.opcode_mode;
+        builder.assert_zero(mode * (mode - AB::Expr::ONE) * (mode - AB::Expr::TWO));
+
+        // mode * (3 - mode) / 2 evaluates to 0, 1, 1 at mode = 0, 1, 2.
+        let half = AB::Expr::from(AB::F::TWO.inverse());
+        let is_valid = mode * (AB::Expr::from_u32(3) - mode) * half.clone();
+        // mode * (mode - 1) / 2 evaluates to 0, 0, 1 at mode = 0, 1, 2.
+        let is_signed = mode * (mode - AB::Expr::ONE) * half;
+        let is_unsigned = is_valid.clone() - is_signed.clone();
+
         builder.assert_bool(cols.cmp_result);
 
         let b = &cols.b;
@@ -115,7 +120,7 @@ where
 
         // Check if b_msb_f and c_msb_f are in
         // [-2^(LIMB_BITS - 1), 2^(LIMB_BITS - 1)) if signed, [0, 2^LIMB_BITS) if unsigned.
-        let sign_shift = AB::Expr::from_u32(1 << (LIMB_BITS - 1)) * cols.opcode_slt_flag;
+        let sign_shift = AB::Expr::from_u32(1 << (LIMB_BITS - 1)) * is_signed.clone();
         self.range_bus
             .range_check(cols.b_msb_f + sign_shift.clone(), LIMB_BITS)
             .eval(builder, is_valid.clone());
@@ -128,12 +133,8 @@ where
             .range_check(cols.diff_val - AB::Expr::ONE, LIMB_BITS)
             .eval(builder, prefix_sum);
 
-        let expected_opcode = flags
-            .iter()
-            .zip(LessThanOpcode::iter())
-            .fold(AB::Expr::ZERO, |acc, (flag, opcode)| {
-                acc + (*flag).into() * AB::Expr::from_u8(opcode as u8)
-            })
+        let expected_opcode = is_signed * AB::Expr::from_u8(LessThanOpcode::SLT as u8)
+            + is_unsigned * AB::Expr::from_u8(LessThanOpcode::SLTU as u8)
             + AB::Expr::from_usize(self.offset);
         let mut a: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
         a[0] = cols.cmp_result.into();

--- a/extensions/riscv/circuit/src/less_than/tests.rs
+++ b/extensions/riscv/circuit/src/less_than/tests.rs
@@ -162,6 +162,7 @@ struct LessThanPrankValues<const NUM_LIMBS: usize> {
     pub c_msb: Option<i32>,
     pub diff_marker: Option<[u32; NUM_LIMBS]>,
     pub diff_val: Option<u32>,
+    pub opcode_mode: Option<u32>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -205,6 +206,9 @@ fn run_negative_less_than_test(
         if let Some(diff_val) = prank_vals.diff_val {
             cols.diff_val = F::from_u32(diff_val);
         }
+        if let Some(opcode_mode) = prank_vals.opcode_mode {
+            cols.opcode_mode = F::from_u32(opcode_mode);
+        }
         cols.cmp_result = F::from_bool(prank_cmp_result);
 
         *trace = RowMajorMatrix::new(values, trace.width());
@@ -245,6 +249,42 @@ fn rv64_lt_wrong_eq_negative_test() {
     let prank_vals = Default::default();
     run_negative_less_than_test(SLT, b, c, true, prank_vals, false);
     run_negative_less_than_test(SLTU, b, c, true, prank_vals, false);
+}
+
+#[test]
+fn rv64_lt_opcode_mode_negative_tests() {
+    let b = [145, 34, 25, 205, 255, 255, 255, 255];
+    let c = [73, 35, 25, 205, 255, 255, 255, 255];
+
+    // An SLT row claiming to be SLTU, and vice versa.
+    for (opcode, wrong_mode) in [(SLT, 1), (SLTU, 2)] {
+        run_negative_less_than_test(
+            opcode,
+            b,
+            c,
+            false,
+            LessThanPrankValues {
+                opcode_mode: Some(wrong_mode),
+                ..Default::default()
+            },
+            true,
+        );
+    }
+
+    // Out-of-range modes: 0 disables the row, 3 breaks the mode.
+    for mode in [0, 3] {
+        run_negative_less_than_test(
+            SLT,
+            b,
+            c,
+            false,
+            LessThanPrankValues {
+                opcode_mode: Some(mode),
+                ..Default::default()
+            },
+            true,
+        );
+    }
 }
 
 #[test]

--- a/extensions/riscv/circuit/src/less_than/trace.rs
+++ b/extensions/riscv/circuit/src/less_than/trace.rs
@@ -102,8 +102,8 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
 
             core_row.c_msb_f = c_msb_f;
             core_row.b_msb_f = b_msb_f;
-            core_row.opcode_sltu_flag = F::from_bool(!is_slt);
-            core_row.opcode_slt_flag = F::from_bool(is_slt);
+            // 1 = SLTU (unsigned), 2 = SLT (signed); 0 is reserved for padding rows.
+            core_row.opcode_mode = if is_slt { F::TWO } else { F::ONE };
             core_row.cmp_result = F::from_bool(cmp_result);
             core_row.c = c.map(F::from_u16);
             core_row.b = b.map(F::from_u16);


### PR DESCRIPTION
This PR encodes `LessThanCoreAir`'s SLT and SLTU flags into a single column (`opcode_mode`)

`opcode_mode` is equal to 0 if it is padding row, equal to 1 for SLTU, and equal to 2 for SLT. As result of removing dedicated SLT and SLTU flags, we modify following calculations:
```
// mode * (3 - mode) / 2 evaluates to 0, 1, 1 at mode = 0, 1, 2.
// is_valid = mode * (3 - mode) / 2;

// mode * (mode - 1) / 2 evaluates to 0, 0, 1 at mode = 0, 1, 2.
// is_signed = mode * (mode - 1) / 2;
// is_unsigned = is_valid - is_signed;
```

Benchmark results: https://github.com/axiom-crypto/openvm-eth/actions/runs/30920298902 (baseline and target are without and with PR respectively).

Little bit hard to do the same for immediate less_than version due to `c_msb_f` column being dependent on SLT flag. It is possible to not increase the degree of expression by writing the SLT part as (mode - 1), but then we need to gate `c_msb_f` related assertions so that for padding rows it wouldn't assert. One solution would be to avoid gating by setting `imm_sign=0` for padding rows (then `c_msb_f` would be equal to zero). Need to think properly

towards INT-8998