### PR TITLE
fix(v2.1): allow noncanonical is-eq setup reads 

### DIFF
--- a/extensions/algebra/circuit/cuda/src/modular_is_eq.cu
+++ b/extensions/algebra/circuit/cuda/src/modular_is_eq.cu
@@ -279,10 +279,14 @@ __global__ void modular_is_eq_replay_tracegen(
         memory, heap_event_start, 1, shared_modulus, c_less
     );
     bool setup_b_is_modulus = is_setup && b_diff == LIMBS;
-    if ((!is_setup && (!b_less || b_diff == LIMBS)) || !c_less || c_diff == LIMBS ||
+    if ((!is_setup && (!b_less || b_diff == LIMBS || !c_less || c_diff == LIMBS)) ||
         (is_setup && !setup_b_is_modulus)) {
         preflight_set_error(error, MODULAR_IS_EQ_REPLAY_ERROR);
         return;
+    }
+    if (is_setup) {
+        b_diff = LIMBS;
+        if (c_diff == LIMBS) c_diff = 0;
     }
 
     VariableRangeChecker range_checker(range_checker_counts, range_checker_bins);
@@ -335,11 +339,11 @@ __global__ void modular_is_eq_replay_tracegen(
     core[offsetof(CoreCols, is_valid)] = Fp::one();
     core[offsetof(CoreCols, is_setup)] = Fp(static_cast<uint32_t>(is_setup));
     core[offsetof(CoreCols, cmp_result)] = Fp(static_cast<uint32_t>(equal));
-    uint32_t c_mark = b_diff == c_diff ? 1 : 2;
+    uint32_t c_mark = !is_setup && b_diff == c_diff ? 1 : 2;
     core[offsetof(CoreCols, c_lt_mark)] = Fp(c_mark);
     uint16_t c_diff_value =
         modular_is_eq_limb<BLOCKS>(memory, heap_event_start, 1, c_diff);
-    core[offsetof(CoreCols, c_lt_diff)] = Fp(shared_modulus[c_diff] - c_diff_value);
+    core[offsetof(CoreCols, c_lt_diff)] = Fp(shared_modulus[c_diff]) - Fp(c_diff_value);
     if (!is_setup) {
         uint16_t b_diff_value =
             modular_is_eq_limb<BLOCKS>(memory, heap_event_start, 0, b_diff);

--- a/extensions/algebra/circuit/cuda/src/modular_is_eq.cu
+++ b/extensions/algebra/circuit/cuda/src/modular_is_eq.cu
@@ -278,15 +278,15 @@ __global__ void modular_is_eq_replay_tracegen(
     size_t c_diff = unsigned_less_than<BLOCKS, LIMBS>(
         memory, heap_event_start, 1, shared_modulus, c_less
     );
-    bool setup_b_is_modulus = is_setup && b_diff == LIMBS;
-    if ((!is_setup && (!b_less || b_diff == LIMBS || !c_less || c_diff == LIMBS)) ||
-        (is_setup && !setup_b_is_modulus)) {
+    if (is_setup) {
+        if (b_diff != LIMBS) {
+            preflight_set_error(error, MODULAR_IS_EQ_REPLAY_ERROR);
+            return;
+        }
+        if (c_diff == LIMBS) c_diff = 0;
+    } else if (!b_less || !c_less) {
         preflight_set_error(error, MODULAR_IS_EQ_REPLAY_ERROR);
         return;
-    }
-    if (is_setup) {
-        b_diff = LIMBS;
-        if (c_diff == LIMBS) c_diff = 0;
     }
 
     VariableRangeChecker range_checker(range_checker_counts, range_checker_bins);
@@ -339,8 +339,9 @@ __global__ void modular_is_eq_replay_tracegen(
     core[offsetof(CoreCols, is_valid)] = Fp::one();
     core[offsetof(CoreCols, is_setup)] = Fp(static_cast<uint32_t>(is_setup));
     core[offsetof(CoreCols, cmp_result)] = Fp(static_cast<uint32_t>(equal));
-    uint32_t c_mark = !is_setup && b_diff == c_diff ? 1 : 2;
-    core[offsetof(CoreCols, c_lt_mark)] = Fp(c_mark);
+    // One marker witnesses both bounds when their differing limbs coincide. Otherwise c uses 2.
+    uint32_t c_marker_value = b_diff == c_diff ? 1 : 2;
+    core[offsetof(CoreCols, c_lt_mark)] = Fp(c_marker_value);
     uint16_t c_diff_value =
         modular_is_eq_limb<BLOCKS>(memory, heap_event_start, 1, c_diff);
     core[offsetof(CoreCols, c_lt_diff)] = Fp(shared_modulus[c_diff]) - Fp(c_diff_value);
@@ -359,7 +360,7 @@ __global__ void modular_is_eq_replay_tracegen(
         if (limb == b_diff) {
             core[offsetof(CoreCols, lt_marker) + limb] = Fp::one();
         } else if (limb == c_diff) {
-            core[offsetof(CoreCols, lt_marker) + limb] = Fp(c_mark);
+            core[offsetof(CoreCols, lt_marker) + limb] = Fp(c_marker_value);
         }
     }
     if (!equal) {

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -304,28 +304,38 @@ impl<const READ_LIMBS: usize, const LIMB_BITS: usize> ModularIsEqualFiller<READ_
         core_row: &mut [F],
     ) -> Result<(), PostflightError> {
         let cols: &mut ModularIsEqualCoreCols<F, READ_LIMBS> = core_row.borrow_mut();
-        let (b_cmp, b_diff_idx) = run_unsigned_less_than::<READ_LIMBS>(&b, &self.modulus_limbs);
-        let (c_cmp, c_diff_idx) = run_unsigned_less_than::<READ_LIMBS>(&c, &self.modulus_limbs);
+        let (b_cmp, mut b_diff_idx) = run_unsigned_less_than::<READ_LIMBS>(&b, &self.modulus_limbs);
+        let (c_cmp, mut c_diff_idx) = run_unsigned_less_than::<READ_LIMBS>(&c, &self.modulus_limbs);
 
         if !is_setup && !b_cmp {
             return Err(PostflightError::new(
                 "modular equality left operand is not less than the modulus",
             ));
         }
-        if !c_cmp {
+        if !is_setup && !c_cmp {
             return Err(PostflightError::new(
                 "modular equality right operand is not less than the modulus",
             ));
         }
+        if is_setup {
+            // Setup constrains b to equal the modulus, so it must not contribute a marker.
+            // Its second memory read is not required to be less than the modulus; choose its
+            // highest differing limb, or limb zero when there is no difference.
+            b_diff_idx = READ_LIMBS;
+            c_diff_idx = (0..READ_LIMBS)
+                .rev()
+                .find(|&i| c[i] != self.modulus_limbs[i])
+                .unwrap_or(0);
+        }
 
         // Writing in reverse order
-        cols.c_lt_mark = if b_diff_idx == c_diff_idx {
+        cols.c_lt_mark = if !is_setup && b_diff_idx == c_diff_idx {
             F::ONE
         } else {
             F::TWO
         };
 
-        cols.c_lt_diff = F::from_u16(self.modulus_limbs[c_diff_idx] - c[c_diff_idx]);
+        cols.c_lt_diff = F::from_u16(self.modulus_limbs[c_diff_idx]) - F::from_u16(c[c_diff_idx]);
         if !is_setup {
             cols.b_lt_diff = F::from_u16(self.modulus_limbs[b_diff_idx] - b[b_diff_idx]);
             range_checker.add_count(
@@ -616,8 +626,10 @@ unsafe fn execute_e12_impl<
         debug_assert!(b_cmp, "{:?} >= modulus {:?}", b, pre_compute.modulus_limbs);
     }
 
-    let (c_cmp, _) = run_unsigned_less_than::<TOTAL_READ_SIZE>(&c, &pre_compute.modulus_limbs);
-    debug_assert!(c_cmp, "{:?} >= modulus {:?}", c, pre_compute.modulus_limbs);
+    if !IS_SETUP {
+        let (c_cmp, _) = run_unsigned_less_than::<TOTAL_READ_SIZE>(&c, &pre_compute.modulus_limbs);
+        debug_assert!(c_cmp, "{:?} >= modulus {:?}", c, pre_compute.modulus_limbs);
+    }
 
     // Compute result (RV64: 8-byte result register)
     let mut write_data = [0u8; RV64_REGISTER_NUM_LIMBS];

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -328,8 +328,9 @@ impl<const READ_LIMBS: usize, const LIMB_BITS: usize> ModularIsEqualFiller<READ_
                 .unwrap_or(0);
         }
 
-        // Writing in reverse order
-        cols.c_lt_mark = if !is_setup && b_diff_idx == c_diff_idx {
+        // Normal rows share one marker when both bounds differ at the same limb. Setup has no
+        // b marker, so its c marker always has value two.
+        cols.c_lt_mark = if b_diff_idx == c_diff_idx {
             F::ONE
         } else {
             F::TWO

--- a/extensions/algebra/circuit/src/modular_chip/tests.rs
+++ b/extensions/algebra/circuit/src/modular_chip/tests.rs
@@ -929,7 +929,7 @@ mod is_equal_tests {
         let (b, c, opcode) = if is_setup {
             (
                 modulus_limbs,
-                [F::ZERO; TOTAL_LIMBS],
+                c.unwrap_or([F::ZERO; TOTAL_LIMBS]),
                 offset + Rv64ModularArithmeticOpcode::SETUP_ISEQ as usize,
             )
         } else {
@@ -1021,6 +1021,43 @@ mod is_equal_tests {
     #[test]
     fn test_modular_is_equal_48limb() {
         test_is_equal::<MODULAR_BLOCKS_48, NUM_LIMBS_48_U16>(17, BLS12_381_MODULUS.clone(), 100);
+    }
+
+    #[test]
+    fn setup_is_equal_allows_noncanonical_right_operand() {
+        const BLOCKS: usize = MODULAR_BLOCKS_32;
+        const LIMBS: usize = NUM_LIMBS_32_U16;
+        let mut rng = create_seeded_rng();
+        let mut tester = VmChipTestBuilder::default();
+        let modulus = secp256k1_coord_prime();
+        let offset = Rv64ModularArithmeticOpcode::CLASS_OFFSET;
+        let modulus_limbs =
+            biguint_to_limbs::<LIMBS>(modulus.clone(), U16_BITS).map(|limb| limb as u16);
+        let mut harness =
+            create_harness::<BLOCKS, LIMBS>(&mut tester, &modulus, modulus_limbs, offset);
+        let modulus_limbs = modulus_limbs.map(F::from_u16);
+
+        for right_operand in [modulus_limbs, [F::from_u16(u16::MAX); LIMBS]] {
+            set_and_execute_is_equal(
+                &mut tester,
+                &mut harness.executor,
+                &mut harness.preflight,
+                &mut rng,
+                &modulus,
+                modulus_limbs,
+                offset,
+                true,
+                None,
+                Some(right_operand),
+            );
+        }
+
+        tester
+            .build()
+            .load(harness)
+            .finalize()
+            .simple_test()
+            .expect("setup rows with non-canonical right operands should verify");
     }
 
     #[test]
@@ -1201,7 +1238,7 @@ mod is_equal_tests {
                 opcode_offset,
                 i == 0, // the first test is a setup test
                 None,
-                None,
+                (i == 0).then_some(modulus_limbs),
             );
         }
 


### PR DESCRIPTION
## Summary

SETUP_ISEQ does not require its second read to be below the modulus, but CPU and GPU trace generation applied the normal IS_EQ validation and rejected setup rows when c >= modulus.

This change handles noncanonical setup reads while preserving strict operand validation for normal IS_EQ. It also performs the setup difference in the proof field to avoid u16 underflow and adds CPU/GPU regression coverage.

## Testing

- focused modular is-equal CPU tests
- focused modular is-equal CUDA test
