### PR TITLE
perf: encode SLT and SLTU into a single column for LessThanImm

### DIFF
--- a/extensions/riscv/circuit/cuda/include/riscv/cores/less_than_imm.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/cores/less_than_imm.cuh
@@ -23,8 +23,8 @@ template <typename T, size_t NUM_LIMBS, size_t LIMB_BITS> struct LessThanImmCore
     T imm_sign;
     T cmp_result;
 
-    T opcode_slt_flag;
-    T opcode_sltu_flag;
+    // 0 = padding, 1 = SLTIU (unsigned), 2 = SLTI (signed).
+    T opcode_mode;
 
     T b_msb_f;
 
@@ -105,8 +105,7 @@ template <size_t NUM_LIMBS, size_t LIMB_BITS> struct LessThanImmCore {
         COL_WRITE_VALUE(row, Cols, cmp_result, cmp_result);
         COL_WRITE_VALUE(row, Cols, b_msb_f, b_msb_f);
         COL_WRITE_VALUE(row, Cols, diff_val, diff_val);
-        COL_WRITE_VALUE(row, Cols, opcode_slt_flag, is_slt);
-        COL_WRITE_VALUE(row, Cols, opcode_sltu_flag, !is_slt);
+        COL_WRITE_VALUE(row, Cols, opcode_mode, is_slt ? 2 : 1);
     }
 
     __device__ void

--- a/extensions/riscv/circuit/src/less_than_imm/core.rs
+++ b/extensions/riscv/circuit/src/less_than_imm/core.rs
@@ -14,7 +14,6 @@ use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing},
     BaseAirWithPublicValues,
 };
-use strum::IntoEnumIterator;
 
 /// Core columns for comparisons with a signed 12-bit immediate.
 #[repr(C)]
@@ -27,8 +26,9 @@ pub struct LessThanImmCoreCols<T, const NUM_LIMBS: usize, const LIMB_BITS: usize
     pub imm_sign: T,
     pub cmp_result: T,
 
-    pub opcode_slt_flag: T,
-    pub opcode_sltu_flag: T,
+    /// Packs the opcode flags into one column:
+    /// 0 = padding, 1 = SLTIU (unsigned), 2 = SLTI (signed).
+    pub opcode_mode: T,
 
     pub b_msb_f: T,
 
@@ -71,15 +71,30 @@ where
         _from_pc: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LessThanImmCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
-        let flags = [cols.opcode_slt_flag, cols.opcode_sltu_flag];
+        // opcode_mode is 0 (padding), 1 (SLTIU) or 2 (SLTI).
+        let mode = cols.opcode_mode;
+        builder.assert_zero(mode * (mode - AB::Expr::ONE) * (mode - AB::Expr::TWO));
 
-        let is_valid = flags.iter().fold(AB::Expr::ZERO, |acc, &flag| {
-            builder.assert_bool(flag);
-            acc + flag.into()
-        });
-        builder.assert_bool(is_valid.clone());
+        // mode * (3 - mode) / 2 evaluates to 0, 1, 1 at mode = 0, 1, 2
+        let is_valid = mode * (AB::Expr::from_u32(3) - mode) * AB::Expr::from(AB::F::TWO.inverse());
+
+        // `mode - 1` is 0 for SLTIU and 1 for SLTI, giving the signed selector at degree 1. The
+        // exact form `mode * (mode - 1) / 2` is degree 2, which would push
+        // `c_msb_f` to degree 3 and the two constraints reading it to degree 4.
+        //
+        // On a mode=0 row, `is_signed` and `is_unsigned` are -1 and 2 rather than 0. `sign_shift` and
+        // `expected_opcode` are unaffected because their interactions have count `is_valid`, which
+        // is exactly 0 there. `c_msb_f` is the one ungated consumer, so `imm_sign` is
+        // pinned to zero on invalid rows below, which forces `c_msb_f` to zero too.
+        let is_signed = mode - AB::Expr::ONE;
+        let is_unsigned = AB::Expr::ONE - is_signed.clone();
+
         builder.assert_bool(cols.cmp_result);
         builder.assert_bool(cols.imm_sign);
+        // An invalid row must have imm_sign = 0.
+        builder
+            .when(not::<AB::Expr>(is_valid.clone()))
+            .assert_zero(cols.imm_sign);
 
         // Range check the low 11 bits of the immediate so the (imm_low11, imm_sign)
         // decomposition of the 24-bit operand is unique.
@@ -105,9 +120,10 @@ where
         builder.assert_zero(b_diff.clone() * (AB::Expr::from_u32(1 << LIMB_BITS) - b_diff));
 
         // Field representation of the immediate's top limb for signed or unsigned comparison.
+        // For padding rows, `c_msb_f=0` due to imm_sign being 0.
         let c_msb_f: AB::Expr = cols.imm_sign
             * (AB::Expr::from_u32((1 << LIMB_BITS) - 1)
-                - cols.opcode_slt_flag * AB::Expr::from_u32(1 << LIMB_BITS));
+                - is_signed.clone() * AB::Expr::from_u32(1 << LIMB_BITS));
 
         // Maps cmp_result to -1 or 1, so cmp_sign^2 = 1.
         let cmp_sign = AB::Expr::from_u8(2) * cols.cmp_result - AB::Expr::ONE;
@@ -133,7 +149,9 @@ where
             .when(not::<AB::Expr>(prefix_sum.clone()))
             .assert_zero(cols.cmp_result);
 
-        let sign_shift = AB::Expr::from_u32(1 << (LIMB_BITS - 1)) * cols.opcode_slt_flag;
+        // For padding rows, `sign_shift` is unaffected by `is_signed` being -2.
+        // This is due to is_valid gating.
+        let sign_shift = AB::Expr::from_u32(1 << (LIMB_BITS - 1)) * is_signed.clone();
         self.range_bus
             .range_check(cols.b_msb_f + sign_shift.clone(), LIMB_BITS)
             .eval(builder, is_valid.clone());
@@ -142,12 +160,10 @@ where
             .range_check(cols.diff_val - AB::Expr::ONE, LIMB_BITS)
             .eval(builder, prefix_sum);
 
-        let expected_opcode = flags
-            .iter()
-            .zip(LessThanImmOpcode::iter())
-            .fold(AB::Expr::ZERO, |acc, (flag, opcode)| {
-                acc + (*flag).into() * AB::Expr::from_u8(opcode as u8)
-            })
+        // For padding rows, `expected_opcode` is gated by `is_valid`. Hence, its content can be
+        // anything.
+        let expected_opcode = is_signed * AB::Expr::from_u8(LessThanImmOpcode::SLTI as u8)
+            + is_unsigned * AB::Expr::from_u8(LessThanImmOpcode::SLTIU as u8)
             + AB::Expr::from_usize(self.offset);
         let mut a: [AB::Expr; NUM_LIMBS] = array::from_fn(|_| AB::Expr::ZERO);
         a[0] = cols.cmp_result.into();

--- a/extensions/riscv/circuit/src/less_than_imm/core.rs
+++ b/extensions/riscv/circuit/src/less_than_imm/core.rs
@@ -82,10 +82,11 @@ where
         // exact form `mode * (mode - 1) / 2` is degree 2, which would push
         // `c_msb_f` to degree 3 and the two constraints reading it to degree 4.
         //
-        // On a mode=0 row, `is_signed` and `is_unsigned` are -1 and 2 rather than 0. `sign_shift` and
-        // `expected_opcode` are unaffected because their interactions have count `is_valid`, which
-        // is exactly 0 there. `c_msb_f` is the one ungated consumer, so `imm_sign` is
-        // pinned to zero on invalid rows below, which forces `c_msb_f` to zero too.
+        // On a mode=0 row, `is_signed` and `is_unsigned` are -1 and 2 rather than 0. `sign_shift`
+        // and `expected_opcode` are unaffected because their interactions have count
+        // `is_valid`, which is exactly 0 there. `c_msb_f` is the one ungated consumer, so
+        // `imm_sign` is pinned to zero on invalid rows below, which forces `c_msb_f` to
+        // zero too.
         let is_signed = mode - AB::Expr::ONE;
         let is_unsigned = AB::Expr::ONE - is_signed.clone();
 

--- a/extensions/riscv/circuit/src/less_than_imm/tests.rs
+++ b/extensions/riscv/circuit/src/less_than_imm/tests.rs
@@ -94,28 +94,39 @@ fn rv64_less_than_immediate_boundaries() {
         .expect("verification failed");
 }
 
-#[test]
-fn rv64_less_than_immediate_result_negative() {
+type CoreCols = LessThanImmCoreCols<F, BLOCK_FE_WIDTH, U16_BITS>;
+
+/// Executes `num_ops` SLTI instructions with immediate `imm` against a zero source register, then
+/// rewrites the core columns of `row` via `prank` and expects verification to fail.
+///
+/// The trace is padded to the next power of two, so a `row` at or past `num_ops` is a padding row.
+fn run_negative_prank(num_ops: usize, imm: i16, row: usize, prank: impl Fn(&mut CoreCols)) {
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
     let mut harness = create_harness(&tester);
-    let (instruction, _) = rv64_rand_write_register_or_imm(
-        &mut tester,
-        0u64.to_le_bytes(),
-        [0; RV64_REGISTER_NUM_LIMBS],
-        Some(encode_i12(1)),
-        LessThanImmOpcode::SLTI.global_opcode().as_usize(),
-        &mut rng,
-    );
-    tester.execute(&mut harness.executor, &mut harness.preflight, &instruction);
+    for _ in 0..num_ops {
+        let (instruction, _) = rv64_rand_write_register_or_imm(
+            &mut tester,
+            0u64.to_le_bytes(),
+            [0; RV64_REGISTER_NUM_LIMBS],
+            Some(encode_i12(imm)),
+            LessThanImmOpcode::SLTI.global_opcode().as_usize(),
+            &mut rng,
+        );
+        tester.execute(&mut harness.executor, &mut harness.preflight, &instruction);
+    }
 
     let adapter_width = BaseAir::<F>::width(&harness.air.adapter);
     let modify_trace = |trace: &mut RowMajorMatrix<F>| {
-        let mut values = trace.row_slice(0).unwrap().to_vec();
-        let cols: &mut LessThanImmCoreCols<F, BLOCK_FE_WIDTH, U16_BITS> =
-            values.split_at_mut(adapter_width).1.borrow_mut();
-        cols.cmp_result = F::ZERO;
-        *trace = RowMajorMatrix::new(values, trace.width());
+        let width = trace.width();
+        let mut values = trace.values.clone();
+        assert!(values.len() / width > row, "trace has no row {row}");
+        let cols: &mut CoreCols = values[row * width..(row + 1) * width]
+            .split_at_mut(adapter_width)
+            .1
+            .borrow_mut();
+        prank(cols);
+        *trace = RowMajorMatrix::new(values, width);
     };
 
     disable_debug_builder();
@@ -124,7 +135,54 @@ fn rv64_less_than_immediate_result_negative() {
         .load_and_prank_trace(harness, modify_trace)
         .finalize()
         .simple_test()
-        .expect_err("altered comparison result should fail");
+        .expect_err("pranked trace should fail verification");
+}
+
+/// Pranks the sole executed row, which is valid.
+fn prank_valid_row(imm: i16, prank: impl Fn(&mut CoreCols)) {
+    run_negative_prank(1, imm, 0, prank);
+}
+
+/// Pranks a padding row: three ops pad the height to four, so row 3 is unused.
+fn prank_padding_row(prank: impl Fn(&mut CoreCols)) {
+    run_negative_prank(3, -1, 3, prank);
+}
+
+#[test]
+fn rv64_less_than_immediate_result_negative() {
+    // 0 < 1 holds, so the honest cmp_result is 1 and clearing it must be rejected.
+    prank_valid_row(1, |cols| cols.cmp_result = F::ZERO);
+}
+
+#[test]
+fn rv64_less_than_immediate_opcode_mode_negative_tests() {
+    // 1 claims SLTIU on a SLTI row; 3 is out of range; 0 marks the row invalid, so its
+    // execution-bus interaction goes missing.
+    for mode in [1, 3, 0] {
+        prank_valid_row(-1, |cols| cols.opcode_mode = F::from_u32(mode));
+    }
+}
+
+#[test]
+fn rv64_less_than_immediate_padding_imm_sign_negative_test() {
+    // With `is_signed = -1`, the AIR computes
+    //   c_msb_f = imm_sign * ((2^16 - 1) - (-1) * 2^16) = imm_sign * (2^17 - 1).
+    const C_MSB: u32 = (1u32 << (U16_BITS + 1)) - 1;
+    // Low limb of a sign-extended immediate whose low 11 bits are zero.
+    const C_LOW: u32 = 0xF800;
+
+    prank_padding_row(|cols| {
+        cols.imm_sign = F::ONE;
+        // Match the sign-extended immediate limb for limb so every raw_diff vanishes.
+        cols.b[0] = F::from_u32(C_LOW);
+        for limb in &mut cols.b[1..BLOCK_FE_WIDTH - 1] {
+            *limb = F::from_u16(u16::MAX);
+        }
+        // The top limb also feeds `b_diff = b[last] - b_msb_f`, which must be 0 or 2^16. Setting
+        // both to C_MSB keeps b_diff = 0 and makes the top raw_diff zero.
+        cols.b[BLOCK_FE_WIDTH - 1] = F::from_u32(C_MSB);
+        cols.b_msb_f = F::from_u32(C_MSB);
+    });
 }
 
 #[cfg(all(feature = "cuda", feature = "rvr"))]

--- a/extensions/riscv/circuit/src/less_than_imm/trace.rs
+++ b/extensions/riscv/circuit/src/less_than_imm/trace.rs
@@ -103,8 +103,8 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             }
 
             core_row.b_msb_f = b_msb_f;
-            core_row.opcode_sltu_flag = F::from_bool(!is_slt);
-            core_row.opcode_slt_flag = F::from_bool(is_slt);
+            // 1 = SLTIU (unsigned), 2 = SLTI (signed); 0 is reserved for padding rows.
+            core_row.opcode_mode = if is_slt { F::TWO } else { F::ONE };
             core_row.cmp_result = F::from_bool(cmp_result);
             core_row.imm_sign = F::from_u8(imm_sign);
             core_row.imm_low11 = F::from_u16(imm_low11);


### PR DESCRIPTION
This PR encodes SLT and SLTU flags into a single `opcode_mode` column for `LessThanImmCoreAir`.  This is done by encoding `opcode_mode` as:
- 0 for padding rows
- 1 for SLTU
- 2 for SLT

```
is_valid = mode * (3 - mode) / 2;
is_signed = mode - 1;
is_unsigned = 1 - is_signed;
```

Although `mode=0` would result in `is_signed=-2` and `is_unsigned=1`, it is handled by `is_valid` gating and setting `imm_sign` column to 0 for padding rows.

benchmark: https://github.com/axiom-crypto/openvm-eth/actions/runs/30926360281 (baseline and target are develop-v2.1.0 and perf/thinner-less-than-imm branches respectively)

resolves INT-8998