### PR TITLE
feat: support program counter up to the full u32

### DIFF
--- a/crates/circuits/mod-builder/src/core_chip.rs
+++ b/crates/circuits/mod-builder/src/core_chip.rs
@@ -138,7 +138,7 @@ where
         &self,
         builder: &mut AB,
         local: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         assert_eq!(local.len(), BaseAir::<AB::F>::width(&self.expr));
         self.expr.eval(builder, local);
@@ -182,7 +182,7 @@ where
         };
 
         let ctx: AdapterAirContext<_, DynAdapterInterface<_>> = AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: reads.into(),
             writes: writes.into(),
             instruction: instruction.into(),

--- a/crates/circuits/primitives/cuda/include/primitives/constants.h
+++ b/crates/circuits/primitives/cuda/include/primitives/constants.h
@@ -27,8 +27,8 @@ inline constexpr size_t RV_IS_TYPE_IMM_BITS = 12;
 
 namespace program {
 // Number of bits of a pc index (`pc / DEFAULT_PC_STEP`), the circuit representation of the
-// program counter. Byte pcs span PC_BITS + PC_STEP_BITS = 32 bits.
-inline constexpr size_t PC_BITS = 30;
+// program counter. Byte pcs span PC_IDX_BITS + PC_STEP_BITS = 32 bits.
+inline constexpr size_t PC_IDX_BITS = 30;
 inline constexpr size_t DEFAULT_PC_STEP = 4;
 // log2 of DEFAULT_PC_STEP.
 inline constexpr size_t PC_STEP_BITS = 2;

--- a/crates/circuits/primitives/cuda/include/primitives/constants.h
+++ b/crates/circuits/primitives/cuda/include/primitives/constants.h
@@ -26,9 +26,20 @@ inline constexpr size_t RV_IS_TYPE_IMM_BITS = 12;
 } // namespace riscv
 
 namespace program {
+// Number of bits of a pc index (`pc / DEFAULT_PC_STEP`), the circuit representation of the
+// program counter. Byte pcs span PC_BITS + PC_STEP_BITS = 32 bits.
 inline constexpr size_t PC_BITS = 30;
 inline constexpr size_t DEFAULT_PC_STEP = 4;
+// log2 of DEFAULT_PC_STEP.
+inline constexpr size_t PC_STEP_BITS = 2;
+// Maximum allowed byte pc: the last DEFAULT_PC_STEP-aligned 32-bit address.
+inline constexpr uint32_t MAX_ALLOWED_PC = UINT32_MAX - (DEFAULT_PC_STEP - 1);
+// Low bits of a pc index packed into the low u16 limb of the corresponding byte pc.
+inline constexpr size_t PC_IDX_LOW_BITS = openvm::U16_BITS - PC_STEP_BITS;
 inline constexpr size_t DEFAULT_BLOCK_SIZE = 8;
+
+// Converts a DEFAULT_PC_STEP-aligned byte pc into the pc index used by circuits.
+__device__ __host__ inline constexpr uint32_t pc_to_idx(uint32_t pc) { return pc >> PC_STEP_BITS; }
 } // namespace program
 
 namespace p3_keccak_air {

--- a/crates/continuations/src/circuit/inner/vm_pvs/air.rs
+++ b/crates/continuations/src/circuit/inner/vm_pvs/air.rs
@@ -149,7 +149,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
 
         // when local and next are valid, constrain increasing proof_idx and adjacency
         let mut when_both_valid = builder.when(and(local.is_valid, not(local.is_last)));
-        when_both_valid.assert_eq(local.child_pvs.final_pc, next.child_pvs.initial_pc);
+        when_both_valid.assert_eq(local.child_pvs.final_pc_idx, next.child_pvs.initial_pc_idx);
         assert_array_eq(
             &mut when_both_valid,
             local.child_pvs.final_root,
@@ -200,7 +200,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             PublicValuesBusMessage {
                 air_idx: cond_connector_air_id.clone(),
                 pv_idx: internal_pp(),
-                value: local.child_pvs.initial_pc.into(),
+                value: local.child_pvs.initial_pc_idx.into(),
             },
             local.is_valid,
         );
@@ -211,7 +211,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             PublicValuesBusMessage {
                 air_idx: cond_connector_air_id.clone(),
                 pv_idx: is_leaf.clone() + internal_pp(),
-                value: local.child_pvs.final_pc.into(),
+                value: local.child_pvs.final_pc_idx.into(),
             },
             local.is_valid,
         );
@@ -305,8 +305,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
          */
         let &VmPvs::<_> {
             program_commit,
-            initial_pc,
-            final_pc,
+            initial_pc_idx,
+            final_pc_idx,
             exit_code,
             is_terminate,
             initial_root,
@@ -316,7 +316,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         // constrain first proof pvs
         builder
             .when_first_row()
-            .assert_eq(local.child_pvs.initial_pc, initial_pc);
+            .assert_eq(local.child_pvs.initial_pc_idx, initial_pc_idx);
         assert_array_eq(
             &mut builder.when_first_row(),
             local.child_pvs.initial_root,
@@ -326,7 +326,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         // constrain last proof pvs
         builder
             .when(local.is_last)
-            .assert_eq(local.child_pvs.final_pc, final_pc);
+            .assert_eq(local.child_pvs.final_pc_idx, final_pc_idx);
         builder
             .when(local.is_last)
             .assert_eq(local.child_pvs.exit_code, exit_code);

--- a/crates/continuations/src/circuit/inner/vm_pvs/trace.rs
+++ b/crates/continuations/src/circuit/inner/vm_pvs/trace.rs
@@ -59,13 +59,13 @@ pub fn generate_proving_ctx(
                 .cached_commitments[PROGRAM_CACHED_TRACE_INDEX];
 
             let &VmConnectorPvs {
-                initial_pc,
-                final_pc,
+                initial_pc_idx,
+                final_pc_idx,
                 exit_code,
                 is_terminate,
             } = proof.public_values[CONNECTOR_AIR_ID].as_slice().borrow();
-            cols.child_pvs.initial_pc = initial_pc;
-            cols.child_pvs.final_pc = final_pc;
+            cols.child_pvs.initial_pc_idx = initial_pc_idx;
+            cols.child_pvs.final_pc_idx = final_pc_idx;
             cols.child_pvs.exit_code = exit_code;
             cols.child_pvs.is_terminate = is_terminate;
 
@@ -91,10 +91,10 @@ pub fn generate_proving_ctx(
             trace[(num_vm_proofs - 1) * width..(num_vm_proofs - 1) * width + base_width].borrow();
 
         pvs.program_commit = first_row.child_pvs.program_commit;
-        pvs.initial_pc = first_row.child_pvs.initial_pc;
+        pvs.initial_pc_idx = first_row.child_pvs.initial_pc_idx;
         pvs.initial_root = first_row.child_pvs.initial_root;
 
-        pvs.final_pc = last_row.child_pvs.final_pc;
+        pvs.final_pc_idx = last_row.child_pvs.final_pc_idx;
         pvs.exit_code = last_row.child_pvs.exit_code;
         pvs.is_terminate = last_row.child_pvs.is_terminate;
         pvs.final_root = last_row.child_pvs.final_root;

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -103,7 +103,7 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for R
 pub struct RootVerifierPvs<F> {
     /// Hashed combination of the app-level ProgramAir cached trace, the Merkle root commit of
     /// the starting app memory state (i.e. initial_root), and the initial app program-counter
-    /// index (i.e. initial_pc).
+    /// index (i.e. initial_pc_idx).
     pub app_exe_commit: [F; DIGEST_SIZE],
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf vk commits.

--- a/crates/continuations/src/circuit/root/mod.rs
+++ b/crates/continuations/src/circuit/root/mod.rs
@@ -102,8 +102,8 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for R
 #[derive(AlignedBorrow, Debug)]
 pub struct RootVerifierPvs<F> {
     /// Hashed combination of the app-level ProgramAir cached trace, the Merkle root commit of
-    /// the starting app memory state (i.e. initial_root), and the initial app program counter
-    /// (i.e. initial_pc).
+    /// the starting app memory state (i.e. initial_root), and the initial app program-counter
+    /// index (i.e. initial_pc).
     pub app_exe_commit: [F; DIGEST_SIZE],
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf vk commits.

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -274,8 +274,8 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * The app_exe_commit is a commit to the app program, initial memory state, and initial
-         * PC. Child public values program_commit, initial_root, and initial_pc are individually
-         * hashed and then permuted together to produce app_exe_commit.
+         * PC index. Child public values program_commit, initial_root, and initial_pc are
+         * individually hashed and then permuted together to produce app_exe_commit.
          */
         self.poseidon2_compress_bus.lookup_key(
             builder,

--- a/crates/continuations/src/circuit/root/verifier/air.rs
+++ b/crates/continuations/src/circuit/root/verifier/air.rs
@@ -52,7 +52,7 @@ pub struct RootVerifierPvsCols<F> {
 
     pub program_commit_hash: [F; DIGEST_SIZE],
     pub initial_root_hash: [F; DIGEST_SIZE],
-    pub initial_pc_hash: [F; DIGEST_SIZE],
+    pub initial_pc_idx_hash: [F; DIGEST_SIZE],
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
 
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
@@ -274,7 +274,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
 
         /*
          * The app_exe_commit is a commit to the app program, initial memory state, and initial
-         * PC index. Child public values program_commit, initial_root, and initial_pc are
+         * PC index. Child public values program_commit, initial_root, and initial_pc_idx are
          * individually hashed and then permuted together to produce app_exe_commit.
          */
         self.poseidon2_compress_bus.lookup_key(
@@ -305,10 +305,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             Poseidon2CompressMessage {
                 input: pad_slice_to_poseidon2_input(
-                    &[local.child_vm_pvs.initial_pc.into()],
+                    &[local.child_vm_pvs.initial_pc_idx.into()],
                     AB::Expr::ZERO,
                 ),
-                output: local.initial_pc_hash.map(Into::into),
+                output: local.initial_pc_idx_hash.map(Into::into),
             },
             AB::F::ONE,
         );
@@ -330,7 +330,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             Poseidon2CompressMessage {
                 input: digests_to_poseidon2_input(
                     local.intermediate_exe_commit,
-                    local.initial_pc_hash,
+                    local.initial_pc_idx_hash,
                 )
                 .map(Into::into),
                 output: app_exe_commit.map(Into::into),

--- a/crates/continuations/src/circuit/root/verifier/trace.rs
+++ b/crates/continuations/src/circuit/root/verifier/trace.rs
@@ -55,7 +55,8 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
 
     let padded_program_commit = pad_slice_to_poseidon2_input(&child_vm_pvs.program_commit, F::ZERO);
     let padded_initial_root = pad_slice_to_poseidon2_input(&child_vm_pvs.initial_root, F::ZERO);
-    let padded_initial_pc = pad_slice_to_poseidon2_input(&[child_vm_pvs.initial_pc], F::ZERO);
+    let padded_initial_pc_idx =
+        pad_slice_to_poseidon2_input(&[child_vm_pvs.initial_pc_idx], F::ZERO);
 
     let perm = poseidon2_perm();
     cols.program_commit_hash = perm.permute(padded_program_commit)[..DIGEST_SIZE]
@@ -64,7 +65,7 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
     cols.initial_root_hash = perm.permute(padded_initial_root)[..DIGEST_SIZE]
         .try_into()
         .unwrap();
-    cols.initial_pc_hash = perm.permute(padded_initial_pc)[..DIGEST_SIZE]
+    cols.initial_pc_idx_hash = perm.permute(padded_initial_pc_idx)[..DIGEST_SIZE]
         .try_into()
         .unwrap();
 
@@ -74,7 +75,7 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
     poseidon2_compress_inputs.extend_from_slice(&[
         padded_program_commit,
         padded_initial_root,
-        padded_initial_pc,
+        padded_initial_pc_idx,
     ]);
 
     cols.intermediate_exe_commit =
@@ -103,10 +104,10 @@ pub fn generate_proving_ctx<SC: StarkProtocolConfig<F = F>>(
     let root_pvs: &mut RootVerifierPvs<F> = public_values.as_mut_slice().borrow_mut();
 
     root_pvs.app_exe_commit =
-        poseidon2_compress_with_capacity(cols.intermediate_exe_commit, cols.initial_pc_hash).0;
+        poseidon2_compress_with_capacity(cols.intermediate_exe_commit, cols.initial_pc_idx_hash).0;
     poseidon2_compress_inputs.push(crate::utils::digests_to_poseidon2_input(
         cols.intermediate_exe_commit,
-        cols.initial_pc_hash,
+        cols.initial_pc_idx_hash,
     ));
 
     root_pvs.app_vm_commit = app_vm_commit;

--- a/crates/static-verifier/src/stages/full_pipeline/public_values.rs
+++ b/crates/static-verifier/src/stages/full_pipeline/public_values.rs
@@ -17,7 +17,7 @@ use crate::{
 pub struct StaticVerifierPvs<T> {
     /// Hashed combination of the app-level ProgramAir cached trace, the Merkle root commit of
     /// the starting app memory state (i.e. initial_root), and the initial app program counter
-    /// (i.e. initial_pc).
+    /// (i.e. initial_pc_idx).
     pub app_exe_commit: T,
     /// Commit to the app-level verifying key, computed by hashing the cached_commit and
     /// vk_pre_hash components of the app, leaf, and internal-for-leaf vk commits.

--- a/crates/toolchain/instructions/src/phantom.rs
+++ b/crates/toolchain/instructions/src/phantom.rs
@@ -7,7 +7,7 @@ pub struct PhantomDiscriminant(pub u16);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromRepr)]
 #[repr(u16)]
 pub enum SysPhantom {
-    /// Does nothing at constraint and runtime level besides advance pc by
+    /// Does nothing besides advance the circuit pc by one index and the runtime byte pc by
     /// [DEFAULT_PC_STEP](super::program::DEFAULT_PC_STEP).
     Nop = 0,
     /// Causes the runtime to panic, on host machine and prints a backtrace.

--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -11,9 +11,10 @@ use crate::instruction::{DebugInfo, Instruction};
 
 /// Number of bits of a pc *index* (`pc / DEFAULT_PC_STEP`), the representation of the program
 /// counter used in circuits: trace columns, execution/program bus messages, and public values.
-/// Byte program counters span `PC_BITS + PC_STEP_BITS = 32` bits, which does not fit in a 31-bit
-/// field element; since instructions are `DEFAULT_PC_STEP`-aligned, circuits track pc indices.
-pub const PC_BITS: usize = 30;
+/// Byte program counters span `PC_IDX_BITS + PC_STEP_BITS = 32` bits, which does not fit in a
+/// 31-bit field element; since instructions are `DEFAULT_PC_STEP`-aligned, circuits track pc
+/// indices.
+pub const PC_IDX_BITS: usize = 30;
 /// We use default PC step of 4 whenever possible for consistency with RISC-V, where 4 comes
 /// from the fact that each standard RISC-V instruction is 32-bits = 4 bytes.
 pub const DEFAULT_PC_STEP: u32 = 4;
@@ -24,7 +25,7 @@ pub const PC_STEP_BITS: usize = DEFAULT_PC_STEP.trailing_zeros() as usize;
 pub const MAX_ALLOWED_PC: u32 = u32::MAX - (DEFAULT_PC_STEP - 1);
 
 /// Converts a byte program counter (a multiple of [DEFAULT_PC_STEP]) into the pc index used by
-/// circuits. The index fits in [PC_BITS] bits, so it fits in a field element even though byte
+/// circuits. The index fits in [PC_IDX_BITS] bits, so it fits in a field element even though byte
 /// program counters span the full 32-bit range.
 #[inline(always)]
 pub const fn pc_to_idx(pc: u32) -> u32 {
@@ -35,7 +36,7 @@ pub const fn pc_to_idx(pc: u32) -> u32 {
 /// Converts a pc index (see [pc_to_idx]) back into a byte program counter.
 #[inline(always)]
 pub const fn idx_to_pc(idx: u32) -> u32 {
-    debug_assert!(idx < (1 << PC_BITS));
+    debug_assert!(idx < (1 << PC_IDX_BITS));
     idx << PC_STEP_BITS
 }
 

--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -226,8 +226,8 @@ impl ProgramDebugInfo {
     /// If `pc` is out of bounds.
     pub fn get(&self, pc: u32) -> &Option<DebugInfo> {
         let pc_base = self.pc_base;
-        let pc_idx = ((pc - pc_base) / DEFAULT_PC_STEP) as usize;
-        &self.inner[pc_idx]
+        let slot_idx = ((pc - pc_base) / DEFAULT_PC_STEP) as usize;
+        &self.inner[slot_idx]
     }
 }
 

--- a/crates/toolchain/instructions/src/program.rs
+++ b/crates/toolchain/instructions/src/program.rs
@@ -9,11 +9,35 @@ use serde::{de::Deserializer, Deserialize, Serialize, Serializer};
 
 use crate::instruction::{DebugInfo, Instruction};
 
+/// Number of bits of a pc *index* (`pc / DEFAULT_PC_STEP`), the representation of the program
+/// counter used in circuits: trace columns, execution/program bus messages, and public values.
+/// Byte program counters span `PC_BITS + PC_STEP_BITS = 32` bits, which does not fit in a 31-bit
+/// field element; since instructions are `DEFAULT_PC_STEP`-aligned, circuits track pc indices.
 pub const PC_BITS: usize = 30;
 /// We use default PC step of 4 whenever possible for consistency with RISC-V, where 4 comes
 /// from the fact that each standard RISC-V instruction is 32-bits = 4 bytes.
 pub const DEFAULT_PC_STEP: u32 = 4;
-pub const MAX_ALLOWED_PC: u32 = (1 << PC_BITS) - 1;
+/// log2 of [DEFAULT_PC_STEP].
+pub const PC_STEP_BITS: usize = DEFAULT_PC_STEP.trailing_zeros() as usize;
+/// Maximum allowed byte program counter: the last `DEFAULT_PC_STEP`-aligned address in the
+/// 32-bit byte address space.
+pub const MAX_ALLOWED_PC: u32 = u32::MAX - (DEFAULT_PC_STEP - 1);
+
+/// Converts a byte program counter (a multiple of [DEFAULT_PC_STEP]) into the pc index used by
+/// circuits. The index fits in [PC_BITS] bits, so it fits in a field element even though byte
+/// program counters span the full 32-bit range.
+#[inline(always)]
+pub const fn pc_to_idx(pc: u32) -> u32 {
+    debug_assert!(pc.is_multiple_of(DEFAULT_PC_STEP));
+    pc >> PC_STEP_BITS
+}
+
+/// Converts a pc index (see [pc_to_idx]) back into a byte program counter.
+#[inline(always)]
+pub const fn idx_to_pc(idx: u32) -> u32 {
+    debug_assert!(idx < (1 << PC_BITS));
+    idx << PC_STEP_BITS
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Program {

--- a/crates/toolchain/transpiler/src/elf.rs
+++ b/crates/toolchain/transpiler/src/elf.rs
@@ -202,7 +202,7 @@ impl Elf {
         let mut base_address = u32::MAX;
         // Track the end of the last executable segment to detect non-contiguous executable
         // segments.
-        let mut last_exec_end: Option<u32> = None;
+        let mut last_exec_end: Option<u64> = None;
 
         // Collect and sort PT_LOAD segments by virtual address to ensure executable
         // segment contiguity checks are correct regardless of ELF header ordering.
@@ -231,7 +231,7 @@ impl Elf {
             // Track executable segments and reject non-contiguous ones.
             if (segment.p_flags & PF_X) != 0 {
                 if let Some(prev_end) = last_exec_end {
-                    if vaddr != prev_end {
+                    if u64::from(vaddr) != prev_end {
                         bail!(
                             "Non-contiguous executable segments are not supported: \
                              previous segment ended at 0x{prev_end:08x}, \
@@ -243,8 +243,8 @@ impl Elf {
                     base_address = vaddr;
                 }
                 last_exec_end = Some(
-                    vaddr
-                        .checked_add(mem_size)
+                    u64::from(vaddr)
+                        .checked_add(u64::from(mem_size))
                         .ok_or_else(|| eyre::eyre!("executable segment end address overflow"))?,
                 );
             }
@@ -254,14 +254,17 @@ impl Elf {
 
             // Read the segment and decode each word as an instruction.
             for i in (0..mem_size).step_by(ELF_WORD_SIZE) {
-                let addr = vaddr
-                    .checked_add(i)
+                let addr_u64 = u64::from(vaddr)
+                    .checked_add(u64::from(i))
                     .ok_or_else(|| eyre::eyre!("vaddr overflow"))?;
-                if u64::from(addr) >= max_mem {
+                if addr_u64 >= max_mem {
                     bail!(
-                        "address [0x{addr:08x}] exceeds maximum address for guest programs [0x{max_mem:08x}]"
+                        "address [0x{addr_u64:08x}] exceeds maximum address for guest programs [0x{max_mem:08x}]"
                     );
-                } else if addr > MAX_ALLOWED_PC && (segment.p_flags & PF_X) != 0 {
+                }
+                let addr = u32::try_from(addr_u64)
+                    .map_err(|_| eyre::eyre!("address exceeds the u32 guest address space"))?;
+                if addr > MAX_ALLOWED_PC && (segment.p_flags & PF_X) != 0 {
                     bail!("instruction address [0x{addr:08x}] exceeds maximum PC [0x{MAX_ALLOWED_PC:08x}]");
                 }
 
@@ -286,14 +289,15 @@ impl Elf {
             }
         }
 
-        let instruction_bytes = u32::try_from(instructions.len())?
-            .checked_mul(ELF_WORD_SIZE as u32)
+        let instruction_bytes = u64::try_from(instructions.len())?
+            .checked_mul(ELF_WORD_SIZE as u64)
             .context("instruction byte length overflow")?;
-        let program_end = base_address
+        let program_end = u64::from(base_address)
             .checked_add(instruction_bytes)
             .context("program end address overflow")?;
         cfg_block_starts.retain(|pc| {
-            pc.is_multiple_of(ELF_WORD_SIZE as u32) && (base_address..program_end).contains(pc)
+            pc.is_multiple_of(ELF_WORD_SIZE as u32)
+                && (u64::from(base_address)..program_end).contains(&u64::from(*pc))
         });
 
         Ok(Elf::new(
@@ -311,6 +315,50 @@ impl Elf {
 mod tests {
     use super::*;
 
+    fn put_u16(bytes: &mut [u8], offset: usize, value: u16) {
+        bytes[offset..offset + 2].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn put_u32(bytes: &mut [u8], offset: usize, value: u32) {
+        bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn put_u64(bytes: &mut [u8], offset: usize, value: u64) {
+        bytes[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn single_instruction_elf(vaddr: u32, instruction: u32) -> Vec<u8> {
+        const ELF_HEADER_SIZE: usize = 64;
+        const PROGRAM_HEADER_SIZE: u16 = 56;
+        const SEGMENT_OFFSET: usize = 0x1000;
+
+        let mut bytes = vec![0; SEGMENT_OFFSET + ELF_WORD_SIZE];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[4] = 2; // ELFCLASS64
+        bytes[5] = 1; // ELFDATA2LSB
+        bytes[6] = 1; // EV_CURRENT
+        put_u16(&mut bytes, 16, ET_EXEC);
+        put_u16(&mut bytes, 18, EM_RISCV);
+        put_u32(&mut bytes, 20, 1);
+        put_u64(&mut bytes, 24, u64::from(vaddr));
+        put_u64(&mut bytes, 32, ELF_HEADER_SIZE as u64);
+        put_u16(&mut bytes, 52, ELF_HEADER_SIZE as u16);
+        put_u16(&mut bytes, 54, PROGRAM_HEADER_SIZE);
+        put_u16(&mut bytes, 56, 1);
+
+        let ph = ELF_HEADER_SIZE;
+        put_u32(&mut bytes, ph, PT_LOAD);
+        put_u32(&mut bytes, ph + 4, elf::abi::PF_R | PF_X);
+        put_u64(&mut bytes, ph + 8, SEGMENT_OFFSET as u64);
+        put_u64(&mut bytes, ph + 16, u64::from(vaddr));
+        put_u64(&mut bytes, ph + 24, u64::from(vaddr));
+        put_u64(&mut bytes, ph + 32, ELF_WORD_SIZE as u64);
+        put_u64(&mut bytes, ph + 40, ELF_WORD_SIZE as u64);
+        put_u64(&mut bytes, ph + 48, ELF_WORD_SIZE as u64);
+        put_u32(&mut bytes, SEGMENT_OFFSET, instruction);
+        bytes
+    }
+
     #[test]
     fn falls_back_to_function_symbols_without_llvm_map() {
         let bytes = include_bytes!("../../../sdk/programs/examples/fibonacci.elf");
@@ -319,5 +367,17 @@ mod tests {
         assert!(llvm_bb_addr_map::block_starts(&elf).is_empty());
         assert_eq!(cfg_block_starts(&elf), function_symbol_block_starts(&elf));
         assert!(!cfg_block_starts(&elf).is_empty());
+    }
+
+    #[test]
+    fn decodes_instruction_at_maximum_pc() {
+        let instruction = 0x0000_0013;
+        let bytes = single_instruction_elf(MAX_ALLOWED_PC, instruction);
+
+        let elf = Elf::decode(&bytes, 1u64 << 32).unwrap();
+
+        assert_eq!(elf.pc_base, MAX_ALLOWED_PC);
+        assert_eq!(elf.pc_start, MAX_ALLOWED_PC);
+        assert_eq!(elf.instructions, vec![instruction]);
     }
 }

--- a/crates/toolchain/transpiler/src/util.rs
+++ b/crates/toolchain/transpiler/src/util.rs
@@ -4,7 +4,6 @@ use openvm_decoder::instruction_formats::{BType, IType, ITypeShamt, JType, RType
 use openvm_instructions::{
     exe::SparseMemoryImage,
     instruction::{Instruction, InstructionOperand},
-    program::DEFAULT_PC_STEP,
     riscv::{MEMORY_AS, REGISTER_NUM_LIMBS},
     LocalOpcode, SystemOpcode, VmOpcode,
 };
@@ -104,15 +103,15 @@ pub fn from_s_type(opcode: usize, dec_insn: &SType) -> Instruction {
 
 /// Create a new [`Instruction`] from a B-type instruction.
 ///
-/// The branch offset must be `DEFAULT_PC_STEP`-aligned: the circuit represents pc values in
-/// units of `DEFAULT_PC_STEP`, so a misaligned offset has no sound encoding. Without the C
-/// extension, RISC-V branch targets are always 4-byte aligned.
+/// The immediate stays a byte offset; the AIR scales it by `inverse(DEFAULT_PC_STEP)` because
+/// circuit-visible pc values are pc indices. A misaligned offset therefore has no sound
+/// encoding, but it cannot be rejected here: the transpiler decodes every word of `.text`,
+/// including embedded data and never-taken branches that merely *look* like misaligned
+/// branches. Misalignment is enforced where the target is actually used — the interpreter
+/// traps on the misaligned pc and tracegen rejects the row via
+/// `checked_branch_target` — so a misaligned branch that is never taken falls through
+/// normally, exactly as it does on hardware.
 pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
-    assert_eq!(
-        dec_insn.imm % DEFAULT_PC_STEP as i32,
-        0,
-        "branch offset must be a multiple of DEFAULT_PC_STEP"
-    );
     Instruction::new(
         VmOpcode::from_usize(opcode),
         InstructionOperand::from_usize(REGISTER_NUM_LIMBS * dec_insn.rs1),
@@ -127,13 +126,10 @@ pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
 
 /// Create a new [`Instruction`] from a J-type instruction.
 ///
-/// The jump offset must be `DEFAULT_PC_STEP`-aligned; see [`from_b_type`].
+/// The jump offset is a byte offset and is not required to be `DEFAULT_PC_STEP`-aligned here;
+/// see [`from_b_type`]. A misaligned JAL that is actually executed is rejected by the
+/// interpreter and by JAL tracegen ("JAL target outside implemented PC address space").
 pub fn from_j_type(opcode: usize, dec_insn: &JType) -> Instruction {
-    assert_eq!(
-        dec_insn.imm % DEFAULT_PC_STEP as i32,
-        0,
-        "jump offset must be a multiple of DEFAULT_PC_STEP"
-    );
     Instruction::new(
         VmOpcode::from_usize(opcode),
         InstructionOperand::from_usize(REGISTER_NUM_LIMBS * dec_insn.rd),

--- a/crates/toolchain/transpiler/src/util.rs
+++ b/crates/toolchain/transpiler/src/util.rs
@@ -102,15 +102,6 @@ pub fn from_s_type(opcode: usize, dec_insn: &SType) -> Instruction {
 }
 
 /// Create a new [`Instruction`] from a B-type instruction.
-///
-/// The immediate stays a byte offset; the AIR scales it by `inverse(DEFAULT_PC_STEP)` because
-/// circuit-visible pc values are pc indices. A misaligned offset therefore has no sound
-/// encoding, but it cannot be rejected here: the transpiler decodes every word of `.text`,
-/// including embedded data and never-taken branches that merely *look* like misaligned
-/// branches. Misalignment is enforced where the target is actually used — the interpreter
-/// rejects the misaligned pc before instruction dispatch and tracegen rejects the row via
-/// `checked_branch_target` — so a misaligned branch that is never taken falls through
-/// normally, exactly as it does on hardware.
 pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
     Instruction::new(
         VmOpcode::from_usize(opcode),
@@ -125,11 +116,6 @@ pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
 }
 
 /// Create a new [`Instruction`] from a J-type instruction.
-///
-/// The jump offset is a byte offset and is not required to be `DEFAULT_PC_STEP`-aligned here;
-/// see [`from_b_type`]. A misaligned JAL that is actually executed is rejected by the
-/// interpreter before instruction dispatch and by JAL tracegen
-/// ("JAL target outside implemented PC address space").
 pub fn from_j_type(opcode: usize, dec_insn: &JType) -> Instruction {
     Instruction::new(
         VmOpcode::from_usize(opcode),

--- a/crates/toolchain/transpiler/src/util.rs
+++ b/crates/toolchain/transpiler/src/util.rs
@@ -4,6 +4,7 @@ use openvm_decoder::instruction_formats::{BType, IType, ITypeShamt, JType, RType
 use openvm_instructions::{
     exe::SparseMemoryImage,
     instruction::{Instruction, InstructionOperand},
+    program::DEFAULT_PC_STEP,
     riscv::{MEMORY_AS, REGISTER_NUM_LIMBS},
     LocalOpcode, SystemOpcode, VmOpcode,
 };
@@ -102,7 +103,16 @@ pub fn from_s_type(opcode: usize, dec_insn: &SType) -> Instruction {
 }
 
 /// Create a new [`Instruction`] from a B-type instruction.
+///
+/// The branch offset must be `DEFAULT_PC_STEP`-aligned: the circuit represents pc values in
+/// units of `DEFAULT_PC_STEP`, so a misaligned offset has no sound encoding. Without the C
+/// extension, RISC-V branch targets are always 4-byte aligned.
 pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
+    assert_eq!(
+        dec_insn.imm % DEFAULT_PC_STEP as i32,
+        0,
+        "branch offset must be a multiple of DEFAULT_PC_STEP"
+    );
     Instruction::new(
         VmOpcode::from_usize(opcode),
         InstructionOperand::from_usize(REGISTER_NUM_LIMBS * dec_insn.rs1),
@@ -116,7 +126,14 @@ pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
 }
 
 /// Create a new [`Instruction`] from a J-type instruction.
+///
+/// The jump offset must be `DEFAULT_PC_STEP`-aligned; see [`from_b_type`].
 pub fn from_j_type(opcode: usize, dec_insn: &JType) -> Instruction {
+    assert_eq!(
+        dec_insn.imm % DEFAULT_PC_STEP as i32,
+        0,
+        "jump offset must be a multiple of DEFAULT_PC_STEP"
+    );
     Instruction::new(
         VmOpcode::from_usize(opcode),
         InstructionOperand::from_usize(REGISTER_NUM_LIMBS * dec_insn.rd),

--- a/crates/toolchain/transpiler/src/util.rs
+++ b/crates/toolchain/transpiler/src/util.rs
@@ -108,7 +108,7 @@ pub fn from_s_type(opcode: usize, dec_insn: &SType) -> Instruction {
 /// encoding, but it cannot be rejected here: the transpiler decodes every word of `.text`,
 /// including embedded data and never-taken branches that merely *look* like misaligned
 /// branches. Misalignment is enforced where the target is actually used — the interpreter
-/// traps on the misaligned pc and tracegen rejects the row via
+/// rejects the misaligned pc before instruction dispatch and tracegen rejects the row via
 /// `checked_branch_target` — so a misaligned branch that is never taken falls through
 /// normally, exactly as it does on hardware.
 pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
@@ -128,7 +128,8 @@ pub fn from_b_type(opcode: usize, dec_insn: &BType) -> Instruction {
 ///
 /// The jump offset is a byte offset and is not required to be `DEFAULT_PC_STEP`-aligned here;
 /// see [`from_b_type`]. A misaligned JAL that is actually executed is rejected by the
-/// interpreter and by JAL tracegen ("JAL target outside implemented PC address space").
+/// interpreter before instruction dispatch and by JAL tracegen
+/// ("JAL target outside implemented PC address space").
 pub fn from_j_type(opcode: usize, dec_insn: &JType) -> Instruction {
     Instruction::new(
         VmOpcode::from_usize(opcode),

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -114,7 +114,7 @@ pub fn verify_vm_stark_proof_pvs(
 
     let &VmPvs::<F> {
         program_commit,
-        initial_pc,
+        initial_pc_idx,
         exit_code,
         is_terminate,
         initial_root,
@@ -139,7 +139,7 @@ pub fn verify_vm_stark_proof_pvs(
 
     // Check that the app_commit is as expected.
     let claimed_app_exe_commit =
-        compute_exe_commit(&hasher, &program_commit, &initial_root, initial_pc);
+        compute_exe_commit(&hasher, &program_commit, &initial_root, initial_pc_idx);
     if claimed_app_exe_commit != vk.baseline.app_exe_commit {
         return Err(VerifyStarkError::AppExeCommitMismatch {
             expected: vk.baseline.app_exe_commit,

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -83,9 +83,9 @@ pub struct VmPvs<F> {
     //////////////////////////////////////////////////////////////////////
     /// CONNECTOR PVS
     //////////////////////////////////////////////////////////////////////
-    /// Starting PC value of the program (or segment) run.
+    /// Starting circuit pc index of the program (or segment) run.
     pub initial_pc: F,
-    /// Final PC value of the program (or segment) run.
+    /// Final circuit pc index of the program (or segment) run.
     pub final_pc: F,
     /// Exit code of the program run.
     pub exit_code: F,

--- a/crates/verify/src/pvs.rs
+++ b/crates/verify/src/pvs.rs
@@ -83,10 +83,10 @@ pub struct VmPvs<F> {
     //////////////////////////////////////////////////////////////////////
     /// CONNECTOR PVS
     //////////////////////////////////////////////////////////////////////
-    /// Starting circuit pc index of the program (or segment) run.
-    pub initial_pc: F,
-    /// Final circuit pc index of the program (or segment) run.
-    pub final_pc: F,
+    /// Starting circuit PC index of the program (or segment) run.
+    pub initial_pc_idx: F,
+    /// Final circuit PC index of the program (or segment) run.
+    pub final_pc_idx: F,
     /// Exit code of the program run.
     pub exit_code: F,
     /// Boolean flag to determine whether or not this segment terminated the program.

--- a/crates/vm/cuda/include/system/program.cuh
+++ b/crates/vm/cuda/include/system/program.cuh
@@ -1,7 +1,7 @@
 #pragma once
 
 template <typename T> struct ProgramExecutionCols {
-    T pc;
+    T pc_idx;
     T opcode;
     T a;
     T b;

--- a/crates/vm/cuda/rvr/include/arch/rvr/replay.cuh
+++ b/crates/vm/cuda/rvr/include/arch/rvr/replay.cuh
@@ -32,6 +32,31 @@ static constexpr __host__ __device__ bool replay_canonical_register_pointer(uint
     return pointer < 32u * 8u && (pointer & 7u) == 0;
 }
 
+// Decodes the canonical field encoding of a signed byte pc offset (negatives are encoded as
+// p - |offset|).
+static constexpr __host__ __device__ int64_t replay_decode_signed_pc_offset(uint32_t encoded) {
+    constexpr uint32_t FIELD_ORDER = 2013265921u; // BabyBear
+    return encoded > FIELD_ORDER / 2 ? int64_t(encoded) - int64_t(FIELD_ORDER)
+                                     : int64_t(encoded);
+}
+
+// Byte target of a taken branch/jump, wrapping like the host interpreter.
+static constexpr __host__ __device__ uint32_t replay_taken_branch_pc(
+    uint32_t pc, uint32_t encoded
+) {
+    return uint32_t(int64_t(pc) + replay_decode_signed_pc_offset(encoded));
+}
+
+// True if a taken branch/jump from byte pc `pc` lands inside the implemented PC address space
+// on a DEFAULT_PC_STEP-aligned slot.
+static constexpr __host__ __device__ bool replay_branch_target_in_bounds(
+    uint32_t pc, uint32_t encoded
+) {
+    int64_t target = int64_t(pc) + replay_decode_signed_pc_offset(encoded);
+    return target >= 0 && target <= int64_t(::program::MAX_ALLOWED_PC) &&
+           target % int64_t(::program::DEFAULT_PC_STEP) == 0;
+}
+
 static_assert(replay_canonical_register_pointer(0));
 static_assert(replay_canonical_register_pointer(31u * 8u));
 static_assert(!replay_canonical_register_pointer(2));

--- a/crates/vm/cuda/src/system/phantom.cu
+++ b/crates/vm/cuda/src/system/phantom.cu
@@ -64,7 +64,7 @@ __global__ void phantom_replay_tracegen(
     uint32_t operands[NUM_PHANTOM_OPERANDS] = {
         instruction.words[1], instruction.words[2], instruction.words[3], instruction.words[4]
     };
-    COL_WRITE_VALUE(row, PhantomCols, pc, from.pc);
+    COL_WRITE_VALUE(row, PhantomCols, pc, ::program::pc_to_idx(from.pc));
     COL_WRITE_ARRAY(row, PhantomCols, operands, operands);
     COL_WRITE_VALUE(row, PhantomCols, timestamp, from.timestamp);
     COL_WRITE_VALUE(row, PhantomCols, is_valid, Fp::one());

--- a/crates/vm/cuda/src/system/phantom.cu
+++ b/crates/vm/cuda/src/system/phantom.cu
@@ -4,7 +4,7 @@
 static constexpr uint32_t NUM_PHANTOM_OPERANDS = 4;
 
 template <typename T> struct PhantomCols {
-    T pc;
+    T pc_idx;
     T operands[NUM_PHANTOM_OPERANDS];
     T timestamp;
     T is_valid;
@@ -64,7 +64,7 @@ __global__ void phantom_replay_tracegen(
     uint32_t operands[NUM_PHANTOM_OPERANDS] = {
         instruction.words[1], instruction.words[2], instruction.words[3], instruction.words[4]
     };
-    COL_WRITE_VALUE(row, PhantomCols, pc, ::program::pc_to_idx(from.pc));
+    COL_WRITE_VALUE(row, PhantomCols, pc_idx, ::program::pc_to_idx(from.pc));
     COL_WRITE_ARRAY(row, PhantomCols, operands, operands);
     COL_WRITE_VALUE(row, PhantomCols, timestamp, from.timestamp);
     COL_WRITE_VALUE(row, PhantomCols, is_valid, Fp::one());

--- a/crates/vm/cuda/src/system/program.cu
+++ b/crates/vm/cuda/src/system/program.cu
@@ -19,7 +19,7 @@ __global__ void program_cached_tracegen(
     RowSlice row(trace + idx, height);
     if (idx < records.len()) {
         auto const &rec = records[idx];
-        COL_WRITE_VALUE(row, ProgramExecutionCols, pc, rec.pc);
+        COL_WRITE_VALUE(row, ProgramExecutionCols, pc_idx, rec.pc_idx);
         COL_WRITE_VALUE(row, ProgramExecutionCols, opcode, rec.opcode);
         COL_WRITE_VALUE(row, ProgramExecutionCols, a, rec.a);
         COL_WRITE_VALUE(row, ProgramExecutionCols, b, rec.b);
@@ -29,8 +29,8 @@ __global__ void program_cached_tracegen(
         COL_WRITE_VALUE(row, ProgramExecutionCols, f, rec.f);
         COL_WRITE_VALUE(row, ProgramExecutionCols, g, rec.g);
     } else {
-        // The pc column contains pc indices; records are already converted host-side.
-        COL_WRITE_VALUE(row, ProgramExecutionCols, pc, program::pc_to_idx(pc_base) + idx);
+        // Records use PC indices; byte PCs do not fit in the proof field.
+        COL_WRITE_VALUE(row, ProgramExecutionCols, pc_idx, program::pc_to_idx(pc_base) + idx);
         COL_WRITE_VALUE(row, ProgramExecutionCols, opcode, terminate_opcode);
         COL_WRITE_VALUE(row, ProgramExecutionCols, a, Fp::zero());
         COL_WRITE_VALUE(row, ProgramExecutionCols, b, Fp::zero());

--- a/crates/vm/cuda/src/system/program.cu
+++ b/crates/vm/cuda/src/system/program.cu
@@ -29,7 +29,8 @@ __global__ void program_cached_tracegen(
         COL_WRITE_VALUE(row, ProgramExecutionCols, f, rec.f);
         COL_WRITE_VALUE(row, ProgramExecutionCols, g, rec.g);
     } else {
-        COL_WRITE_VALUE(row, ProgramExecutionCols, pc, pc_base + (idx * program::DEFAULT_PC_STEP));
+        // The pc column contains pc indices; records are already converted host-side.
+        COL_WRITE_VALUE(row, ProgramExecutionCols, pc, program::pc_to_idx(pc_base) + idx);
         COL_WRITE_VALUE(row, ProgramExecutionCols, opcode, terminate_opcode);
         COL_WRITE_VALUE(row, ProgramExecutionCols, a, Fp::zero());
         COL_WRITE_VALUE(row, ProgramExecutionCols, b, Fp::zero());

--- a/crates/vm/cuda/src/testing/program.cu
+++ b/crates/vm/cuda/src/testing/program.cu
@@ -14,7 +14,7 @@ __global__ void program_testing_tracegen(
     RowSlice row(trace + idx, height);
     if (idx < num_records) {
         auto record = reinterpret_cast<ProgramExecutionCols<Fp> *>(records)[idx];
-        COL_WRITE_VALUE(row, ProgramExecutionCols, pc, record.pc);
+        COL_WRITE_VALUE(row, ProgramExecutionCols, pc_idx, record.pc_idx);
         COL_WRITE_VALUE(row, ProgramExecutionCols, opcode, record.opcode);
         COL_WRITE_VALUE(row, ProgramExecutionCols, a, record.a);
         COL_WRITE_VALUE(row, ProgramExecutionCols, b, record.b);

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -280,7 +280,7 @@ pub struct ExecutionBridgeInteractor<AB: InteractionBuilder> {
     to_state: ExecutionState<AB::Expr>,
 }
 
-pub enum PcIncOrSet<T> {
+pub enum PcIdxIncOrSet<T> {
     Inc(T),
     Set(T),
 }
@@ -317,7 +317,7 @@ impl<T> ExecutionState<T> {
 
 impl ExecutionBus {
     /// Caller must constrain that `enabled` is boolean.
-    pub fn execute_and_increment_pc<AB: InteractionBuilder>(
+    pub fn execute_and_increment_pc_idx<AB: InteractionBuilder>(
         &self,
         builder: &mut AB,
         enabled: impl Into<AB::Expr>,
@@ -363,18 +363,18 @@ impl ExecutionBridge {
 
     /// If `to_pc_idx` is `Some`, then `pc_idx_inc` is ignored and `to_state` uses `to_pc_idx`.
     /// Otherwise `to_pc_idx = from_pc_idx + pc_idx_inc`.
-    pub fn execute_and_increment_or_set_pc<AB: InteractionBuilder>(
+    pub fn execute_and_increment_or_set_pc_idx<AB: InteractionBuilder>(
         &self,
         opcode: impl Into<AB::Expr>,
         operands: impl IntoIterator<Item = impl Into<AB::Expr>>,
         from_state: ExecutionState<impl Into<AB::Expr> + Clone>,
         timestamp_change: impl Into<AB::Expr>,
-        pc_kind: impl Into<PcIncOrSet<AB::Expr>>,
+        pc_idx_kind: impl Into<PcIdxIncOrSet<AB::Expr>>,
     ) -> ExecutionBridgeInteractor<AB> {
         let to_state = ExecutionState {
-            pc: match pc_kind.into() {
-                PcIncOrSet::Set(to_pc_idx) => to_pc_idx,
-                PcIncOrSet::Inc(pc_idx_inc) => from_state.pc.clone().into() + pc_idx_inc,
+            pc: match pc_idx_kind.into() {
+                PcIdxIncOrSet::Set(to_pc_idx) => to_pc_idx,
+                PcIdxIncOrSet::Inc(pc_idx_inc) => from_state.pc.clone().into() + pc_idx_inc,
             },
             timestamp: from_state.timestamp.clone().into() + timestamp_change.into(),
         };
@@ -383,7 +383,7 @@ impl ExecutionBridge {
 
     /// The `pc` in [ExecutionState] is a pc index (see `pc_to_idx`), so advancing to the next
     /// instruction increments it by one.
-    pub fn execute_and_increment_pc<AB: InteractionBuilder>(
+    pub fn execute_and_increment_pc_idx<AB: InteractionBuilder>(
         &self,
         opcode: impl Into<AB::Expr>,
         operands: impl IntoIterator<Item = impl Into<AB::Expr>>,
@@ -434,11 +434,11 @@ impl<AB: InteractionBuilder> ExecutionBridgeInteractor<AB> {
     }
 }
 
-impl<T: PrimeCharacteristicRing> From<(u32, Option<T>)> for PcIncOrSet<T> {
+impl<T: PrimeCharacteristicRing> From<(u32, Option<T>)> for PcIdxIncOrSet<T> {
     fn from((pc_idx_inc, to_pc_idx): (u32, Option<T>)) -> Self {
         match to_pc_idx {
-            None => PcIncOrSet::Inc(T::from_u32(pc_idx_inc)),
-            Some(to_pc_idx) => PcIncOrSet::Set(to_pc_idx),
+            None => PcIdxIncOrSet::Inc(T::from_u32(pc_idx_inc)),
+            Some(to_pc_idx) => PcIdxIncOrSet::Set(to_pc_idx),
         }
     }
 }

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -237,6 +237,11 @@ pub struct E2PreCompute<DATA> {
 #[derive(
     Clone, Copy, Debug, PartialEq, Default, AlignedBorrow, StructReflection, Serialize, Deserialize,
 )]
+/// An execution state shared by runtime and circuit code.
+///
+/// In runtime and replay code, `pc` is an architectural byte address. In AIR columns and bus
+/// messages, `pc` is the circuit pc index returned by `pc_to_idx`. The field keeps the generic
+/// name because this type is used at both boundaries.
 pub struct ExecutionState<T> {
     pub pc: T,
     pub timestamp: T,
@@ -356,8 +361,8 @@ impl ExecutionBridge {
         }
     }
 
-    /// If `to_pc` is `Some`, then `pc_inc` is ignored and the `to_state` uses `to_pc`. Otherwise
-    /// `to_pc = from_pc + pc_inc`.
+    /// If `to_pc_idx` is `Some`, then `pc_idx_inc` is ignored and `to_state` uses `to_pc_idx`.
+    /// Otherwise `to_pc_idx = from_pc_idx + pc_idx_inc`.
     pub fn execute_and_increment_or_set_pc<AB: InteractionBuilder>(
         &self,
         opcode: impl Into<AB::Expr>,
@@ -368,8 +373,8 @@ impl ExecutionBridge {
     ) -> ExecutionBridgeInteractor<AB> {
         let to_state = ExecutionState {
             pc: match pc_kind.into() {
-                PcIncOrSet::Set(to_pc) => to_pc,
-                PcIncOrSet::Inc(pc_inc) => from_state.pc.clone().into() + pc_inc,
+                PcIncOrSet::Set(to_pc_idx) => to_pc_idx,
+                PcIncOrSet::Inc(pc_idx_inc) => from_state.pc.clone().into() + pc_idx_inc,
             },
             timestamp: from_state.timestamp.clone().into() + timestamp_change.into(),
         };
@@ -430,10 +435,10 @@ impl<AB: InteractionBuilder> ExecutionBridgeInteractor<AB> {
 }
 
 impl<T: PrimeCharacteristicRing> From<(u32, Option<T>)> for PcIncOrSet<T> {
-    fn from((pc_inc, to_pc): (u32, Option<T>)) -> Self {
-        match to_pc {
-            None => PcIncOrSet::Inc(T::from_u32(pc_inc)),
-            Some(to_pc) => PcIncOrSet::Set(to_pc),
+    fn from((pc_idx_inc, to_pc_idx): (u32, Option<T>)) -> Self {
+        match to_pc_idx {
+            None => PcIncOrSet::Inc(T::from_u32(pc_idx_inc)),
+            Some(to_pc_idx) => PcIncOrSet::Set(to_pc_idx),
         }
     }
 }

--- a/crates/vm/src/arch/execution.rs
+++ b/crates/vm/src/arch/execution.rs
@@ -1,8 +1,6 @@
 use openvm_circuit_primitives::{AlignedBytesBorrow, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    instruction::Instruction, program::DEFAULT_PC_STEP, PhantomDiscriminant, VmOpcode,
-};
+use openvm_instructions::{instruction::Instruction, PhantomDiscriminant, VmOpcode};
 use openvm_stark_backend::{
     interaction::{BusIndex, InteractionBuilder, PermutationCheckBus},
     p3_field::PrimeCharacteristicRing,
@@ -378,6 +376,8 @@ impl ExecutionBridge {
         self.execute(opcode, operands, from_state, to_state)
     }
 
+    /// The `pc` in [ExecutionState] is a pc index (see `pc_to_idx`), so advancing to the next
+    /// instruction increments it by one.
     pub fn execute_and_increment_pc<AB: InteractionBuilder>(
         &self,
         opcode: impl Into<AB::Expr>,
@@ -386,7 +386,7 @@ impl ExecutionBridge {
         timestamp_change: impl Into<AB::Expr>,
     ) -> ExecutionBridgeInteractor<AB> {
         let to_state = ExecutionState {
-            pc: from_state.pc.clone().into() + AB::Expr::from_u32(DEFAULT_PC_STEP),
+            pc: from_state.pc.clone().into() + AB::Expr::ONE,
             timestamp: from_state.timestamp.clone().into() + timestamp_change.into(),
         };
         self.execute(opcode, operands, from_state, to_state)
@@ -440,7 +440,7 @@ impl<T: PrimeCharacteristicRing> From<(u32, Option<T>)> for PcIncOrSet<T> {
 
 /// Phantom sub-instructions affect the runtime of the VM and the trace matrix values.
 /// However they all have no AIR constraints besides advancing the pc by
-/// [DEFAULT_PC_STEP].
+/// [`DEFAULT_PC_STEP`](openvm_instructions::program::DEFAULT_PC_STEP) bytes (one pc index).
 ///
 /// They should not mutate memory, but they can mutate the input & hint streams.
 ///

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -80,7 +80,8 @@ where
 }
 
 pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
-    /// Leave as `None` to allow the adapter to decide the `to_pc` automatically.
+    /// Circuit pc index after this instruction. Leave as `None` to allow the adapter to choose
+    /// the next index automatically.
     pub to_pc: Option<T>,
     pub reads: I::Reads,
     pub writes: I::Writes,

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -43,7 +43,7 @@ pub trait VmAdapterAir<AB: AirBuilder>: BaseAir<AB::F> {
     );
 
     /// Return the expression for the pc index (`pc_to_idx(from_pc)`) of the instruction.
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var;
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var;
 }
 
 pub trait VmCoreAir<AB, I>: BaseAirWithPublicValues<AB::F>
@@ -51,9 +51,7 @@ where
     AB: AirBuilder,
     I: VmAdapterInterface<AB::Expr>,
 {
-    /// Returns `(to_pc, interface)`. Pc values on the buses are pc indices (see `pc_to_idx`):
-    /// `from_pc_idx` is the pc index of the instruction, and the returned `to_pc` is also a
-    /// pc index.
+    /// Returns `(to_pc_idx, interface)`. PC values on the buses are PC indices (see `pc_to_idx`).
     fn eval(
         &self,
         builder: &mut AB,
@@ -80,9 +78,9 @@ where
 }
 
 pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
-    /// Circuit pc index after this instruction. Leave as `None` to allow the adapter to choose
+    /// Circuit PC index after this instruction. Leave as `None` to allow the adapter to choose
     /// the next index automatically.
-    pub to_pc: Option<T>,
+    pub to_pc_idx: Option<T>,
     pub reads: I::Reads,
     pub writes: I::Writes,
     pub instruction: I::ProcessedInstruction,
@@ -155,9 +153,11 @@ where
         let local: &[AB::Var] = (*local).borrow();
         let (local_adapter, local_core) = local.split_at(self.adapter.width());
 
-        let ctx = self
-            .core
-            .eval(builder, local_core, self.adapter.get_from_pc(local_adapter));
+        let ctx = self.core.eval(
+            builder,
+            local_core,
+            self.adapter.get_from_pc_idx(local_adapter),
+        );
         self.adapter.eval(builder, local_adapter, ctx);
     }
 }
@@ -353,7 +353,7 @@ mod conversions {
             >,
         ) -> Self {
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads: ctx.reads.into(),
                 writes: ctx.writes.into(),
                 instruction: ctx.instruction.into(),
@@ -384,7 +384,7 @@ mod conversions {
     {
         fn from(ctx: AdapterAirContext<T, DynAdapterInterface<T>>) -> Self {
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads: ctx.reads.into(),
                 writes: ctx.writes.into(),
                 instruction: ctx.instruction.into(),
@@ -457,7 +457,7 @@ mod conversions {
             let mut writes_it = ctx.writes.into_iter();
             let writes = from_fn(|_| writes_it.next().unwrap());
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads,
                 writes,
                 instruction: ctx.instruction.into(),
@@ -506,7 +506,7 @@ mod conversions {
             let mut writes_it = ctx.writes.into_iter().flatten();
             let writes = from_fn(|_| writes_it.next().unwrap());
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads,
                 writes,
                 instruction: ctx.instruction,
@@ -534,7 +534,7 @@ mod conversions {
         /// If `READ_CELLS != NUM_READS * READ_SIZE` or `WRITE_CELLS != NUM_WRITES * WRITE_SIZE`.
         fn from(
             AdapterAirContext {
-                to_pc,
+                to_pc_idx,
                 reads,
                 writes,
                 instruction,
@@ -560,7 +560,7 @@ mod conversions {
             let writes: [[T; WRITE_SIZE]; NUM_WRITES] =
                 from_fn(|_| from_fn(|_| writes_it.next().unwrap()));
             AdapterAirContext {
-                to_pc,
+                to_pc_idx,
                 reads,
                 writes,
                 instruction,
@@ -671,7 +671,7 @@ mod conversions {
             >,
         ) -> Self {
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads: ctx.reads.into(),
                 writes: ctx.writes.into(),
                 instruction: ctx.instruction.into(),
@@ -697,7 +697,7 @@ mod conversions {
     {
         fn from(ctx: AdapterAirContext<T, DynAdapterInterface<T>>) -> Self {
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads: ctx.reads.into(),
                 writes: ctx.writes.into(),
                 instruction: ctx.instruction.into(),
@@ -712,7 +712,7 @@ mod conversions {
     {
         fn from(ctx: AdapterAirContext<T, FlatInterface<T, PI, READ_CELLS, WRITE_CELLS>>) -> Self {
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads: ctx.reads.to_vec().into(),
                 writes: ctx.writes.to_vec().into(),
                 instruction: ctx.instruction.into(),
@@ -791,7 +791,7 @@ mod conversions {
             let mut reads_it = ctx.reads.into_iter();
             let reads = from_fn(|_| from_fn(|_| reads_it.next().unwrap()));
             AdapterAirContext {
-                to_pc: ctx.to_pc,
+                to_pc_idx: ctx.to_pc_idx,
                 reads,
                 writes: (),
                 instruction: ctx.instruction,

--- a/crates/vm/src/arch/integration_api.rs
+++ b/crates/vm/src/arch/integration_api.rs
@@ -42,7 +42,7 @@ pub trait VmAdapterAir<AB: AirBuilder>: BaseAir<AB::F> {
         interface: AdapterAirContext<AB::Expr, Self::Interface>,
     );
 
-    /// Return the `from_pc` expression.
+    /// Return the expression for the pc index (`pc_to_idx(from_pc)`) of the instruction.
     fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var;
 }
 
@@ -51,12 +51,14 @@ where
     AB: AirBuilder,
     I: VmAdapterInterface<AB::Expr>,
 {
-    /// Returns `(to_pc, interface)`.
+    /// Returns `(to_pc, interface)`. Pc values on the buses are pc indices (see `pc_to_idx`):
+    /// `from_pc_idx` is the pc index of the instruction, and the returned `to_pc` is also a
+    /// pc index.
     fn eval(
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I>;
 
     /// The offset the opcodes by this chip start from.

--- a/crates/vm/src/arch/interpreter/mod.rs
+++ b/crates/vm/src/arch/interpreter/mod.rs
@@ -1,20 +1,19 @@
 use std::{
     alloc::{alloc, dealloc, handle_alloc_error, Layout},
     borrow::{Borrow, BorrowMut},
-    iter::repeat_n,
     ptr::NonNull,
 };
 
 use itertools::Itertools;
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
-#[cfg(test)]
-use openvm_instructions::instruction::InstructionOperand;
 use openvm_instructions::{
     exe::{SparseMemoryImage, VmExe},
     instruction::Instruction,
     program::{Program, DEFAULT_PC_STEP},
     LocalOpcode, SystemOpcode,
 };
+#[cfg(test)]
+use openvm_instructions::{instruction::InstructionOperand, program::MAX_ALLOWED_PC};
 use openvm_stark_backend::p3_field::PrimeField32;
 
 #[cfg(test)]
@@ -44,9 +43,7 @@ pub struct InterpretedInstance<'a, Ctx> {
     #[allow(dead_code)]
     pre_compute_buf: AlignedBuf,
     /// Instruction table of function pointers and pointers to the pre-computed buffer. Indexed by
-    /// `pc_index = pc / DEFAULT_PC_STEP`.
-    /// SAFETY: The first `pc_base / DEFAULT_PC_STEP` entries will be unreachable. We do this to
-    /// avoid needing to subtract `pc_base` during runtime.
+    /// the instruction slot `(pc - pc_base) / DEFAULT_PC_STEP`.
     #[cfg(not(feature = "tco"))]
     pre_compute_insns: Vec<PreComputeInstruction<Ctx>>,
     #[cfg(feature = "tco")]
@@ -55,6 +52,7 @@ pub struct InterpretedInstance<'a, Ctx> {
     #[cfg(feature = "tco")]
     handlers: Vec<Handler<Ctx>>,
 
+    pc_base: u32,
     pc_start: u32,
 
     init_memory: SparseMemoryImage,
@@ -88,6 +86,7 @@ macro_rules! run {
                     $crate::arch::interpreter::execute_trampoline(
                         &mut $exec_state,
                         &$interpreter.pre_compute_insns,
+                        $interpreter.pc_base,
                     );
                 }
             }
@@ -155,14 +154,15 @@ where
         let pc_start = exe.pc_start;
         let init_memory = exe.init_memory.clone();
         #[cfg(feature = "tco")]
-        let handlers = repeat_n(&None, get_pc_index(program.pc_base))
-            .chain(program.instructions_and_debug_infos.iter())
+        let handlers = program
+            .instructions_and_debug_infos
+            .iter()
             .zip_eq(split_pre_compute_buf.iter_mut())
             .enumerate()
             .map(
-                |(pc_idx, (inst_opt, pre_compute))| -> Result<Handler<Ctx>, StaticProgramError> {
+                |(slot, (inst_opt, pre_compute))| -> Result<Handler<Ctx>, StaticProgramError> {
                     if let Some((inst, _)) = inst_opt {
-                        let pc = pc_idx as u32 * DEFAULT_PC_STEP;
+                        let pc = program.pc_base + slot as u32 * DEFAULT_PC_STEP;
                         if get_system_opcode_handler::<Ctx>(pc, inst, pre_compute)?.is_some() {
                             Ok(terminate_execute_tco_handler)
                         } else {
@@ -183,6 +183,7 @@ where
             pre_compute_buf,
             #[cfg(not(feature = "tco"))]
             pre_compute_insns,
+            pc_base: program.pc_base,
             pc_start,
             init_memory,
             #[cfg(feature = "tco")]
@@ -204,28 +205,28 @@ where
     #[cfg(feature = "tco")]
     #[inline(always)]
     pub fn get_pre_compute(&self, pc: u32) -> *const u8 {
-        let pc_idx = get_pc_index(pc);
+        debug_assert!(pc >= self.pc_base);
+        debug_assert!((pc - self.pc_base).is_multiple_of(DEFAULT_PC_STEP));
+        let slot = get_pc_index(pc.wrapping_sub(self.pc_base));
         // SAFETY:
         // - we assume that pc is in bounds
         // - pre_compute_buf is allocated for pre_compute_max_size * program_len bytes, with each
         //   instruction getting pre_compute_max_size bytes
         // - self.pre_compute_buf.ptr is non-null
         // - initialization of the contents of the slice is the responsibility of each Executor
-        debug_assert!(
-            (pc_idx + 1) * self.pre_compute_max_size <= self.pre_compute_buf.layout.size()
-        );
+        debug_assert!((slot + 1) * self.pre_compute_max_size <= self.pre_compute_buf.layout.size());
         unsafe {
             self.pre_compute_buf
                 .ptr
-                .add(pc_idx * self.pre_compute_max_size)
+                .add(slot * self.pre_compute_max_size)
         }
     }
 
     #[cfg(feature = "tco")]
     #[inline(always)]
     pub fn get_handler(&self, pc: u32) -> Option<Handler<Ctx>> {
-        let pc_idx = checked_pc_index(pc)?;
-        self.handlers.get(pc_idx).copied()
+        let slot = checked_program_slot(pc, self.pc_base)?;
+        self.handlers.get(slot).copied()
     }
 }
 
@@ -259,14 +260,15 @@ where
         let pc_start = exe.pc_start;
         let init_memory = exe.init_memory.clone();
         #[cfg(feature = "tco")]
-        let handlers = repeat_n(&None, get_pc_index(program.pc_base))
-            .chain(program.instructions_and_debug_infos.iter())
+        let handlers = program
+            .instructions_and_debug_infos
+            .iter()
             .zip_eq(split_pre_compute_buf.iter_mut())
             .enumerate()
             .map(
-                |(pc_idx, (inst_opt, pre_compute))| -> Result<Handler<Ctx>, StaticProgramError> {
+                |(slot, (inst_opt, pre_compute))| -> Result<Handler<Ctx>, StaticProgramError> {
                     if let Some((inst, _)) = inst_opt {
-                        let pc = pc_idx as u32 * DEFAULT_PC_STEP;
+                        let pc = program.pc_base + slot as u32 * DEFAULT_PC_STEP;
                         if get_system_opcode_handler::<Ctx>(pc, inst, pre_compute)?.is_some() {
                             Ok(terminate_execute_tco_handler)
                         } else {
@@ -289,6 +291,7 @@ where
             pre_compute_buf,
             #[cfg(not(feature = "tco"))]
             pre_compute_insns,
+            pc_base: program.pc_base,
             pc_start,
             init_memory,
             #[cfg(feature = "tco")]
@@ -300,9 +303,7 @@ where
 }
 
 pub(crate) fn alloc_pre_compute_buf(program: &Program, pre_compute_max_size: usize) -> AlignedBuf {
-    let base_idx = get_pc_index(program.pc_base);
-    let padded_program_len = base_idx + program.instructions_and_debug_infos.len();
-    let buf_len = padded_program_len * pre_compute_max_size;
+    let buf_len = program.instructions_and_debug_infos.len() * pre_compute_max_size;
     AlignedBuf::uninit(buf_len, pre_compute_max_size)
 }
 
@@ -311,9 +312,7 @@ pub(crate) fn split_pre_compute_buf<'a>(
     pre_compute_buf: &'a mut AlignedBuf,
     pre_compute_max_size: usize,
 ) -> Vec<&'a mut [u8]> {
-    let base_idx = get_pc_index(program.pc_base);
-    let padded_program_len = base_idx + program.instructions_and_debug_infos.len();
-    let buf_len = padded_program_len * pre_compute_max_size;
+    let buf_len = program.instructions_and_debug_infos.len() * pre_compute_max_size;
     // SAFETY:
     // - pre_compute_buf.ptr was allocated with exactly buf_len bytes
     // - lifetime 'a ensures the returned slices don't outlive the AlignedBuf
@@ -332,6 +331,7 @@ pub(crate) fn split_pre_compute_buf<'a>(
 unsafe fn execute_trampoline<Ctx: ExecutionCtxTrait>(
     exec_state: &mut VmExecState<GuestMemory, Ctx>,
     fn_ptrs: &[PreComputeInstruction<Ctx>],
+    pc_base: u32,
 ) {
     while exec_state
         .exit_code
@@ -344,12 +344,12 @@ unsafe fn execute_trampoline<Ctx: ExecutionCtxTrait>(
         }
         let pc = exec_state.pc();
         Ctx::on_instruction_start(exec_state, pc);
-        let Some(pc_index) = checked_pc_index(pc) else {
+        let Some(slot) = checked_program_slot(pc, pc_base) else {
             exec_state.exit_code = Err(ExecutionError::PcOutOfBounds(pc));
             break;
         };
 
-        if let Some(inst) = fn_ptrs.get(pc_index) {
+        if let Some(inst) = fn_ptrs.get(slot) {
             // SAFETY: pre_compute assumed to live long enough
             unsafe { (inst.handler)(inst.pre_compute, exec_state) };
         } else {
@@ -364,8 +364,11 @@ pub fn get_pc_index(pc: u32) -> usize {
 }
 
 #[inline(always)]
-fn checked_pc_index(pc: u32) -> Option<usize> {
-    pc.is_multiple_of(DEFAULT_PC_STEP).then(|| get_pc_index(pc))
+fn checked_program_slot(pc: u32, pc_base: u32) -> Option<usize> {
+    let delta = pc.checked_sub(pc_base)?;
+    delta
+        .is_multiple_of(DEFAULT_PC_STEP)
+        .then(|| get_pc_index(delta))
 }
 
 /// Bytes allocated according to the given Layout.
@@ -514,8 +517,9 @@ where
         exec_state.exit_code = Err(ExecutionError::Unreachable(exec_state.pc()));
     };
 
-    repeat_n(&None, get_pc_index(program.pc_base))
-        .chain(program.instructions_and_debug_infos.iter())
+    program
+        .instructions_and_debug_infos
+        .iter()
         .zip_eq(pre_compute.iter_mut())
         .enumerate()
         .map(|(i, (inst_opt, buf))| {
@@ -526,7 +530,7 @@ where
             let buf: &mut [u8] = unsafe { &mut *(*buf as *mut [u8]) };
             let pre_inst = if let Some((inst, _)) = inst_opt {
                 tracing::trace!("get_pre_compute_instruction {inst:?}");
-                let pc = i as u32 * DEFAULT_PC_STEP;
+                let pc = program.pc_base + i as u32 * DEFAULT_PC_STEP;
                 if let Some(handler) = get_system_opcode_handler(pc, inst, buf)? {
                     PreComputeInstruction {
                         handler,
@@ -570,8 +574,9 @@ where
     let unreachable_handler: ExecuteFunc<Ctx> = |_, exec_state| {
         exec_state.exit_code = Err(ExecutionError::Unreachable(exec_state.pc()));
     };
-    repeat_n(&None, get_pc_index(program.pc_base))
-        .chain(program.instructions_and_debug_infos.iter())
+    program
+        .instructions_and_debug_infos
+        .iter()
         .zip_eq(pre_compute.iter_mut())
         .enumerate()
         .map(|(i, (inst_opt, buf))| {
@@ -582,9 +587,7 @@ where
             let buf: &mut [u8] = unsafe { &mut *(*buf as *mut [u8]) };
             let pre_inst = if let Some((inst, _)) = inst_opt {
                 tracing::trace!("get_metered_pre_compute_instruction {inst:?}");
-                // `i` already includes the `get_pc_index(pc_base)` padding, so it is the
-                // absolute pc slot (matching `get_pre_compute_instructions`).
-                let pc = i as u32 * DEFAULT_PC_STEP;
+                let pc = program.pc_base + i as u32 * DEFAULT_PC_STEP;
                 if let Some(handler) = get_system_opcode_handler(pc, inst, buf)? {
                     PreComputeInstruction {
                         handler,
@@ -665,13 +668,68 @@ mod tests {
     use super::*;
     use crate::{arch::execution_mode::MeteredCostCtx, system::SystemExecutor};
 
-    #[test]
-    fn misaligned_pc_is_rejected_before_dispatch() {
+    fn terminate_exe(pc_base: u32, pc_start: u32) -> VmExe {
         let terminate = Instruction {
             opcode: SystemOpcode::TERMINATE.global_opcode(),
             ..Default::default()
         };
-        let exe = VmExe::new(Program::new_without_debug_infos(&[terminate], 0)).with_pc_start(2);
+        VmExe::new(Program::new_without_debug_infos(&[terminate], pc_base)).with_pc_start(pc_start)
+    }
+
+    #[test]
+    fn high_pc_program_uses_relative_table_for_execution() {
+        let exe = terminate_exe(MAX_ALLOWED_PC, MAX_ALLOWED_PC);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
+            .expect("terminate-only program should be statically valid");
+
+        assert_eq!(
+            interpreter.pre_compute_buf.layout.size(),
+            size_of::<TerminatePreCompute>()
+        );
+        assert_eq!(
+            interpreter.execute(Streams::default()).unwrap().pc(),
+            MAX_ALLOWED_PC
+        );
+    }
+
+    #[test]
+    fn metered_high_pc_program_uses_relative_table_for_execution() {
+        let exe = terminate_exe(MAX_ALLOWED_PC, MAX_ALLOWED_PC);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
+            &inventory,
+            &exe,
+            &[],
+        )
+        .expect("terminate-only program should be statically valid");
+
+        assert_eq!(
+            interpreter.pre_compute_buf.layout.size(),
+            size_of::<TerminatePreCompute>()
+        );
+        let (_, state) = interpreter
+            .execute_metered_cost(Streams::default(), MeteredCostCtx::new(vec![]))
+            .unwrap();
+        assert_eq!(state.pc(), MAX_ALLOWED_PC);
+    }
+
+    #[test]
+    fn pc_before_program_base_is_rejected() {
+        let exe = terminate_exe(DEFAULT_PC_STEP, 0);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
+            .expect("terminate-only program should be statically valid");
+
+        assert!(matches!(
+            interpreter.execute(Streams::default()),
+            Err(ExecutionError::PcOutOfBounds(0))
+        ));
+    }
+
+    #[test]
+    fn misaligned_pc_is_rejected_before_dispatch() {
+        let exe = terminate_exe(0, 2);
         let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
         let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
             .expect("terminate-only program should be statically valid");
@@ -684,11 +742,7 @@ mod tests {
 
     #[test]
     fn metered_misaligned_pc_is_rejected_before_dispatch() {
-        let terminate = Instruction {
-            opcode: SystemOpcode::TERMINATE.global_opcode(),
-            ..Default::default()
-        };
-        let exe = VmExe::new(Program::new_without_debug_infos(&[terminate], 0)).with_pc_start(2);
+        let exe = terminate_exe(0, 2);
         let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
         let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
             &inventory,

--- a/crates/vm/src/arch/interpreter/mod.rs
+++ b/crates/vm/src/arch/interpreter/mod.rs
@@ -574,7 +574,9 @@ where
             let buf: &mut [u8] = unsafe { &mut *(*buf as *mut [u8]) };
             let pre_inst = if let Some((inst, _)) = inst_opt {
                 tracing::trace!("get_metered_pre_compute_instruction {inst:?}");
-                let pc = program.pc_base + i as u32 * DEFAULT_PC_STEP;
+                // `i` already includes the `get_pc_index(pc_base)` padding, so it is the
+                // absolute pc slot (matching `get_pre_compute_instructions`).
+                let pc = i as u32 * DEFAULT_PC_STEP;
                 if let Some(handler) = get_system_opcode_handler(pc, inst, buf)? {
                     PreComputeInstruction {
                         handler,

--- a/crates/vm/src/arch/interpreter/mod.rs
+++ b/crates/vm/src/arch/interpreter/mod.rs
@@ -224,7 +224,7 @@ where
     #[cfg(feature = "tco")]
     #[inline(always)]
     pub fn get_handler(&self, pc: u32) -> Option<Handler<Ctx>> {
-        let pc_idx = get_pc_index(pc);
+        let pc_idx = checked_pc_index(pc)?;
         self.handlers.get(pc_idx).copied()
     }
 }
@@ -344,7 +344,10 @@ unsafe fn execute_trampoline<Ctx: ExecutionCtxTrait>(
         }
         let pc = exec_state.pc();
         Ctx::on_instruction_start(exec_state, pc);
-        let pc_index = get_pc_index(pc);
+        let Some(pc_index) = checked_pc_index(pc) else {
+            exec_state.exit_code = Err(ExecutionError::PcOutOfBounds(pc));
+            break;
+        };
 
         if let Some(inst) = fn_ptrs.get(pc_index) {
             // SAFETY: pre_compute assumed to live long enough
@@ -358,6 +361,11 @@ unsafe fn execute_trampoline<Ctx: ExecutionCtxTrait>(
 #[inline(always)]
 pub fn get_pc_index(pc: u32) -> usize {
     (pc / DEFAULT_PC_STEP) as usize
+}
+
+#[inline(always)]
+fn checked_pc_index(pc: u32) -> Option<usize> {
+    pc.is_multiple_of(DEFAULT_PC_STEP).then(|| get_pc_index(pc))
 }
 
 /// Bytes allocated according to the given Layout.
@@ -652,7 +660,48 @@ pub(super) fn check_termination(
 
 #[cfg(test)]
 mod tests {
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
     use super::*;
+    use crate::{arch::execution_mode::MeteredCostCtx, system::SystemExecutor};
+
+    #[test]
+    fn misaligned_pc_is_rejected_before_dispatch() {
+        let terminate = Instruction {
+            opcode: SystemOpcode::TERMINATE.global_opcode(),
+            ..Default::default()
+        };
+        let exe = VmExe::new(Program::new_without_debug_infos(&[terminate], 0)).with_pc_start(2);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
+            .expect("terminate-only program should be statically valid");
+
+        assert!(matches!(
+            interpreter.execute(Streams::default()),
+            Err(ExecutionError::PcOutOfBounds(2))
+        ));
+    }
+
+    #[test]
+    fn metered_misaligned_pc_is_rejected_before_dispatch() {
+        let terminate = Instruction {
+            opcode: SystemOpcode::TERMINATE.global_opcode(),
+            ..Default::default()
+        };
+        let exe = VmExe::new(Program::new_without_debug_infos(&[terminate], 0)).with_pc_start(2);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
+            &inventory,
+            &exe,
+            &[],
+        )
+        .expect("terminate-only program should be statically valid");
+
+        assert!(matches!(
+            interpreter.execute_metered_cost(Streams::default(), MeteredCostCtx::new(vec![])),
+            Err(ExecutionError::PcOutOfBounds(2))
+        ));
+    }
 
     #[test]
     fn terminate_rejects_negative_exit_code() {

--- a/crates/vm/src/arch/interpreter/mod.rs
+++ b/crates/vm/src/arch/interpreter/mod.rs
@@ -365,6 +365,9 @@ pub fn get_pc_index(pc: u32) -> usize {
 
 #[inline(always)]
 fn checked_program_slot(pc: u32, pc_base: u32) -> Option<usize> {
+    if !pc.is_multiple_of(DEFAULT_PC_STEP) {
+        return None;
+    }
     let delta = pc.checked_sub(pc_base)?;
     delta
         .is_multiple_of(DEFAULT_PC_STEP)
@@ -694,6 +697,52 @@ mod tests {
     }
 
     #[test]
+    fn high_pc_program_resolves_nonzero_relative_slot() {
+        let terminate = Instruction {
+            opcode: SystemOpcode::TERMINATE.global_opcode(),
+            ..Default::default()
+        };
+        let program = Program::new_without_debug_infos_with_option(
+            &[None, Some(terminate)],
+            MAX_ALLOWED_PC - DEFAULT_PC_STEP,
+        );
+        let exe = VmExe::new(program).with_pc_start(MAX_ALLOWED_PC);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
+            .expect("terminate-only program should be statically valid");
+
+        assert_eq!(
+            interpreter.execute(Streams::default()).unwrap().pc(),
+            MAX_ALLOWED_PC
+        );
+    }
+
+    #[test]
+    fn metered_high_pc_program_resolves_nonzero_relative_slot() {
+        let terminate = Instruction {
+            opcode: SystemOpcode::TERMINATE.global_opcode(),
+            ..Default::default()
+        };
+        let program = Program::new_without_debug_infos_with_option(
+            &[None, Some(terminate)],
+            MAX_ALLOWED_PC - DEFAULT_PC_STEP,
+        );
+        let exe = VmExe::new(program).with_pc_start(MAX_ALLOWED_PC);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
+            &inventory,
+            &exe,
+            &[],
+        )
+        .expect("terminate-only program should be statically valid");
+
+        let (_, state) = interpreter
+            .execute_metered_cost(Streams::default(), MeteredCostCtx::new(vec![]))
+            .unwrap();
+        assert_eq!(state.pc(), MAX_ALLOWED_PC);
+    }
+
+    #[test]
     fn metered_high_pc_program_uses_relative_table_for_execution() {
         let exe = terminate_exe(MAX_ALLOWED_PC, MAX_ALLOWED_PC);
         let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
@@ -743,6 +792,49 @@ mod tests {
     #[test]
     fn metered_misaligned_pc_is_rejected_before_dispatch() {
         let exe = terminate_exe(0, 2);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
+            &inventory,
+            &exe,
+            &[],
+        )
+        .expect("terminate-only program should be statically valid");
+
+        assert!(matches!(
+            interpreter.execute_metered_cost(Streams::default(), MeteredCostCtx::new(vec![])),
+            Err(ExecutionError::PcOutOfBounds(2))
+        ));
+    }
+
+    #[test]
+    fn pc_with_misaligned_delta_from_program_base_is_rejected() {
+        let exe = terminate_exe(2, DEFAULT_PC_STEP);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
+            .expect("terminate-only program should be statically valid");
+
+        assert!(matches!(
+            interpreter.execute(Streams::default()),
+            Err(ExecutionError::PcOutOfBounds(DEFAULT_PC_STEP))
+        ));
+    }
+
+    #[test]
+    fn misaligned_program_base_is_rejected_before_dispatch() {
+        let exe = terminate_exe(2, 2);
+        let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
+        let interpreter = InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe)
+            .expect("terminate-only program should be statically valid");
+
+        assert!(matches!(
+            interpreter.execute(Streams::default()),
+            Err(ExecutionError::PcOutOfBounds(2))
+        ));
+    }
+
+    #[test]
+    fn metered_misaligned_program_base_is_rejected_before_dispatch() {
+        let exe = terminate_exe(2, 2);
         let inventory = ExecutorInventory::<SystemExecutor>::new(SystemConfig::default());
         let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
             &inventory,

--- a/crates/vm/src/arch/postflight/index.rs
+++ b/crates/vm/src/arch/postflight/index.rs
@@ -137,6 +137,11 @@ pub(super) fn resolve_program_slot(
     program_index: usize,
 ) -> Result<usize, PostflightError> {
     let pc = history.program[program_index].pc;
+    if !pc.is_multiple_of(DEFAULT_PC_STEP) {
+        return Err(PostflightError::new(format!(
+            "program log PC {pc:#x} is not instruction-aligned"
+        )));
+    }
     let delta = pc.checked_sub(program.pc_base).ok_or_else(|| {
         PostflightError::new(format!("program log PC {pc:#x} precedes the program base"))
     })?;

--- a/crates/vm/src/arch/postflight/tests.rs
+++ b/crates/vm/src/arch/postflight/tests.rs
@@ -359,6 +359,26 @@ fn retains_a_terminated_boundary_and_frequency() {
 }
 
 #[test]
+fn rejects_misaligned_program_base_and_pc() {
+    let terminate =
+        Instruction::from_usize(SystemOpcode::TERMINATE.global_opcode(), [0, 0, 0, 0, 0]);
+    let program = Program::new_without_debug_infos(&[terminate], 2);
+    let boundary = PreflightProgramEvent {
+        pc: 2,
+        timestamp: 1,
+    };
+    let history = PreflightHistory {
+        program: vec![boundary, boundary],
+        ..Default::default()
+    };
+
+    let error = Postflight::<BabyBear>::new(&program, &history, &MemoryConfig::default(), Some(0))
+        .err()
+        .unwrap();
+    assert!(error.to_string().contains("is not instruction-aligned"));
+}
+
+#[test]
 fn rejects_negative_terminate_exit_code() {
     let terminate = Instruction {
         opcode: SystemOpcode::TERMINATE.global_opcode(),

--- a/crates/vm/src/arch/testing/cpu.rs
+++ b/crates/vm/src/arch/testing/cpu.rs
@@ -9,7 +9,11 @@ use openvm_circuit_primitives::{
     Chip,
 };
 use openvm_cpu_backend::{CpuBackend, CpuDevice, CpuProverError};
-use openvm_instructions::{instruction::Instruction, program::Program, riscv::REGISTER_NUM_LIMBS};
+use openvm_instructions::{
+    instruction::Instruction,
+    program::{Program, DEFAULT_PC_STEP, MAX_ALLOWED_PC},
+    riscv::REGISTER_NUM_LIMBS,
+};
 use openvm_poseidon2_air::Poseidon2SubAir;
 use openvm_stark_backend::{
     interaction::{LookupBus, PermutationCheckBus},
@@ -77,7 +81,7 @@ where
     ) where
         E: Executor<F> + Clone,
     {
-        let initial_pc = self.next_elem_size_u32();
+        let initial_pc = self.next_pc();
         self.execute_with_pc(executor, preflight, instruction, initial_pc);
     }
 
@@ -172,16 +176,16 @@ where
         to_byte_ptr_bits(self.memory.controller.memory_config().pointer_max_bits)
     }
 
-    fn last_to_pc(&self) -> F {
+    fn last_to_pc(&self) -> u32 {
         self.execution.last_to_pc()
     }
 
-    fn last_from_pc(&self) -> F {
+    fn last_from_pc(&self) -> u32 {
         self.execution.last_from_pc()
     }
 
-    fn execution_final_state(&self) -> ExecutionState<F> {
-        self.execution.records.last().unwrap().final_state
+    fn execution_final_state(&self) -> ExecutionState<u32> {
+        self.execution.last_states.unwrap().1
     }
 
     fn streams_mut(&mut self) -> &mut Streams {
@@ -257,8 +261,10 @@ impl<F: VmField> VmChipTestBuilder<F> {
         }
     }
 
-    fn next_elem_size_u32(&mut self) -> u32 {
-        (self.internal_rng.next_u32() % (1 << (F::bits() - 2))) & !3
+    /// Samples a DEFAULT_PC_STEP-aligned byte pc over the full 32-bit range, excluding the
+    /// last instruction slot (where the fallthrough pc would overflow).
+    fn next_pc(&mut self) -> u32 {
+        (self.internal_rng.next_u32() & !3).min(MAX_ALLOWED_PC - DEFAULT_PC_STEP)
     }
 
     fn write_heap<const NUM_LIMBS: usize>(

--- a/crates/vm/src/arch/testing/cuda.rs
+++ b/crates/vm/src/arch/testing/cuda.rs
@@ -31,11 +31,11 @@ use openvm_cuda_common::{
 };
 use openvm_instructions::{
     instruction::Instruction,
-    program::{Program, PC_BITS},
+    program::{Program, DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     riscv::REGISTER_NUM_LIMBS,
 };
 #[cfg(feature = "rvr")]
-use openvm_instructions::{program::DEFAULT_PC_STEP, LocalOpcode, SystemOpcode};
+use openvm_instructions::{LocalOpcode, SystemOpcode};
 use openvm_poseidon2_air::{Poseidon2Config, Poseidon2SubAir};
 use openvm_stark_backend::{
     interaction::{LookupBus, PermutationCheckBus},
@@ -230,7 +230,9 @@ impl TestBuilder<F> for GpuChipTestBuilder {
     ) where
         E: Executor<F> + Clone,
     {
-        let initial_pc = self.rng.random_range(0..(1 << PC_BITS));
+        // A DEFAULT_PC_STEP-aligned byte pc over the full 32-bit range, excluding the last
+        // instruction slot (where the fallthrough pc would overflow).
+        let initial_pc = (self.rng.random::<u32>() & !3).min(MAX_ALLOWED_PC - DEFAULT_PC_STEP);
         self.execute_with_pc(executor, preflight, instruction, initial_pc);
     }
 
@@ -314,16 +316,17 @@ impl TestBuilder<F> for GpuChipTestBuilder {
         to_byte_ptr_bits(self.memory.config.pointer_max_bits)
     }
 
-    fn last_to_pc(&self) -> F {
+    fn last_to_pc(&self) -> u32 {
         self.execution.0.last_to_pc()
     }
 
-    fn last_from_pc(&self) -> F {
+    fn last_from_pc(&self) -> u32 {
         self.execution.0.last_from_pc()
     }
 
-    fn execution_final_state(&self) -> ExecutionState<F> {
-        self.execution.0.records.last().unwrap().final_state
+    fn execution_final_state(&self) -> ExecutionState<u32> {
+        // Byte-pc state; the records themselves hold pc indices.
+        self.execution.0.last_states.unwrap().1
     }
 
     fn streams_mut(&mut self) -> &mut Streams {

--- a/crates/vm/src/arch/testing/execution/mod.rs
+++ b/crates/vm/src/arch/testing/execution/mod.rs
@@ -42,14 +42,14 @@ impl<F: PrimeField32> ExecutionTester<F> {
         initial_state: ExecutionState<u32>,
         final_state: ExecutionState<u32>,
     ) {
-        let to_idx = |state: ExecutionState<u32>| ExecutionState {
+        let to_indexed_state = |state: ExecutionState<u32>| ExecutionState {
             pc: pc_to_idx(state.pc),
             timestamp: state.timestamp,
         };
         self.records.push(DummyExecutionInteractionCols {
             count: F::NEG_ONE, // send
-            initial_state: to_idx(initial_state).map(F::from_u32),
-            final_state: to_idx(final_state).map(F::from_u32),
+            initial_state: to_indexed_state(initial_state).map(F::from_u32),
+            final_state: to_indexed_state(final_state).map(F::from_u32),
         });
         self.last_states = Some((initial_state, final_state));
     }

--- a/crates/vm/src/arch/testing/execution/mod.rs
+++ b/crates/vm/src/arch/testing/execution/mod.rs
@@ -3,6 +3,7 @@ use std::{borrow::BorrowMut, mem::size_of};
 use air::DummyExecutionInteractionCols;
 use openvm_circuit_primitives::Chip;
 use openvm_cpu_backend::CpuBackend;
+use openvm_instructions::program::pc_to_idx;
 use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
@@ -22,6 +23,8 @@ pub use cuda::*;
 pub struct ExecutionTester<F: Field> {
     pub bus: ExecutionBus,
     pub records: Vec<DummyExecutionInteractionCols<F>>,
+    /// The raw byte-pc states of the last execution (the records hold pc indices).
+    pub last_states: Option<(ExecutionState<u32>, ExecutionState<u32>)>,
 }
 
 impl<F: PrimeField32> ExecutionTester<F> {
@@ -29,27 +32,38 @@ impl<F: PrimeField32> ExecutionTester<F> {
         Self {
             bus,
             records: vec![],
+            last_states: None,
         }
     }
 
+    /// The states carry byte pcs; the execution bus carries pc indices.
     pub fn execute(
         &mut self,
         initial_state: ExecutionState<u32>,
         final_state: ExecutionState<u32>,
     ) {
+        let to_idx = |state: ExecutionState<u32>| ExecutionState {
+            pc: pc_to_idx(state.pc),
+            timestamp: state.timestamp,
+        };
         self.records.push(DummyExecutionInteractionCols {
             count: F::NEG_ONE, // send
-            initial_state: initial_state.map(F::from_u32),
-            final_state: final_state.map(F::from_u32),
-        })
+            initial_state: to_idx(initial_state).map(F::from_u32),
+            final_state: to_idx(final_state).map(F::from_u32),
+        });
+        self.last_states = Some((initial_state, final_state));
     }
 
-    pub fn last_from_pc(&self) -> F {
-        self.records.last().unwrap().initial_state.pc
+    /// Byte pc of the last execution's initial state. Returned as a `u32` because byte pcs
+    /// span the full 32-bit range and do not fit in a field element.
+    pub fn last_from_pc(&self) -> u32 {
+        self.last_states.unwrap().0.pc
     }
 
-    pub fn last_to_pc(&self) -> F {
-        self.records.last().unwrap().final_state.pc
+    /// Byte pc of the last execution's final state. Returned as a `u32` because byte pcs
+    /// span the full 32-bit range and do not fit in a field element.
+    pub fn last_to_pc(&self) -> u32 {
+        self.last_states.unwrap().1.pc
     }
 }
 

--- a/crates/vm/src/arch/testing/mod.rs
+++ b/crates/vm/src/arch/testing/mod.rs
@@ -238,10 +238,13 @@ pub trait TestBuilder<F: PrimeField32> {
     /// Bit width for RISC-V byte pointers used by extension tests and adapter configs.
     fn address_bits(&self) -> usize;
 
-    fn last_to_pc(&self) -> F;
-    fn last_from_pc(&self) -> F;
+    /// Byte pc of the last execution's final state (byte pcs do not fit in a field element).
+    fn last_to_pc(&self) -> u32;
+    /// Byte pc of the last execution's initial state.
+    fn last_from_pc(&self) -> u32;
 
-    fn execution_final_state(&self) -> ExecutionState<F>;
+    /// Byte-pc state of the last execution's final state.
+    fn execution_final_state(&self) -> ExecutionState<u32>;
     fn streams_mut(&mut self) -> &mut Streams;
 
     fn get_default_register(&mut self, increment: usize) -> usize;

--- a/crates/vm/src/arch/testing/program/mod.rs
+++ b/crates/vm/src/arch/testing/program/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::BorrowMut, mem::size_of};
 
 use openvm_circuit_primitives::Chip;
 use openvm_cpu_backend::CpuBackend;
-use openvm_instructions::instruction::Instruction;
+use openvm_instructions::{instruction::Instruction, program::pc_to_idx};
 use openvm_stark_backend::{
     p3_field::{Field, PrimeCharacteristicRing, PrimeField32},
     p3_matrix::dense::RowMajorMatrix,
@@ -35,9 +35,10 @@ impl<F: PrimeField32> ProgramTester<F> {
         }
     }
 
+    /// `initial_state.pc` is a byte pc; the program bus carries pc indices.
     pub fn execute(&mut self, instruction: &Instruction, initial_state: &ExecutionState<u32>) {
         self.records.push(ProgramExecutionCols {
-            pc: F::from_u32(initial_state.pc),
+            pc: F::from_u32(pc_to_idx(initial_state.pc)),
             opcode: F::from_usize(instruction.opcode.as_usize()),
             a: instruction_operand_to_field(instruction.a),
             b: instruction_operand_to_field(instruction.b),

--- a/crates/vm/src/arch/testing/program/mod.rs
+++ b/crates/vm/src/arch/testing/program/mod.rs
@@ -38,7 +38,7 @@ impl<F: PrimeField32> ProgramTester<F> {
     /// `initial_state.pc` is a byte pc; the program bus carries pc indices.
     pub fn execute(&mut self, instruction: &Instruction, initial_state: &ExecutionState<u32>) {
         self.records.push(ProgramExecutionCols {
-            pc: F::from_u32(pc_to_idx(initial_state.pc)),
+            pc_idx: F::from_u32(pc_to_idx(initial_state.pc)),
             opcode: F::from_usize(instruction.opcode.as_usize()),
             a: instruction_operand_to_field(instruction.a),
             b: instruction_operand_to_field(instruction.b),

--- a/crates/vm/src/arch/vm.rs
+++ b/crates/vm/src/arch/vm.rs
@@ -806,8 +806,8 @@ pub enum VmVerificationError<SC: StarkProtocolConfig> {
         actual: [u32; VM_DIGEST_WIDTH],
     },
 
-    #[error("initial pc mismatch (initial: {initial}, prev_final: {prev_final})")]
-    InitialPcMismatch { initial: u32, prev_final: u32 },
+    #[error("initial pc index mismatch (initial: {initial}, prev_final: {prev_final})")]
+    InitialPcIdxMismatch { initial: u32, prev_final: u32 },
 
     #[error("initial memory root mismatch")]
     InitialMemoryRootMismatch,
@@ -2049,8 +2049,8 @@ where
         return Err(VmVerificationError::ProofNotFound);
     }
     let mut prev_final_memory_root = None;
-    let mut prev_final_pc = None;
-    let mut start_pc = None;
+    let mut prev_final_pc_idx = None;
+    let mut start_pc_idx = None;
     let mut initial_memory_root = None;
     let mut program_commit = None;
 
@@ -2089,17 +2089,17 @@ where
                 let pvs: &VmConnectorPvs<_> = pvs.as_slice().borrow();
 
                 if i != 0 {
-                    // Check initial pc matches the previous final pc.
-                    if pvs.initial_pc != prev_final_pc.unwrap() {
-                        return Err(VmVerificationError::InitialPcMismatch {
-                            initial: pvs.initial_pc.as_canonical_u32(),
-                            prev_final: prev_final_pc.unwrap().as_canonical_u32(),
+                    // Check the initial PC index against the previous final PC index.
+                    if pvs.initial_pc_idx != prev_final_pc_idx.unwrap() {
+                        return Err(VmVerificationError::InitialPcIdxMismatch {
+                            initial: pvs.initial_pc_idx.as_canonical_u32(),
+                            prev_final: prev_final_pc_idx.unwrap().as_canonical_u32(),
                         });
                     }
                 } else {
-                    start_pc = Some(pvs.initial_pc);
+                    start_pc_idx = Some(pvs.initial_pc_idx);
                 }
-                prev_final_pc = Some(pvs.final_pc);
+                prev_final_pc_idx = Some(pvs.final_pc_idx);
 
                 let expected_is_terminate = i == proofs.len() - 1;
                 if pvs.is_terminate != PrimeCharacteristicRing::from_bool(expected_is_terminate) {
@@ -2177,7 +2177,7 @@ where
         &vm_poseidon2_hasher(),
         &program_commit.unwrap().into(),
         initial_memory_root.as_ref().unwrap(),
-        start_pc.unwrap(),
+        start_pc_idx.unwrap(),
     );
     Ok(VerifiedExecutionPayload {
         exe_commit,

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -6,7 +6,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_cpu_backend::CpuBackend;
-use openvm_instructions::LocalOpcode;
+use openvm_instructions::{program::pc_to_idx, LocalOpcode};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PairBuilder},
@@ -245,9 +245,11 @@ impl VmConnectorChip {
         }
     }
 
+    /// `state.pc` is a byte program counter; it is stored (and later exposed as a public value)
+    /// as a pc index, matching the circuit representation of the pc.
     pub fn begin(&mut self, state: ExecutionState<u32>) {
         self.boundary_states[0] = Some(ConnectorCols {
-            pc: state.pc,
+            pc: pc_to_idx(state.pc),
             timestamp: state.timestamp,
             is_terminate: 0,
             exit_code: 0,
@@ -256,9 +258,11 @@ impl VmConnectorChip {
         });
     }
 
+    /// `state.pc` is a byte program counter; it is stored (and later exposed as a public value)
+    /// as a pc index, matching the circuit representation of the pc.
     pub fn end(&mut self, state: ExecutionState<u32>, exit_code: Option<u32>) {
         self.boundary_states[1] = Some(ConnectorCols {
-            pc: state.pc,
+            pc: pc_to_idx(state.pc),
             timestamp: state.timestamp,
             is_terminate: exit_code.is_some() as u32,
             exit_code: exit_code.unwrap_or(DEFAULT_SUSPEND_EXIT_CODE),

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -43,9 +43,9 @@ pub struct VmConnectorAir {
 #[derive(Debug, Clone, Copy, AlignedBorrow, StructReflection)]
 #[repr(C)]
 pub struct VmConnectorPvs<F> {
-    /// The initial PC of this segment.
+    /// The initial circuit pc index of this segment.
     pub initial_pc: F,
-    /// The final PC of this segment.
+    /// The final circuit pc index of this segment.
     pub final_pc: F,
     /// The exit code of the whole program. 0 means exited normally. This is only meaningful when
     /// `is_terminate` is 1.
@@ -116,6 +116,7 @@ impl VmConnectorAir {
 #[derive(Debug, Copy, Clone, AlignedBorrow, StructReflection, Serialize, Deserialize)]
 #[repr(C)]
 pub struct ConnectorCols<T> {
+    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
     pub pc: T,
     pub timestamp: T,
     pub is_terminate: T,
@@ -163,14 +164,16 @@ impl<AB: InteractionBuilder + PairBuilder + AirBuilderWithPublicValues> Air<AB> 
         let next: &ConnectorCols<AB::Var> = (*next).borrow();
 
         let &VmConnectorPvs {
-            initial_pc,
-            final_pc,
+            initial_pc: initial_pc_idx,
+            final_pc: final_pc_idx,
             exit_code,
             is_terminate,
         } = builder.public_values().borrow();
 
-        builder.when_transition().assert_eq(local.pc, initial_pc);
-        builder.when_transition().assert_eq(next.pc, final_pc);
+        builder
+            .when_transition()
+            .assert_eq(local.pc, initial_pc_idx);
+        builder.when_transition().assert_eq(next.pc, final_pc_idx);
         builder
             .when_transition()
             .when(next.is_terminate)
@@ -287,7 +290,7 @@ where
     Val<SC>: PrimeField32,
 {
     fn generate_proving_ctx(&self) -> AirProvingContext<CpuBackend<SC>> {
-        let [initial_state, final_state] = self.boundary_states.map(|state| {
+        let [initial_row, final_row] = self.boundary_states.map(|state| {
             let mut state = state.unwrap();
             // Decompose and range check timestamp
             let range_max_bits = self.range_checker.range_max_bits();
@@ -302,16 +305,16 @@ where
         });
 
         let trace = RowMajorMatrix::new(
-            [initial_state.flatten(), final_state.flatten()].concat(),
+            [initial_row.flatten(), final_row.flatten()].concat(),
             ConnectorCols::<Val<SC>>::width(),
         );
 
         let mut public_values = Val::<SC>::zero_vec(VmConnectorPvs::<Val<SC>>::width());
         *public_values.as_mut_slice().borrow_mut() = VmConnectorPvs {
-            initial_pc: initial_state.pc,
-            final_pc: final_state.pc,
-            exit_code: final_state.exit_code,
-            is_terminate: final_state.is_terminate,
+            initial_pc: initial_row.pc,
+            final_pc: final_row.pc,
+            exit_code: final_row.exit_code,
+            is_terminate: final_row.is_terminate,
         };
         AirProvingContext::simple(trace, public_values)
     }

--- a/crates/vm/src/system/connector/mod.rs
+++ b/crates/vm/src/system/connector/mod.rs
@@ -43,10 +43,10 @@ pub struct VmConnectorAir {
 #[derive(Debug, Clone, Copy, AlignedBorrow, StructReflection)]
 #[repr(C)]
 pub struct VmConnectorPvs<F> {
-    /// The initial circuit pc index of this segment.
-    pub initial_pc: F,
-    /// The final circuit pc index of this segment.
-    pub final_pc: F,
+    /// The initial circuit PC index of this segment.
+    pub initial_pc_idx: F,
+    /// The final circuit PC index of this segment.
+    pub final_pc_idx: F,
     /// The exit code of the whole program. 0 means exited normally. This is only meaningful when
     /// `is_terminate` is 1.
     pub exit_code: F,
@@ -116,8 +116,8 @@ impl VmConnectorAir {
 #[derive(Debug, Copy, Clone, AlignedBorrow, StructReflection, Serialize, Deserialize)]
 #[repr(C)]
 pub struct ConnectorCols<T> {
-    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
-    pub pc: T,
+    /// Circuit PC index (`byte_pc / DEFAULT_PC_STEP`).
+    pub pc_idx: T,
     pub timestamp: T,
     pub is_terminate: T,
     pub exit_code: T,
@@ -131,7 +131,7 @@ pub struct ConnectorCols<T> {
 impl<T: Copy> ConnectorCols<T> {
     fn map<F>(self, f: impl Fn(T) -> F) -> ConnectorCols<F> {
         ConnectorCols {
-            pc: f(self.pc),
+            pc_idx: f(self.pc_idx),
             timestamp: f(self.timestamp),
             is_terminate: f(self.is_terminate),
             exit_code: f(self.exit_code),
@@ -142,7 +142,7 @@ impl<T: Copy> ConnectorCols<T> {
 
     fn flatten(&self) -> [T; 6] {
         [
-            self.pc,
+            self.pc_idx,
             self.timestamp,
             self.is_terminate,
             self.exit_code,
@@ -164,16 +164,18 @@ impl<AB: InteractionBuilder + PairBuilder + AirBuilderWithPublicValues> Air<AB> 
         let next: &ConnectorCols<AB::Var> = (*next).borrow();
 
         let &VmConnectorPvs {
-            initial_pc: initial_pc_idx,
-            final_pc: final_pc_idx,
+            initial_pc_idx,
+            final_pc_idx,
             exit_code,
             is_terminate,
         } = builder.public_values().borrow();
 
         builder
             .when_transition()
-            .assert_eq(local.pc, initial_pc_idx);
-        builder.when_transition().assert_eq(next.pc, final_pc_idx);
+            .assert_eq(local.pc_idx, initial_pc_idx);
+        builder
+            .when_transition()
+            .assert_eq(next.pc_idx, final_pc_idx);
         builder
             .when_transition()
             .when(next.is_terminate)
@@ -200,12 +202,12 @@ impl<AB: InteractionBuilder + PairBuilder + AirBuilderWithPublicValues> Air<AB> 
         self.execution_bus.execute(
             builder,
             local.is_begin, // 1 only if these are [0th, 1st] and not [1st, 0th]
-            ExecutionState::new(next.pc, next.timestamp),
-            ExecutionState::new(local.pc, local.timestamp),
+            ExecutionState::new(next.pc_idx, next.timestamp),
+            ExecutionState::new(local.pc_idx, local.timestamp),
         );
         self.program_bus.lookup_instruction(
             builder,
-            next.pc,
+            next.pc_idx,
             AB::Expr::from_usize(TERMINATE.global_opcode().as_usize()),
             [AB::Expr::ZERO, AB::Expr::ZERO, next.exit_code.into()],
             local.is_begin * next.is_terminate,
@@ -249,10 +251,10 @@ impl VmConnectorChip {
     }
 
     /// `state.pc` is a byte program counter; it is stored (and later exposed as a public value)
-    /// as a pc index, matching the circuit representation of the pc.
+    /// as a PC index, matching the circuit representation.
     pub fn begin(&mut self, state: ExecutionState<u32>) {
         self.boundary_states[0] = Some(ConnectorCols {
-            pc: pc_to_idx(state.pc),
+            pc_idx: pc_to_idx(state.pc),
             timestamp: state.timestamp,
             is_terminate: 0,
             exit_code: 0,
@@ -262,10 +264,10 @@ impl VmConnectorChip {
     }
 
     /// `state.pc` is a byte program counter; it is stored (and later exposed as a public value)
-    /// as a pc index, matching the circuit representation of the pc.
+    /// as a PC index, matching the circuit representation.
     pub fn end(&mut self, state: ExecutionState<u32>, exit_code: Option<u32>) {
         self.boundary_states[1] = Some(ConnectorCols {
-            pc: pc_to_idx(state.pc),
+            pc_idx: pc_to_idx(state.pc),
             timestamp: state.timestamp,
             is_terminate: exit_code.is_some() as u32,
             exit_code: exit_code.unwrap_or(DEFAULT_SUSPEND_EXIT_CODE),
@@ -311,8 +313,8 @@ where
 
         let mut public_values = Val::<SC>::zero_vec(VmConnectorPvs::<Val<SC>>::width());
         *public_values.as_mut_slice().borrow_mut() = VmConnectorPvs {
-            initial_pc: initial_row.pc,
-            final_pc: final_row.pc,
+            initial_pc_idx: initial_row.pc_idx,
+            final_pc_idx: final_row.pc_idx,
             exit_code: final_row.exit_code,
             is_terminate: final_row.is_terminate,
         };

--- a/crates/vm/src/system/cuda/program.rs
+++ b/crates/vm/src/system/cuda/program.rs
@@ -5,7 +5,10 @@ use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend, GpuDevice}
 #[cfg(test)]
 use openvm_cuda_common::pinned;
 use openvm_cuda_common::{copy::MemCopyH2D, d_buffer::DeviceBuffer, stream::GpuDeviceCtx};
-use openvm_instructions::{program::Program, LocalOpcode, SystemOpcode};
+use openvm_instructions::{
+    program::{pc_to_idx, Program},
+    LocalOpcode, SystemOpcode,
+};
 use openvm_stark_backend::prover::{
     AirProvingContext, CommittedTraceData, MatrixDimensions, TraceCommitter,
 };
@@ -31,12 +34,14 @@ impl ProgramChipGPU {
     }
 
     pub fn generate_cached_trace(program: Program, device_ctx: &GpuDeviceCtx) -> DeviceMatrix<F> {
+        // The pc column contains pc indices (see `pc_to_idx`): byte pcs span 32 bits and do
+        // not fit in a field element.
         let instructions = program
             .enumerate_by_pc()
             .into_iter()
             .map(|(pc, instruction, _)| {
                 [
-                    F::from_u32(pc),
+                    F::from_u32(pc_to_idx(pc)),
                     F::from_usize(instruction.opcode.as_usize()),
                     instruction_operand_to_field(instruction.a),
                     instruction_operand_to_field(instruction.b),

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
 
 use super::memory::online::GuestMemory;
-use crate::arch::{ExecutionBridge, ExecutionState, PcIncOrSet, PhantomSubExecutor, Streams};
+use crate::arch::{ExecutionBridge, ExecutionState, PcIdxIncOrSet, PhantomSubExecutor, Streams};
 
 mod execution;
 #[cfg(test)]
@@ -46,8 +46,8 @@ pub struct PhantomAir {
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Copy, Clone, Serialize, Deserialize)]
 pub struct PhantomCols<T> {
-    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
-    pub pc: T,
+    /// Circuit PC index (`byte_pc / DEFAULT_PC_STEP`).
+    pub pc_idx: T,
     #[serde(with = "BigArray")]
     pub operands: [T; NUM_PHANTOM_OPERANDS],
     pub timestamp: T,
@@ -67,7 +67,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {
         let main = builder.main();
         let local = main.row_slice(0).expect("window should have two elements");
         let &PhantomCols {
-            pc: pc_idx,
+            pc_idx,
             operands,
             timestamp,
             is_valid,
@@ -75,12 +75,12 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {
 
         builder.assert_bool(is_valid);
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 AB::F::from_usize(self.phantom_opcode.as_usize()),
                 operands,
                 ExecutionState::<AB::Expr>::new(pc_idx, timestamp),
                 AB::Expr::ONE,
-                PcIncOrSet::Inc(AB::Expr::ONE),
+                PcIdxIncOrSet::Inc(AB::Expr::ONE),
             )
             .eval(builder, is_valid);
     }

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -6,7 +6,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, PhantomDiscriminant, VmOpcode};
+use openvm_instructions::{PhantomDiscriminant, VmOpcode};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{Air, AirBuilder, BaseAir},
@@ -78,7 +78,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {
                 operands,
                 ExecutionState::<AB::Expr>::new(pc, timestamp),
                 AB::Expr::ONE,
-                PcIncOrSet::Inc(AB::Expr::from_u32(DEFAULT_PC_STEP)),
+                PcIncOrSet::Inc(AB::Expr::ONE),
             )
             .eval(builder, is_valid);
     }

--- a/crates/vm/src/system/phantom/mod.rs
+++ b/crates/vm/src/system/phantom/mod.rs
@@ -1,5 +1,6 @@
 //! Chip to handle phantom instructions.
-//! The Air will always constrain a NOP which advances pc by DEFAULT_PC_STEP.
+//! The AIR constrains a NOP that advances the circuit pc by one index. The runtime executor
+//! advances the architectural byte pc by `DEFAULT_PC_STEP`.
 //! The runtime executor will execute different phantom instructions that may
 //! affect trace generation based on the operand.
 use std::{borrow::Borrow, sync::Arc};
@@ -45,6 +46,7 @@ pub struct PhantomAir {
 #[repr(C)]
 #[derive(AlignedBorrow, StructReflection, Copy, Clone, Serialize, Deserialize)]
 pub struct PhantomCols<T> {
+    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
     pub pc: T,
     #[serde(with = "BigArray")]
     pub operands: [T; NUM_PHANTOM_OPERANDS],
@@ -65,7 +67,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {
         let main = builder.main();
         let local = main.row_slice(0).expect("window should have two elements");
         let &PhantomCols {
-            pc,
+            pc: pc_idx,
             operands,
             timestamp,
             is_valid,
@@ -76,7 +78,7 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for PhantomAir {
             .execute_and_increment_or_set_pc(
                 AB::F::from_usize(self.phantom_opcode.as_usize()),
                 operands,
-                ExecutionState::<AB::Expr>::new(pc, timestamp),
+                ExecutionState::<AB::Expr>::new(pc_idx, timestamp),
                 AB::Expr::ONE,
                 PcIncOrSet::Inc(AB::Expr::ONE),
             )

--- a/crates/vm/src/system/phantom/tests.rs
+++ b/crates/vm/src/system/phantom/tests.rs
@@ -10,7 +10,6 @@ use openvm_instructions::{
 };
 #[cfg(all(feature = "cuda", feature = "rvr"))]
 use openvm_instructions::{program::Program, riscv::MEMORY_AS};
-use openvm_stark_backend::p3_field::{PrimeCharacteristicRing, PrimeField32};
 use openvm_stark_sdk::p3_baby_bear::BabyBear;
 use rand::rngs::StdRng;
 use rustc_hash::FxHashMap;
@@ -61,13 +60,13 @@ fn run_phantom_test<E>(
     E: Executor<F> + Clone,
 {
     let nop = Instruction::from_isize(phantom_opcode, 0, 0, 0, 0, 0);
-    let mut pc = F::ZERO;
+    let mut pc = 0u32;
 
     for _ in 0..num_nops {
-        tester.execute_with_pc(executor, preflight, &nop, pc.as_canonical_u32());
+        tester.execute_with_pc(executor, preflight, &nop, pc);
         let new_state = tester.execution_final_state();
-        assert_eq!(pc + F::from_usize(4), new_state.pc);
-        assert_eq!(F::TWO, new_state.timestamp);
+        assert_eq!(pc + 4, new_state.pc);
+        assert_eq!(2, new_state.timestamp);
         pc = new_state.pc;
     }
 }

--- a/crates/vm/src/system/phantom/trace.rs
+++ b/crates/vm/src/system/phantom/trace.rs
@@ -41,7 +41,7 @@ pub(crate) fn generate_trace_from_postflight<F: PrimeField32>(
 
         let row: &mut PhantomCols<F> =
             trace.values[row_index * width..(row_index + 1) * width].borrow_mut();
-        row.pc = F::from_u32(pc_to_idx(pc));
+        row.pc_idx = F::from_u32(pc_to_idx(pc));
         row.operands = operands.map(F::from_u32);
         row.timestamp = F::from_u32(timestamp);
         row.is_valid = F::ONE;

--- a/crates/vm/src/system/phantom/trace.rs
+++ b/crates/vm/src/system/phantom/trace.rs
@@ -1,6 +1,9 @@
 use std::borrow::BorrowMut;
 
-use openvm_instructions::{program::DEFAULT_PC_STEP, LocalOpcode, SystemOpcode};
+use openvm_instructions::{
+    program::{pc_to_idx, DEFAULT_PC_STEP},
+    LocalOpcode, SystemOpcode,
+};
 use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix};
 
 use super::PhantomCols;
@@ -38,7 +41,7 @@ pub(crate) fn generate_trace_from_postflight<F: PrimeField32>(
 
         let row: &mut PhantomCols<F> =
             trace.values[row_index * width..(row_index + 1) * width].borrow_mut();
-        row.pc = F::from_u32(pc);
+        row.pc = F::from_u32(pc_to_idx(pc));
         row.operands = operands.map(F::from_u32);
         row.timestamp = F::from_u32(timestamp);
         row.is_valid = F::ONE;

--- a/crates/vm/src/system/program/air.rs
+++ b/crates/vm/src/system/program/air.rs
@@ -21,8 +21,8 @@ pub struct ProgramCols<T> {
 #[derive(Copy, Clone, Debug, AlignedBorrow, StructReflection, PartialEq, Eq)]
 #[repr(C)]
 pub struct ProgramExecutionCols<T> {
-    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
-    pub pc: T,
+    /// Circuit PC index (`byte_pc / DEFAULT_PC_STEP`).
+    pub pc_idx: T,
 
     pub opcode: T,
     pub a: T,

--- a/crates/vm/src/system/program/air.rs
+++ b/crates/vm/src/system/program/air.rs
@@ -21,6 +21,7 @@ pub struct ProgramCols<T> {
 #[derive(Copy, Clone, Debug, AlignedBorrow, StructReflection, PartialEq, Eq)]
 #[repr(C)]
 pub struct ProgramExecutionCols<T> {
+    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
     pub pc: T,
 
     pub opcode: T,

--- a/crates/vm/src/system/program/bus.rs
+++ b/crates/vm/src/system/program/bus.rs
@@ -28,14 +28,14 @@ impl ProgramBus {
     pub fn lookup_instruction<AB: InteractionBuilder, E: Into<AB::Expr>>(
         &self,
         builder: &mut AB,
-        pc: impl Into<AB::Expr>,
+        pc_idx: impl Into<AB::Expr>,
         opcode: impl Into<AB::Expr>,
         operands: impl IntoIterator<Item = E>,
         enabled: impl Into<AB::Expr>,
     ) {
         self.inner.lookup_key(
             builder,
-            [pc.into(), opcode.into()].into_iter().chain(
+            [pc_idx.into(), opcode.into()].into_iter().chain(
                 operands
                     .into_iter()
                     .map(Into::into)

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -72,7 +72,8 @@ fn interaction_test(program: Program, execution: Vec<u32>) {
         if let Some((instruction, _)) = option {
             program_cells.extend([
                 BabyBear::from_u32(frequency),
-                BabyBear::from_usize(index * (DEFAULT_PC_STEP as usize)),
+                // The program bus carries pc indices; with pc_base = 0 that is the slot index.
+                BabyBear::from_usize(index),
                 BabyBear::from_usize(instruction.opcode.as_usize()),
                 instruction_operand_to_field(instruction.a),
                 instruction_operand_to_field(instruction.b),

--- a/crates/vm/src/system/program/tests/mod.rs
+++ b/crates/vm/src/system/program/tests/mod.rs
@@ -201,7 +201,7 @@ fn test_program_negative() {
     for (pc_idx, instruction) in instructions.iter().enumerate() {
         program_rows.extend(vec![
             BabyBear::from_u32(execution_frequencies[pc_idx]),
-            BabyBear::from_usize(pc_idx * DEFAULT_PC_STEP as usize),
+            BabyBear::from_usize(pc_idx),
             BabyBear::from_usize(instruction.opcode.as_usize()),
             instruction_operand_to_field(instruction.a),
             instruction_operand_to_field(instruction.b),

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -121,13 +121,13 @@ pub fn compute_exe_commit<F: PrimeField32>(
     padded_pc_start_idx[0] = pc_start_idx;
     let program_hash = hasher.hash(program_commit);
     let memory_hash = hasher.hash(init_memory_root);
-    let pc_hash = hasher.hash(&padded_pc_start_idx);
-    hasher.compress(&hasher.compress(&program_hash, &memory_hash), &pc_hash)
+    let pc_idx_hash = hasher.hash(&padded_pc_start_idx);
+    hasher.compress(&hasher.compress(&program_hash, &memory_hash), &pc_idx_hash)
 }
 
 pub(crate) fn generate_cached_trace<F: PrimeField32>(program: &Program) -> RowMajorMatrix<F> {
     let width = ProgramExecutionCols::<F>::width();
-    // The pc column contains pc indices (see [pc_to_idx]): byte pcs span 32 bits and do not fit
+    // The pc_idx column contains PC indices (see [pc_to_idx]): byte PCs span 32 bits and do not fit
     // in a field element.
     let mut instructions = program
         .enumerate_by_pc()
@@ -149,7 +149,7 @@ pub(crate) fn generate_cached_trace<F: PrimeField32>(program: &Program) -> RowMa
         .for_each(|(row, (pc_idx, instruction))| {
             let row: &mut ProgramExecutionCols<F> = row.borrow_mut();
             *row = ProgramExecutionCols {
-                pc: F::from_u32(pc_idx),
+                pc_idx: F::from_u32(pc_idx),
                 opcode: F::from_usize(instruction.opcode.as_usize()),
                 a: instruction_operand_to_field(instruction.a),
                 b: instruction_operand_to_field(instruction.b),

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -115,13 +115,13 @@ pub fn compute_exe_commit<F: PrimeField32>(
     hasher: &Poseidon2Hasher<F>,
     program_commit: &[F; VM_DIGEST_WIDTH],
     init_memory_root: &[F; VM_DIGEST_WIDTH],
-    pc_start: F,
+    pc_start_idx: F,
 ) -> [F; VM_DIGEST_WIDTH] {
-    let mut padded_pc_start = [F::ZERO; VM_DIGEST_WIDTH];
-    padded_pc_start[0] = pc_start;
+    let mut padded_pc_start_idx = [F::ZERO; VM_DIGEST_WIDTH];
+    padded_pc_start_idx[0] = pc_start_idx;
     let program_hash = hasher.hash(program_commit);
     let memory_hash = hasher.hash(init_memory_root);
-    let pc_hash = hasher.hash(&padded_pc_start);
+    let pc_hash = hasher.hash(&padded_pc_start_idx);
     hasher.compress(&hasher.compress(&program_hash, &memory_hash), &pc_hash)
 }
 

--- a/crates/vm/src/system/program/trace.rs
+++ b/crates/vm/src/system/program/trace.rs
@@ -6,7 +6,7 @@ use openvm_cpu_backend::CpuBackend;
 use openvm_instructions::{
     exe::VmExe,
     instruction::InstructionOperand,
-    program::{Program, DEFAULT_PC_STEP},
+    program::{pc_to_idx, Program},
     LocalOpcode, SystemOpcode, VM_DIGEST_WIDTH,
 };
 use openvm_stark_backend::{
@@ -100,14 +100,14 @@ pub fn compute_exe_commit_from_mem_config<F: PrimeField32>(
         &hasher,
         program_commitment,
         &init_memory_commit,
-        F::from_u32(exe.pc_start),
+        F::from_u32(pc_to_idx(exe.pc_start)),
     )
 }
 
 /// Computes a Merklelized hash of:
 /// - Program code commitment (commitment of the cached trace)
 /// - Merkle root of the initial memory
-/// - Starting program counter (`pc_start`)
+/// - Starting program counter as a pc index (`pc_to_idx(pc_start)`)
 ///
 /// The Merklelization uses [Poseidon2Hasher] as a cryptographic hash function (for the leaves)
 /// and a cryptographic compression function (for internal nodes).
@@ -127,16 +127,18 @@ pub fn compute_exe_commit<F: PrimeField32>(
 
 pub(crate) fn generate_cached_trace<F: PrimeField32>(program: &Program) -> RowMajorMatrix<F> {
     let width = ProgramExecutionCols::<F>::width();
+    // The pc column contains pc indices (see [pc_to_idx]): byte pcs span 32 bits and do not fit
+    // in a field element.
     let mut instructions = program
         .enumerate_by_pc()
         .into_iter()
-        .map(|(pc, instruction, _)| (pc, instruction))
+        .map(|(pc, instruction, _)| (pc_to_idx(pc), instruction))
         .collect_vec();
 
     let padding = padding_instruction();
     while !instructions.len().is_power_of_two() {
         instructions.push((
-            program.pc_base + instructions.len() as u32 * DEFAULT_PC_STEP,
+            pc_to_idx(program.pc_base) + instructions.len() as u32,
             padding.clone(),
         ));
     }
@@ -144,10 +146,10 @@ pub(crate) fn generate_cached_trace<F: PrimeField32>(program: &Program) -> RowMa
     let mut rows = F::zero_vec(instructions.len() * width);
     rows.par_chunks_mut(width)
         .zip(instructions)
-        .for_each(|(row, (pc, instruction))| {
+        .for_each(|(row, (pc_idx, instruction))| {
             let row: &mut ProgramExecutionCols<F> = row.borrow_mut();
             *row = ProgramExecutionCols {
-                pc: F::from_u32(pc),
+                pc: F::from_u32(pc_idx),
                 opcode: F::from_usize(instruction.opcode.as_usize()),
                 a: instruction_operand_to_field(instruction.a),
                 b: instruction_operand_to_field(instruction.b),

--- a/docs/crates/vm.md
+++ b/docs/crates/vm.md
@@ -343,8 +343,8 @@ pub trait VmAdapterAir<AB: AirBuilder>: BaseAir<AB::F> {
         interface: AdapterAirContext<AB::Expr, Self::Interface>,
     );
 
-    /// Return the `from_pc` expression.
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var;
+    /// Return the `from_pc_idx` expression.
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var;
 }
 
 pub trait VmCoreAir<AB, I>: BaseAirWithPublicValues<AB::F>
@@ -352,12 +352,12 @@ where
     AB: AirBuilder,
     I: VmAdapterInterface<AB::Expr>,
 {
-    /// Returns `(to_pc, interface)`.
+    /// Returns `(to_pc_idx, interface)`.
     fn eval(
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I>;
 
     /// The offset the opcodes by this chip start from.
@@ -379,8 +379,8 @@ where
 }
 
 pub struct AdapterAirContext<T, I: VmAdapterInterface<T>> {
-    /// Leave as `None` to allow the adapter to decide the `to_pc` automatically.
-    pub to_pc: Option<T>,
+    /// Leave as `None` to allow the adapter to decide the `to_pc_idx` automatically.
+    pub to_pc_idx: Option<T>,
     pub reads: I::Reads,
     pub writes: I::Writes,
     pub instruction: I::ProcessedInstruction,

--- a/extensions/algebra/circuit/cuda/src/modular_is_eq.cu
+++ b/extensions/algebra/circuit/cuda/src/modular_is_eq.cu
@@ -289,7 +289,8 @@ __global__ void modular_is_eq_replay_tracegen(
     VariableRangeChecker range_checker(range_checker_counts, range_checker_bins);
     MemoryAuxColsFactory memory_aux(range_checker, timestamp_max_bits);
 
-    row[offsetof(AdapterCols, from_state) + offsetof(ExecutionState<uint8_t>, pc)] = Fp(from.pc);
+    row[offsetof(AdapterCols, from_state) + offsetof(ExecutionState<uint8_t>, pc)] =
+        Fp(::program::pc_to_idx(from.pc));
     row[offsetof(AdapterCols, from_state) + offsetof(ExecutionState<uint8_t>, timestamp)] =
         Fp(from.timestamp);
     for (size_t read = 0; read < 2; read++) {

--- a/extensions/algebra/circuit/src/modular_chip/is_eq.rs
+++ b/extensions/algebra/circuit/src/modular_chip/is_eq.rs
@@ -124,7 +124,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &ModularIsEqualCoreCols<_, READ_LIMBS> = local_core.borrow();
 
@@ -263,7 +263,7 @@ where
         a[0] = cols.cmp_result.into();
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [a].into(),
             instruction: MinimalInstruction {

--- a/extensions/algebra/circuit/src/trace.rs
+++ b/extensions/algebra/circuit/src/trace.rs
@@ -15,7 +15,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
     VmOpcode,
 };
@@ -426,7 +426,7 @@ pub(crate) fn generate_modular_is_equal_trace_from_postflight<
                 adapter_cols.rs_ptr[read] = F::from_u32(rs_ptrs[read]);
             }
             adapter_cols.from_state.timestamp = F::from_u32(from_timestamp);
-            adapter_cols.from_state.pc = F::from_u32(from_pc);
+            adapter_cols.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
             chip.inner.fill_trace_row_from_execution_data(
                 temporary_range_checker.as_ref(),

--- a/extensions/bigint/circuit/cuda/src/bigint_replay.cu
+++ b/extensions/bigint/circuit/cuda/src/bigint_replay.cu
@@ -552,10 +552,13 @@ __device__ bool int256_u8_write_matches(
     return true;
 }
 
-__device__ __forceinline__ uint32_t int256_branch_target(uint32_t pc, uint32_t immediate) {
-    uint64_t sum = uint64_t(pc) + immediate;
-    if (sum >= INT256_REPLAY_FIELD_ORDER) sum -= INT256_REPLAY_FIELD_ORDER;
-    return static_cast<uint32_t>(sum);
+// Taken targets must stay inside the implemented PC address space on an aligned slot
+// (mirrors the CPU trace filler's `checked_branch_target`).
+__device__ __forceinline__ bool int256_valid_branch_target(
+    uint32_t pc, uint32_t immediate, uint32_t to_pc
+) {
+    return replay_branch_target_in_bounds(pc, immediate) &&
+           to_pc == replay_taken_branch_pc(pc, immediate);
 }
 
 __global__ void add_sub256_replay_tracegen(
@@ -1175,7 +1178,7 @@ __global__ void branch_equal256_replay_tracegen(
     for (size_t i = 0; i < INT256_NUM_U16_LIMBS; i++) equal &= a[i] == b[i];
     bool take = replay.local_opcode == 0 ? equal : !equal;
     bool valid_pc =
-        take ? replay.to_pc == int256_branch_target(replay.from_pc, replay.immediate)
+        take ? int256_valid_branch_target(replay.from_pc, replay.immediate, replay.to_pc)
              : int256_sequential_pc(replay.from_pc, replay.to_pc);
     if (!valid_pc) {
         preflight_set_error(inputs.error, INT256_REPLAY_BAD_BRANCH);
@@ -1243,7 +1246,7 @@ __global__ void branch_less_than256_replay_tracegen(
     int256_flatten_u16_reads(replay, a, b);
     bool take = int256_branch_less_than(a, b, replay.local_opcode);
     bool valid_pc =
-        take ? replay.to_pc == int256_branch_target(replay.from_pc, replay.immediate)
+        take ? int256_valid_branch_target(replay.from_pc, replay.immediate, replay.to_pc)
              : int256_sequential_pc(replay.from_pc, replay.to_pc);
     if (!valid_pc) {
         preflight_set_error(inputs.error, INT256_REPLAY_BAD_BRANCH);

--- a/extensions/bigint/circuit/src/tests.rs
+++ b/extensions/bigint/circuit/src/tests.rs
@@ -21,7 +21,7 @@ use openvm_circuit_primitives::{
     var_range::SharedVariableRangeCheckerChip,
 };
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     riscv::BYTE_BITS,
     LocalOpcode,
 };
@@ -39,7 +39,7 @@ use openvm_riscv_circuit::{
 use openvm_riscv_transpiler::{
     BaseAluOpcode, BranchEqualOpcode, BranchLessThanOpcode, LessThanOpcode, MulOpcode, ShiftOpcode,
 };
-use openvm_stark_backend::p3_field::{PrimeCharacteristicRing, PrimeField32};
+use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
 use openvm_stark_sdk::{p3_baby_bear::BabyBear, utils::create_seeded_rng};
 use rand::{rngs::StdRng, Rng};
 use test_case::test_case;
@@ -339,7 +339,10 @@ fn set_and_execute_rand<E: Executor<F> + Clone>(
     let b = generate_long_number::<INT256_NUM_U8_LIMBS, BYTE_BITS>(rng);
     let c = generate_long_number::<INT256_NUM_U8_LIMBS, BYTE_BITS>(rng);
     if branch {
-        let imm = rng.random_range((-ABS_MAX_BRANCH)..ABS_MAX_BRANCH);
+        // Branch offsets are DEFAULT_PC_STEP-aligned byte offsets.
+        let imm = rng.random_range(
+            (-ABS_MAX_BRANCH / DEFAULT_PC_STEP as i32)..(ABS_MAX_BRANCH / DEFAULT_PC_STEP as i32),
+        ) * DEFAULT_PC_STEP as i32;
         let instruction = heap_branch_default(
             tester,
             vec![b.map(F::from_u32)],
@@ -348,17 +351,20 @@ fn set_and_execute_rand<E: Executor<F> + Clone>(
             opcode,
         );
 
+        // An aligned byte pc over the full 32-bit range, keeping the taken target in bounds.
+        let lo = (-imm).max(0) as u32 / DEFAULT_PC_STEP;
+        let hi = (MAX_ALLOWED_PC - DEFAULT_PC_STEP - imm.max(0) as u32) / DEFAULT_PC_STEP;
         tester.execute_with_pc(
             executor,
             preflight,
             &instruction,
-            rng.random_range((ABS_MAX_BRANCH as u32)..(1 << (PC_BITS - 1))),
+            rng.random_range(lo..=hi) * DEFAULT_PC_STEP,
         );
 
         let cmp_result = branch_fn.unwrap()(opcode, &b, &c);
-        let from_pc = tester.last_from_pc().as_canonical_u32() as i32;
-        let to_pc = tester.last_to_pc().as_canonical_u32() as i32;
-        assert_eq!(to_pc, from_pc + if cmp_result { imm } else { 4 });
+        let from_pc = tester.last_from_pc() as i64;
+        let to_pc = tester.last_to_pc() as i64;
+        assert_eq!(to_pc, from_pc + if cmp_result { imm as i64 } else { 4 });
     } else {
         let instruction = write_heap_default(
             tester,

--- a/extensions/bigint/circuit/src/trace.rs
+++ b/extensions/bigint/circuit/src/trace.rs
@@ -17,7 +17,7 @@ use openvm_circuit_primitives::var_range::{
 };
 use openvm_instructions::{
     instruction::Instruction,
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
     LocalOpcode, VmOpcode,
 };
@@ -25,7 +25,10 @@ use openvm_riscv_adapters::{
     VecHeapAdapterCols, VecHeapBranchU16AdapterCols, VecHeapU16AdapterCols,
 };
 use openvm_riscv_circuit::{
-    adapters::{add_block_index_range_checks, ptr_to_u16_limbs, U16_BITS},
+    adapters::{
+        add_block_index_range_checks, checked_branch_target, ptr_to_u16_limbs, taken_branch_pc,
+        U16_BITS,
+    },
     AddSubCoreCols, BitwiseLogicCoreCols, BranchEqualCoreCols, BranchLessThanCoreCols,
     LessThanCoreCols, MultiplicationCoreCols, ShiftLogicalCoreCols, ShiftRightArithmeticCoreCols,
 };
@@ -234,7 +237,7 @@ fn replay_alu_u16<F: PrimeField32, M>(
     adapter_row.rd_ptr = F::from_u32(rd_ptr);
     adapter_row.rs_ptr = rs_ptrs.map(F::from_u32);
     adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-    adapter_row.from_state.pc = F::from_u32(from_pc);
+    adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
     Ok(AluReplay {
         inputs,
@@ -325,7 +328,7 @@ fn replay_alu_bytes<F: PrimeField32, M>(
     adapter_row.rd_ptr = F::from_u32(rd_ptr);
     adapter_row.rs_ptr = rs_ptrs.map(F::from_u32);
     adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-    adapter_row.from_state.pc = F::from_u32(from_pc);
+    adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
     Ok(AluReplay {
         inputs,
@@ -371,7 +374,8 @@ fn replay_branch<F: PrimeField32, M>(
     let decision = branch(inputs);
     let taken = decision.taken;
     let next_pc = if taken {
-        from_pc.wrapping_add_signed(instruction.c.as_i32())
+        checked_branch_target(from_pc, instruction.c.as_i32())?;
+        taken_branch_pc(from_pc, instruction.c.as_i32())
     } else {
         from_pc.wrapping_add(DEFAULT_PC_STEP)
     };
@@ -394,7 +398,7 @@ fn replay_branch<F: PrimeField32, M>(
     adapter_row.rs_val = rs_vals.map(|pointer| ptr_to_u16_limbs(pointer).map(F::from_u16));
     adapter_row.rs_ptr = rs_ptrs.map(F::from_u32);
     adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-    adapter_row.from_state.pc = F::from_u32(from_pc);
+    adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
     Ok(BranchReplay {
         inputs,
         taken,

--- a/extensions/deferral/circuit/cuda/rvr/output.cu
+++ b/extensions/deferral/circuit/cuda/rvr/output.cu
@@ -432,7 +432,7 @@ __global__ void deferral_output_replay_tracegen(
     COL_WRITE_VALUE(row, DeferralOutputCols, is_first, is_first);
     COL_WRITE_VALUE(row, DeferralOutputCols, is_last, is_last);
     COL_WRITE_VALUE(row, DeferralOutputCols, section_idx, section_idx);
-    COL_WRITE_VALUE(row, DeferralOutputCols, from_state.pc, from.pc);
+    COL_WRITE_VALUE(row, DeferralOutputCols, from_state.pc, ::program::pc_to_idx(from.pc));
     COL_WRITE_VALUE(row, DeferralOutputCols, from_state.timestamp, from.timestamp);
     COL_WRITE_VALUE(row, DeferralOutputCols, rd_ptr, rd_ptr);
     COL_WRITE_VALUE(row, DeferralOutputCols, rs_ptr, rs_ptr);

--- a/extensions/deferral/circuit/cuda/src/call.cu
+++ b/extensions/deferral/circuit/cuda/src/call.cu
@@ -229,7 +229,7 @@ __device__ __forceinline__ void deferral_call_adapter_tracegen(
         bitwise_buffer.add_range(record.rs_val[i], record.rs_val[i + 1]);
     }
 
-    COL_WRITE_VALUE(row, DeferralCallAdapterCols, from_state.pc, record.from_pc);
+    COL_WRITE_VALUE(row, DeferralCallAdapterCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     COL_WRITE_VALUE(row, DeferralCallAdapterCols, from_state.timestamp, record.from_timestamp);
     COL_WRITE_VALUE(row, DeferralCallAdapterCols, rd_ptr, record.rd_ptr);
     COL_WRITE_VALUE(row, DeferralCallAdapterCols, rs_ptr, record.rs_ptr);

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -18,7 +18,6 @@ use openvm_circuit_primitives::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
     riscv::{BYTE_BITS, MEMORY_AS, REGISTER_AS, WORD_NUM_LIMBS},
     LocalOpcode, DEFERRAL_AS,
 };
@@ -528,7 +527,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 ],
                 cols.from_state,
                 AB::Expr::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }

--- a/extensions/deferral/circuit/src/call/air.rs
+++ b/extensions/deferral/circuit/src/call/air.rs
@@ -113,7 +113,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &DeferralCallCoreCols<_> = local_core.borrow();
         builder.assert_bool(cols.is_valid);
@@ -194,7 +194,7 @@ where
             .eval(builder, cols.is_valid);
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: DeferralCallReads {
                 input_commit: cols.reads.input_commit.map(Into::into),
                 old_input_acc: cols.reads.old_input_acc.map(Into::into),
@@ -516,7 +516,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
         }
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rd_ptr.into(),
@@ -527,12 +527,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for DeferralCallAdapterAir {
                 ],
                 cols.from_state,
                 AB::Expr::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &DeferralCallAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/deferral/circuit/src/call/tests.rs
+++ b/extensions/deferral/circuit/src/call/tests.rs
@@ -440,7 +440,7 @@ fn postflight_call_trace_rejects_truncated_history_without_mutating_periphery() 
         &mut rng,
         NUM_DEFERRALS,
     );
-    let from_pc = tester.last_from_pc().as_canonical_u32();
+    let from_pc = tester.last_from_pc();
     let sentinel = instruction.clone();
     let program = Program::new_without_debug_infos(&[instruction, sentinel], from_pc);
     let history = &mut harness.preflight.executions[0].history;

--- a/extensions/deferral/circuit/src/call/trace.rs
+++ b/extensions/deferral/circuit/src/call/trace.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{BYTE_BITS, MEMORY_AS, REGISTER_AS, WORD_NUM_LIMBS},
     LocalOpcode, DEFERRAL_AS,
 };
@@ -375,7 +375,7 @@ fn fill_call_adapter<F: VmField>(
     cols.rs_ptr = F::from_u32(replay.rs_ptr);
     cols.rd_ptr = F::from_u32(replay.rd_ptr);
     cols.from_state.timestamp = F::from_u32(replay.from_timestamp);
-    cols.from_state.pc = F::from_u32(replay.from_pc);
+    cols.from_state.pc = F::from_u32(pc_to_idx(replay.from_pc));
 }
 
 fn fill_call_core<F: VmField>(

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -428,7 +428,7 @@ where
         // Evaluate the execution interaction. Because a single opcode spans many
         // rows, we only execute this on the last one.
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 AB::Expr::from_usize(DeferralOpcode::OUTPUT.global_opcode_usize()),
                 [
                     local.rd_ptr.into(),

--- a/extensions/deferral/circuit/src/output/air.rs
+++ b/extensions/deferral/circuit/src/output/air.rs
@@ -17,7 +17,6 @@ use openvm_circuit_primitives::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
     riscv::{BYTE_BITS, MEMORY_AS, REGISTER_AS, WORD_NUM_LIMBS},
     LocalOpcode,
 };
@@ -441,7 +440,7 @@ where
                 local.from_state,
                 (local.section_idx * AB::Expr::from_usize(DIGEST_BYTE_MEMORY_OPS))
                     + AB::Expr::from_usize(OUTPUT_TOTAL_MEMORY_OPS + 2),
-                (DEFAULT_PC_STEP, None),
+                (1, None),
             )
             .eval(builder, local.is_last);
     }

--- a/extensions/deferral/circuit/src/output/tests.rs
+++ b/extensions/deferral/circuit/src/output/tests.rs
@@ -19,10 +19,7 @@ use openvm_instructions::{
     riscv::{BYTE_BITS, MEMORY_AS, REGISTER_AS},
     LocalOpcode, DEFERRAL_AS,
 };
-use openvm_stark_backend::{
-    interaction::BusIndex,
-    p3_field::{PrimeCharacteristicRing, PrimeField32},
-};
+use openvm_stark_backend::{interaction::BusIndex, p3_field::PrimeCharacteristicRing};
 use openvm_stark_sdk::{
     config::baby_bear_poseidon2::DIGEST_SIZE, p3_baby_bear::BabyBear, utils::create_seeded_rng,
 };
@@ -462,7 +459,7 @@ fn postflight_output_trace_rejects_truncated_history_without_mutating_periphery(
         &mut rng,
         NUM_DEFERRALS,
     );
-    let from_pc = tester.last_from_pc().as_canonical_u32();
+    let from_pc = tester.last_from_pc();
     let sentinel = instruction.clone();
     let program = Program::new_without_debug_infos(&[instruction, sentinel], from_pc);
     let history = &mut harness.preflight.executions[0].history;

--- a/extensions/deferral/circuit/src/output/trace.rs
+++ b/extensions/deferral/circuit/src/output/trace.rs
@@ -11,7 +11,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_deferral_transpiler::DeferralOpcode;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{BYTE_BITS, MEMORY_AS, REGISTER_AS, WORD_NUM_LIMBS},
     LocalOpcode,
 };
@@ -247,7 +247,7 @@ fn fill_output_section<F: VmField>(
         cols.is_first = F::from_bool(row_idx == 0);
         cols.is_last = F::from_bool(row_idx + 1 == num_rows);
         cols.section_idx = F::from_usize(row_idx);
-        cols.from_state.pc = F::from_u32(section.from_pc);
+        cols.from_state.pc = F::from_u32(pc_to_idx(section.from_pc));
         cols.from_state.timestamp = F::from_u32(section.from_timestamp);
         cols.rd_ptr = F::from_u32(section.rd_ptr);
         cols.rs_ptr = F::from_u32(section.rs_ptr);

--- a/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
+++ b/extensions/keccak256/circuit/cuda/include/keccakf_op.cuh
@@ -15,7 +15,7 @@ inline constexpr size_t NUM_OP_ROWS_PER_INS = 1; // 1 row per instruction
 
 // Column structure matching Rust KeccakfOpCols (from columns.rs)
 template <typename T> struct KeccakfOpCols {
-    T pc;
+    T pc_idx;
     T is_valid;
     T timestamp;
     T rd_ptr;

--- a/extensions/keccak256/circuit/cuda/include/xorin.cuh
+++ b/extensions/keccak256/circuit/cuda/include/xorin.cuh
@@ -11,7 +11,7 @@ inline constexpr size_t XORIN_REGISTER_READS = 3;
 
 template <typename T>
 struct XorinInstructionCols {
-    T pc;
+    T pc_idx;
     T is_enabled;
     T buffer_reg_ptr;
     T input_reg_ptr;

--- a/extensions/keccak256/circuit/cuda/rvr/keccakf_op.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/keccakf_op.cu
@@ -163,7 +163,7 @@ __global__ void keccakf_op_replay_tracegen(
 
     VariableRangeChecker range_checker(range_checker_ptr, range_checker_num_bins);
     MemoryAuxColsFactory mem_helper(range_checker, timestamp_max_bits);
-    KECCAKF_OP_WRITE(pc, ::program::pc_to_idx(from.pc));
+    KECCAKF_OP_WRITE(pc_idx, ::program::pc_to_idx(from.pc));
     KECCAKF_OP_WRITE(is_valid, 1);
     KECCAKF_OP_WRITE(timestamp, from.timestamp);
     KECCAKF_OP_WRITE(rd_ptr, rd_ptr);

--- a/extensions/keccak256/circuit/cuda/rvr/keccakf_op.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/keccakf_op.cu
@@ -163,7 +163,7 @@ __global__ void keccakf_op_replay_tracegen(
 
     VariableRangeChecker range_checker(range_checker_ptr, range_checker_num_bins);
     MemoryAuxColsFactory mem_helper(range_checker, timestamp_max_bits);
-    KECCAKF_OP_WRITE(pc, from.pc);
+    KECCAKF_OP_WRITE(pc, ::program::pc_to_idx(from.pc));
     KECCAKF_OP_WRITE(is_valid, 1);
     KECCAKF_OP_WRITE(timestamp, from.timestamp);
     KECCAKF_OP_WRITE(rd_ptr, rd_ptr);

--- a/extensions/keccak256/circuit/cuda/rvr/xorin.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/xorin.cu
@@ -252,7 +252,7 @@ __global__ void xorin_replay_tracegen(
     MemoryAuxColsFactory mem_helper(range_checker, timestamp_max_bits);
     BitwiseOperationLookup bitwise_lookup(bitwise_lookup_ptr);
 
-    XORIN_WRITE(instruction.pc, from.pc);
+    XORIN_WRITE(instruction.pc, ::program::pc_to_idx(from.pc));
     XORIN_WRITE(instruction.is_enabled, 1);
     XORIN_WRITE(instruction.buffer_reg_ptr, buffer_reg_ptr);
     XORIN_WRITE(instruction.input_reg_ptr, input_reg_ptr);

--- a/extensions/keccak256/circuit/cuda/rvr/xorin.cu
+++ b/extensions/keccak256/circuit/cuda/rvr/xorin.cu
@@ -252,7 +252,7 @@ __global__ void xorin_replay_tracegen(
     MemoryAuxColsFactory mem_helper(range_checker, timestamp_max_bits);
     BitwiseOperationLookup bitwise_lookup(bitwise_lookup_ptr);
 
-    XORIN_WRITE(instruction.pc, ::program::pc_to_idx(from.pc));
+    XORIN_WRITE(instruction.pc_idx, ::program::pc_to_idx(from.pc));
     XORIN_WRITE(instruction.is_enabled, 1);
     XORIN_WRITE(instruction.buffer_reg_ptr, buffer_reg_ptr);
     XORIN_WRITE(instruction.input_reg_ptr, input_reg_ptr);

--- a/extensions/keccak256/circuit/src/keccakf_op/air.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/air.rs
@@ -128,7 +128,7 @@ impl<AB: InteractionBuilder> Air<AB> for KeccakfOpAir {
 
         // ======== Execution bus =========
         self.execution_bridge
-            .execute_and_increment_pc(
+            .execute_and_increment_pc_idx(
                 AB::Expr::from_usize(KeccakfOpcode::KECCAKF as usize + self.offset),
                 [
                     rd_ptr.into(),
@@ -137,7 +137,7 @@ impl<AB: InteractionBuilder> Air<AB> for KeccakfOpAir {
                     AB::Expr::from_u32(REGISTER_AS),
                     AB::Expr::from_u32(MEMORY_AS),
                 ],
-                ExecutionState::new(local.pc, local.timestamp),
+                ExecutionState::new(local.pc_idx, local.timestamp),
                 AB::F::from_usize(timestamp_delta),
             )
             .eval(builder, is_valid);

--- a/extensions/keccak256/circuit/src/keccakf_op/columns.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/columns.rs
@@ -8,8 +8,8 @@ use crate::{KECCAK_WIDTH_MEM_OPS, KECCAK_WIDTH_U16S};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, AlignedBorrow, StructReflection)]
 pub struct KeccakfOpCols<T> {
-    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
-    pub pc: T,
+    /// Circuit PC index (`byte_pc / DEFAULT_PC_STEP`).
+    pub pc_idx: T,
     /// True on the row handling execution for an instruction.
     pub is_valid: T,
     /// The starting timestamp for execution in this row.

--- a/extensions/keccak256/circuit/src/keccakf_op/columns.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/columns.rs
@@ -8,7 +8,7 @@ use crate::{KECCAK_WIDTH_MEM_OPS, KECCAK_WIDTH_U16S};
 #[repr(C)]
 #[derive(Copy, Clone, Debug, AlignedBorrow, StructReflection)]
 pub struct KeccakfOpCols<T> {
-    /// Program counter
+    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
     pub pc: T,
     /// True on the row handling execution for an instruction.
     pub is_valid: T,

--- a/extensions/keccak256/circuit/src/keccakf_op/trace.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/trace.rs
@@ -68,7 +68,7 @@ impl<F: PrimeField32> KeccakfOpChip<F> {
         row.fill(F::ZERO);
         let local: &mut KeccakfOpCols<F> = row.borrow_mut();
 
-        local.pc = F::from_u32(pc_to_idx(replay.pc));
+        local.pc_idx = F::from_u32(pc_to_idx(replay.pc));
         local.is_valid = F::ONE;
         local.timestamp = F::from_u32(replay.timestamp);
         local.rd_ptr = F::from_u32(replay.rd_ptr);

--- a/extensions/keccak256/circuit/src/keccakf_op/trace.rs
+++ b/extensions/keccak256/circuit/src/keccakf_op/trace.rs
@@ -13,7 +13,7 @@ use openvm_circuit_primitives::var_range::{
     SharedVariableRangeCheckerChip, VariableRangeCheckerChip,
 };
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
     LocalOpcode,
 };
@@ -68,7 +68,7 @@ impl<F: PrimeField32> KeccakfOpChip<F> {
         row.fill(F::ZERO);
         let local: &mut KeccakfOpCols<F> = row.borrow_mut();
 
-        local.pc = F::from_u32(replay.pc);
+        local.pc = F::from_u32(pc_to_idx(replay.pc));
         local.is_valid = F::ONE;
         local.timestamp = F::from_u32(replay.timestamp);
         local.rd_ptr = F::from_u32(replay.rd_ptr);

--- a/extensions/keccak256/circuit/src/xorin/air.rs
+++ b/extensions/keccak256/circuit/src/xorin/air.rs
@@ -124,7 +124,7 @@ impl XorinVmAir {
         }
 
         self.execution_bridge
-            .execute_and_increment_pc(
+            .execute_and_increment_pc_idx(
                 AB::Expr::from_usize(XorinOpcode::XORIN as usize + self.offset),
                 [
                     buffer_reg_ptr.into(),
@@ -133,7 +133,7 @@ impl XorinVmAir {
                     AB::Expr::from_u32(REGISTER_AS),
                     AB::Expr::from_u32(MEMORY_AS),
                 ],
-                ExecutionState::new(instruction.pc, instruction.start_timestamp),
+                ExecutionState::new(instruction.pc_idx, instruction.start_timestamp),
                 timestamp_change,
             )
             .eval(builder, is_enabled);

--- a/extensions/keccak256/circuit/src/xorin/columns.rs
+++ b/extensions/keccak256/circuit/src/xorin/columns.rs
@@ -17,8 +17,8 @@ pub struct XorinVmCols<T> {
 #[derive(Copy, Clone, Debug, Default, AlignedBorrow, StructReflection, derive_new::new)]
 #[allow(clippy::too_many_arguments)]
 pub struct XorinInstructionCols<T> {
-    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
-    pub pc: T,
+    /// Circuit PC index (`byte_pc / DEFAULT_PC_STEP`).
+    pub pc_idx: T,
     pub is_enabled: T,
     pub buffer_reg_ptr: T,
     pub input_reg_ptr: T,

--- a/extensions/keccak256/circuit/src/xorin/columns.rs
+++ b/extensions/keccak256/circuit/src/xorin/columns.rs
@@ -17,6 +17,7 @@ pub struct XorinVmCols<T> {
 #[derive(Copy, Clone, Debug, Default, AlignedBorrow, StructReflection, derive_new::new)]
 #[allow(clippy::too_many_arguments)]
 pub struct XorinInstructionCols<T> {
+    /// Circuit pc index (`byte_pc / DEFAULT_PC_STEP`).
     pub pc: T,
     pub is_enabled: T,
     pub buffer_reg_ptr: T,

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -138,7 +138,7 @@ impl XorinVmFiller {
         row_slice.fill(F::ZERO);
         let trace_row: &mut XorinVmCols<F> = row_slice.borrow_mut();
 
-        trace_row.instruction.pc = F::from_u32(pc_to_idx(from_pc));
+        trace_row.instruction.pc_idx = F::from_u32(pc_to_idx(from_pc));
         trace_row.instruction.is_enabled = F::ONE;
         trace_row.instruction.buffer_reg_ptr = F::from_u32(rd_ptr);
         trace_row.instruction.input_reg_ptr = F::from_u32(rs1_ptr);

--- a/extensions/keccak256/circuit/src/xorin/trace.rs
+++ b/extensions/keccak256/circuit/src/xorin/trace.rs
@@ -4,7 +4,7 @@ use openvm_circuit::{
     arch::*, system::memory::MemoryAuxColsFactory, utils::next_power_of_two_or_zero,
 };
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
     LocalOpcode,
 };
@@ -138,7 +138,7 @@ impl XorinVmFiller {
         row_slice.fill(F::ZERO);
         let trace_row: &mut XorinVmCols<F> = row_slice.borrow_mut();
 
-        trace_row.instruction.pc = F::from_u32(from_pc);
+        trace_row.instruction.pc = F::from_u32(pc_to_idx(from_pc));
         trace_row.instruction.is_enabled = F::ONE;
         trace_row.instruction.buffer_reg_ptr = F::from_u32(rd_ptr);
         trace_row.instruction.input_reg_ptr = F::from_u32(rs1_ptr);

--- a/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap.cuh
+++ b/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap.cuh
@@ -152,7 +152,7 @@ struct VecHeapAdapter {
         }
 
         COL_WRITE_VALUE(row, Cols, from_state.timestamp, record.from_timestamp);
-        COL_WRITE_VALUE(row, Cols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, Cols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     }
 };
 

--- a/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap_branch.cuh
+++ b/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap_branch.cuh
@@ -97,7 +97,7 @@ struct VecHeapBranchAdapter {
         }
 
         COL_WRITE_VALUE(row, Cols, from_state.timestamp, record.from_timestamp);
-        COL_WRITE_VALUE(row, Cols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, Cols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     }
 };
 

--- a/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap_branch_u16.cuh
+++ b/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap_branch_u16.cuh
@@ -96,6 +96,6 @@ template <size_t NUM_READS, size_t BLOCKS_PER_READ> struct VecHeapBranchU16Adapt
         }
 
         COL_WRITE_VALUE(row, Cols, from_state.timestamp, record.from_timestamp);
-        COL_WRITE_VALUE(row, Cols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, Cols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     }
 };

--- a/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap_u16.cuh
+++ b/extensions/riscv-adapters/cuda/include/riscv-adapters/vec_heap_u16.cuh
@@ -154,6 +154,6 @@ struct VecHeapU16Adapter {
         }
 
         COL_WRITE_VALUE(row, Cols, from_state.timestamp, record.from_timestamp);
-        COL_WRITE_VALUE(row, Cols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, Cols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     }
 };

--- a/extensions/riscv-adapters/src/eq_mod.rs
+++ b/extensions/riscv-adapters/src/eq_mod.rs
@@ -15,10 +15,7 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerBus, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
-    riscv::{MEMORY_AS, REGISTER_AS},
-};
+use openvm_instructions::riscv::{MEMORY_AS, REGISTER_AS};
 use openvm_riscv_circuit::adapters::{
     eval_byte_ptr_limbs_to_block_index, expand_to_block, reg_byte_ptr_to_cell_ptr_limbs,
     PTR_U16_LIMBS, REGISTER_NUM_LIMBS,
@@ -193,7 +190,7 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }

--- a/extensions/riscv-adapters/src/eq_mod.rs
+++ b/extensions/riscv-adapters/src/eq_mod.rs
@@ -173,7 +173,7 @@ impl<
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rd_ptr.into(),
@@ -190,12 +190,12 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &IsEqualModAdapterCols<_, NUM_READS, BLOCKS_PER_READ> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv-adapters/src/eq_mod_u16.rs
+++ b/extensions/riscv-adapters/src/eq_mod_u16.rs
@@ -15,10 +15,7 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerBus, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
-    riscv::{MEMORY_AS, REGISTER_AS},
-};
+use openvm_instructions::riscv::{MEMORY_AS, REGISTER_AS};
 use openvm_riscv_circuit::adapters::{
     eval_byte_ptr_limbs_to_block_index, expand_to_block, reg_byte_ptr_to_cell_ptr_limbs,
     PTR_U16_LIMBS,
@@ -183,7 +180,7 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }

--- a/extensions/riscv-adapters/src/eq_mod_u16.rs
+++ b/extensions/riscv-adapters/src/eq_mod_u16.rs
@@ -163,7 +163,7 @@ impl<
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rd_ptr.into(),
@@ -180,12 +180,12 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &IsEqualModU16AdapterCols<_, NUM_READS, BLOCKS_PER_READ> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv-adapters/src/vec_heap.rs
+++ b/extensions/riscv-adapters/src/vec_heap.rs
@@ -22,7 +22,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::pc_to_idx,
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_riscv_circuit::adapters::{
@@ -176,7 +176,7 @@ impl<const NUM_READS: usize, const BLOCKS: usize> VecHeapAdapterFiller<NUM_READS
                 *cols_ptr = F::from_u32(*ptr);
             });
         cols.from_state.timestamp = F::from_u32(input.from_timestamp);
-        cols.from_state.pc = F::from_u32(input.from_pc);
+        cols.from_state.pc = F::from_u32(pc_to_idx(input.from_pc));
     }
 }
 
@@ -301,7 +301,7 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }

--- a/extensions/riscv-adapters/src/vec_heap.rs
+++ b/extensions/riscv-adapters/src/vec_heap.rs
@@ -284,7 +284,7 @@ impl<
         }
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rd_ptr.into(),
@@ -301,12 +301,12 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &VecHeapAdapterCols<_, NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE> =
             local.borrow();
         cols.from_state.pc

--- a/extensions/riscv-adapters/src/vec_heap_branch.rs
+++ b/extensions/riscv-adapters/src/vec_heap_branch.rs
@@ -15,10 +15,7 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerBus, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
-    riscv::{MEMORY_AS, REGISTER_AS},
-};
+use openvm_instructions::riscv::{MEMORY_AS, REGISTER_AS};
 use openvm_riscv_circuit::adapters::{
     eval_byte_ptr_limbs_to_block_index, expand_to_block, reg_byte_ptr_to_cell_ptr_limbs,
     PTR_U16_LIMBS,
@@ -153,7 +150,7 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const BLOCKS_PER_READ: usiz
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }

--- a/extensions/riscv-adapters/src/vec_heap_branch.rs
+++ b/extensions/riscv-adapters/src/vec_heap_branch.rs
@@ -133,7 +133,7 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const BLOCKS_PER_READ: usiz
         }
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rs_ptr
@@ -150,12 +150,12 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const BLOCKS_PER_READ: usiz
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &VecHeapBranchAdapterCols<_, NUM_READS, BLOCKS_PER_READ> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv-adapters/src/vec_heap_branch_u16.rs
+++ b/extensions/riscv-adapters/src/vec_heap_branch_u16.rs
@@ -15,10 +15,7 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerBus, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
-    riscv::{MEMORY_AS, REGISTER_AS},
-};
+use openvm_instructions::riscv::{MEMORY_AS, REGISTER_AS};
 use openvm_riscv_circuit::adapters::{
     eval_byte_ptr_limbs_to_block_index, expand_to_block, reg_byte_ptr_to_cell_ptr_limbs,
     PTR_U16_LIMBS,
@@ -150,7 +147,7 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const BLOCKS_PER_READ: usiz
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }

--- a/extensions/riscv-adapters/src/vec_heap_branch_u16.rs
+++ b/extensions/riscv-adapters/src/vec_heap_branch_u16.rs
@@ -130,7 +130,7 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const BLOCKS_PER_READ: usiz
         }
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rs_ptr
@@ -147,12 +147,12 @@ impl<AB: InteractionBuilder, const NUM_READS: usize, const BLOCKS_PER_READ: usiz
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &VecHeapBranchU16AdapterCols<_, NUM_READS, BLOCKS_PER_READ> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv-adapters/src/vec_heap_u16.rs
+++ b/extensions/riscv-adapters/src/vec_heap_u16.rs
@@ -15,10 +15,7 @@ use openvm_circuit_primitives::{
     var_range::VariableRangeCheckerBus, ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
-    riscv::{MEMORY_AS, REGISTER_AS},
-};
+use openvm_instructions::riscv::{MEMORY_AS, REGISTER_AS};
 use openvm_riscv_circuit::adapters::{
     eval_byte_ptr_limbs_to_block_index, expand_to_block, reg_byte_ptr_to_cell_ptr_limbs,
     PTR_U16_LIMBS,
@@ -203,7 +200,7 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }

--- a/extensions/riscv-adapters/src/vec_heap_u16.rs
+++ b/extensions/riscv-adapters/src/vec_heap_u16.rs
@@ -183,7 +183,7 @@ impl<
         }
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     cols.rd_ptr.into(),
@@ -200,12 +200,12 @@ impl<
                 ],
                 cols.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid.clone());
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &VecHeapU16AdapterCols<_, NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE> =
             local.borrow();
         cols.from_state.pc

--- a/extensions/riscv-adapters/src/vec_to_flat.rs
+++ b/extensions/riscv-adapters/src/vec_to_flat.rs
@@ -187,7 +187,7 @@ where
             AB::Expr,
             InnerI<AB::Expr, NUM_READS, BLOCKS_PER_READ, BLOCKS_PER_WRITE, BLOCK_VALUE_WIDTH>,
         > = AdapterAirContext {
-            to_pc: ctx.to_pc,
+            to_pc_idx: ctx.to_pc_idx,
             reads: inner_reads,
             writes: inner_writes,
             instruction: ctx.instruction,
@@ -196,8 +196,8 @@ where
         self.0.eval(builder, local, inner_ctx)
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
-        self.0.get_from_pc(local)
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
+        self.0.get_from_pc_idx(local)
     }
 }
 
@@ -340,7 +340,7 @@ where
             AB::Expr,
             InnerI<AB::Expr, NUM_READS, BLOCKS_PER_READ, BLOCK_VALUE_WIDTH>,
         > = AdapterAirContext {
-            to_pc: ctx.to_pc,
+            to_pc_idx: ctx.to_pc_idx,
             reads: inner_reads,
             writes: (),
             instruction: ctx.instruction,
@@ -349,8 +349,8 @@ where
         self.0.eval(builder, local, inner_ctx)
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
-        self.0.get_from_pc(local)
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
+        self.0.get_from_pc_idx(local)
     }
 }
 

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_imm.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_imm.cuh
@@ -47,7 +47,7 @@ struct BaseAluImmAdapter {
         uint32_t write_prev_timestamp,
         uint16_t const (&write_prev_data)[BLOCK_FE_WIDTH]
     ) {
-        COL_WRITE_VALUE(row, BaseAluImmAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BaseAluImmAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, BaseAluImmAdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, BaseAluImmAdapterCols, rd_ptr, rd_ptr);
         COL_WRITE_VALUE(row, BaseAluImmAdapterCols, rs1_ptr, rs1_ptr);
@@ -69,7 +69,7 @@ struct BaseAluImmAdapter {
     }
 
     __device__ void fill_trace_row(RowSlice row, BaseAluImmAdapterRecord record) {
-        COL_WRITE_VALUE(row, BaseAluImmAdapterCols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, BaseAluImmAdapterCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
         COL_WRITE_VALUE(row, BaseAluImmAdapterCols, from_state.timestamp, record.from_timestamp);
         COL_WRITE_VALUE(row, BaseAluImmAdapterCols, rd_ptr, record.rd_ptr);
         COL_WRITE_VALUE(row, BaseAluImmAdapterCols, rs1_ptr, record.rs1_ptr);

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_imm_u16.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_imm_u16.cuh
@@ -47,7 +47,7 @@ struct BaseAluImmU16Adapter {
         uint32_t write_prev_timestamp,
         uint16_t const (&write_prev_data)[BLOCK_FE_WIDTH]
     ) {
-        COL_WRITE_VALUE(row, BaseAluImmU16AdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BaseAluImmU16AdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, BaseAluImmU16AdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, BaseAluImmU16AdapterCols, rd_ptr, rd_ptr);
         COL_WRITE_VALUE(row, BaseAluImmU16AdapterCols, rs1_ptr, rs1_ptr);

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_reg.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_reg.cuh
@@ -50,7 +50,7 @@ struct BaseAluRegAdapter {
         uint32_t write_prev_timestamp,
         uint16_t const (&write_prev_data)[BLOCK_FE_WIDTH]
     ) {
-        COL_WRITE_VALUE(row, BaseAluRegAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BaseAluRegAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, BaseAluRegAdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, BaseAluRegAdapterCols, rd_ptr, rd_ptr);
         COL_WRITE_VALUE(row, BaseAluRegAdapterCols, rs1_ptr, rs1_ptr);
@@ -76,7 +76,7 @@ struct BaseAluRegAdapter {
     }
 
     __device__ void fill_trace_row(RowSlice row, BaseAluRegAdapterRecord record) {
-        COL_WRITE_VALUE(row, BaseAluRegAdapterCols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, BaseAluRegAdapterCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
         COL_WRITE_VALUE(
             row, BaseAluRegAdapterCols, from_state.timestamp, record.from_timestamp
         );

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_reg_u16.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_reg_u16.cuh
@@ -51,7 +51,7 @@ struct BaseAluRegU16Adapter {
         uint32_t write_prev_timestamp,
         uint16_t const (&write_prev_data)[BLOCK_FE_WIDTH]
     ) {
-        COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, rd_ptr, rd_ptr);
         COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, rs1_ptr, rs1_ptr);
@@ -77,7 +77,7 @@ struct BaseAluRegU16Adapter {
     }
 
     __device__ void fill_trace_row(RowSlice row, BaseAluRegU16AdapterRecord record) {
-        COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, BaseAluRegU16AdapterCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
         COL_WRITE_VALUE(
             row, BaseAluRegU16AdapterCols, from_state.timestamp, record.from_timestamp
         );

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_imm_u16.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_imm_u16.cuh
@@ -82,7 +82,7 @@ struct BaseAluWImmU16Adapter {
         COL_WRITE_VALUE(
             row, BaseAluWImmU16AdapterCols, from_state.timestamp, from_timestamp
         );
-        COL_WRITE_VALUE(row, BaseAluWImmU16AdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BaseAluWImmU16AdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
     }
 
     __device__ void fill_trace_row(RowSlice row, BaseAluWImmU16AdapterRecord record) {

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_reg_u16.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/alu_w_reg_u16.cuh
@@ -101,7 +101,7 @@ struct BaseAluWRegU16Adapter {
         COL_WRITE_VALUE(
             row, BaseAluWRegU16AdapterCols, from_state.timestamp, from_timestamp
         );
-        COL_WRITE_VALUE(row, BaseAluWRegU16AdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BaseAluWRegU16AdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
     }
 
     __device__ void fill_trace_row(RowSlice row, BaseAluWRegU16AdapterRecord record) {

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/branch.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/branch.cuh
@@ -48,7 +48,7 @@ struct BranchAdapter {
             rs1_prev_timestamp,
             from_timestamp
         );
-        COL_WRITE_VALUE(row, BranchAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, BranchAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, BranchAdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, BranchAdapterCols, rs1_ptr, rs1_ptr);
         COL_WRITE_VALUE(row, BranchAdapterCols, rs2_ptr, rs2_ptr);

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/jalr.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/jalr.cuh
@@ -70,7 +70,7 @@ struct JalrAdapter {
 
         COL_WRITE_VALUE(row, JalrAdapterCols, rs1_ptr, rs1_ptr);
         COL_WRITE_VALUE(row, JalrAdapterCols, from_state.timestamp, from_timestamp);
-        COL_WRITE_VALUE(row, JalrAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, JalrAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
     }
 
     __device__ void fill_trace_row(RowSlice row, JalrAdapterRecord record) {

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/load.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/load.cuh
@@ -53,7 +53,7 @@ struct LoadAdapter {
         uint16_t imm,
         bool imm_sign
     ) {
-        COL_WRITE_VALUE(row, LoadMultiByteAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, LoadMultiByteAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, LoadMultiByteAdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, LoadMultiByteAdapterCols, rs1_ptr, rs1_ptr);
 
@@ -157,7 +157,7 @@ struct LoadByteAdapter {
         uint16_t imm,
         bool imm_sign
     ) {
-        COL_WRITE_VALUE(row, LoadByteAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, LoadByteAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(
             row, LoadByteAdapterCols, from_state.timestamp, from_timestamp
         );

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/mul.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/mul.cuh
@@ -58,6 +58,6 @@ __device__ inline void MultAdapter::fill_trace_row(RowSlice row, MultAdapterReco
     COL_WRITE_VALUE(row, MultAdapterCols, rs2_ptr, record.rs2_ptr);
     COL_WRITE_VALUE(row, MultAdapterCols, rs1_ptr, record.rs1_ptr);
     COL_WRITE_VALUE(row, MultAdapterCols, rd_ptr, record.rd_ptr);
-    COL_WRITE_VALUE(row, MultAdapterCols, from_state.pc, record.from_pc);
+    COL_WRITE_VALUE(row, MultAdapterCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     COL_WRITE_VALUE(row, MultAdapterCols, from_state.timestamp, record.from_timestamp);
 }

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/mul_w.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/mul_w.cuh
@@ -89,6 +89,6 @@ struct MultWAdapter {
         COL_WRITE_VALUE(row, MultWAdapterCols, rs1_ptr, record.rs1_ptr);
         COL_WRITE_VALUE(row, MultWAdapterCols, rd_ptr, record.rd_ptr);
         COL_WRITE_VALUE(row, MultWAdapterCols, from_state.timestamp, record.from_timestamp);
-        COL_WRITE_VALUE(row, MultWAdapterCols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, MultWAdapterCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
     }
 };

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/rdwrite.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/rdwrite.cuh
@@ -34,7 +34,7 @@ struct RdWriteAdapter {
         uint32_t prev_timestamp,
         uint16_t const (&prev_data)[BLOCK_FE_WIDTH]
     ) {
-        COL_WRITE_VALUE(row, RdWriteAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, RdWriteAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, RdWriteAdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, RdWriteAdapterCols, rd_ptr, rd_ptr);
 
@@ -96,7 +96,7 @@ struct CondRdWriteAdapter {
         } else {
             inner.fill_zero(0, sizeof(RdWriteAdapterCols<uint8_t>));
             COL_WRITE_VALUE(inner, RdWriteAdapterCols, from_state.timestamp, from_timestamp);
-            COL_WRITE_VALUE(inner, RdWriteAdapterCols, from_state.pc, from_pc);
+            COL_WRITE_VALUE(inner, RdWriteAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         }
     }
 

--- a/extensions/riscv/circuit/cuda/include/riscv/adapters/store.cuh
+++ b/extensions/riscv/circuit/cuda/include/riscv/adapters/store.cuh
@@ -49,7 +49,7 @@ struct StoreAdapter {
         uint16_t imm,
         uint8_t imm_sign
     ) {
-        COL_WRITE_VALUE(row, StoreMultiByteAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, StoreMultiByteAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(row, StoreMultiByteAdapterCols, from_state.timestamp, from_timestamp);
         COL_WRITE_VALUE(row, StoreMultiByteAdapterCols, rs1_ptr, rs1_ptr);
 
@@ -143,7 +143,7 @@ struct StoreByteAdapter {
         uint16_t imm,
         uint8_t imm_sign
     ) {
-        COL_WRITE_VALUE(row, StoreByteAdapterCols, from_state.pc, from_pc);
+        COL_WRITE_VALUE(row, StoreByteAdapterCols, from_state.pc, ::program::pc_to_idx(from_pc));
         COL_WRITE_VALUE(
             row, StoreByteAdapterCols, from_state.timestamp, from_timestamp
         );

--- a/extensions/riscv/circuit/cuda/rvr/checkpoint_replay.cu
+++ b/extensions/riscv/circuit/cuda/rvr/checkpoint_replay.cu
@@ -1381,7 +1381,7 @@ __device__ bool replay_chunk(
                     preflight_set_error(error, ERROR_BAD_INSTRUCTION);
                     return false;
                 }
-                result = state.pc + 4;
+                result = uint64_t(state.pc) + 4;
                 if (needs_write) {
                     if (memory != nullptr) {
                         if (uint64_t(memory_start) + emitted + 1 > memory_capacity) {
@@ -1439,11 +1439,11 @@ __device__ bool replay_chunk(
                              : int64_t(instruction->words[3]);
                 uint64_t target =
                     (state.regs[rs1] + uint64_t(signed_offset)) & ~uint64_t(1);
-                if (target > UINT32_MAX) {
+                if (target > UINT32_MAX || target % DEFAULT_PC_STEP != 0) {
                     preflight_set_error(error, ERROR_BAD_INSTRUCTION);
                     return false;
                 }
-                result = state.pc + 4;
+                result = uint64_t(state.pc) + 4;
                 if (memory != nullptr) {
                     uint32_t event_count = 1 + needs_write;
                     if (uint64_t(memory_start) + emitted + event_count > memory_capacity) {

--- a/extensions/riscv/circuit/cuda/rvr/checkpoint_replay.cu
+++ b/extensions/riscv/circuit/cuda/rvr/checkpoint_replay.cu
@@ -1439,11 +1439,12 @@ __device__ bool replay_chunk(
                              : int64_t(instruction->words[3]);
                 uint64_t target =
                     (state.regs[rs1] + uint64_t(signed_offset)) & ~uint64_t(1);
-                if (target > UINT32_MAX || target % DEFAULT_PC_STEP != 0) {
+                if (target > UINT32_MAX ||
+                    target % ::program::DEFAULT_PC_STEP != 0) {
                     preflight_set_error(error, ERROR_BAD_INSTRUCTION);
                     return false;
                 }
-                result = uint64_t(state.pc) + 4;
+                result = uint64_t(state.pc) + ::program::DEFAULT_PC_STEP;
                 if (memory != nullptr) {
                     uint32_t event_count = 1 + needs_write;
                     if (uint64_t(memory_start) + emitted + event_count > memory_capacity) {

--- a/extensions/riscv/circuit/cuda/rvr/checkpoint_replay.cu
+++ b/extensions/riscv/circuit/cuda/rvr/checkpoint_replay.cu
@@ -528,9 +528,10 @@ __device__ __forceinline__ bool validate_reveal(
 }
 
 __device__ __forceinline__ uint32_t branch_target(uint32_t pc, uint32_t encoded_offset) {
-    uint64_t sum = uint64_t(pc) + encoded_offset;
-    if (sum >= BABY_BEAR_ORDER) sum -= BABY_BEAR_ORDER;
-    return uint32_t(sum);
+    // `encoded_offset` is the canonical field encoding of a signed byte offset; byte pcs span
+    // the full 32-bit range, so the target is computed with integer arithmetic (wrapping like
+    // the host interpreter), not field arithmetic.
+    return replay_taken_branch_pc(pc, encoded_offset);
 }
 
 __device__ __forceinline__ bool execute_branch_condition(

--- a/extensions/riscv/circuit/cuda/rvr/src/auipc.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/auipc.inc.cuh
@@ -73,7 +73,7 @@ __global__ void auipc_replay_tracegen(
     replay_u16_block(write.value, logged_data);
     uint64_t expected_result = run_auipc(from.pc, imm);
     uint64_t expected_high = expected_result >> 32;
-    if (expected_high != 0 && expected_high != UINT32_MAX) {
+    if (expected_high != 0 && expected_high != 1 && expected_high != UINT32_MAX) {
         preflight_set_error(error, 199);
         return;
     }

--- a/extensions/riscv/circuit/cuda/rvr/src/auipc.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/auipc.inc.cuh
@@ -43,11 +43,6 @@ __global__ void auipc_replay_tracegen(
     }
     auto const &from = *transition.from;
     auto const &to = *transition.to;
-    constexpr uint32_t MAX_PC = (1u << PC_BITS) - 1;
-    if (from.pc > MAX_PC - DEFAULT_PC_STEP) {
-        preflight_set_error(error, 192);
-        return;
-    }
     auto const &instruction = *transition.instruction;
     uint32_t rd_ptr = instruction.words[1];
     uint32_t imm = instruction.words[3];

--- a/extensions/riscv/circuit/cuda/rvr/src/beq.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/beq.inc.cuh
@@ -95,9 +95,18 @@ __global__ void beq_replay_tracegen(
         equal &= rs1[i] == rs2[i];
     }
     bool should_branch = is_beq ? equal : !equal;
-    Fp expected_next_pc_field(from.pc);
-    expected_next_pc_field += Fp(should_branch ? encoded_imm : 4);
-    uint32_t expected_next_pc = expected_next_pc_field.asUInt32();
+    uint32_t expected_next_pc;
+    if (should_branch) {
+        // Taken targets must stay inside the implemented PC address space on an aligned
+        // slot (mirrors the CPU trace filler).
+        if (!replay_branch_target_in_bounds(from.pc, encoded_imm)) {
+            preflight_set_error(error, 28);
+            return;
+        }
+        expected_next_pc = replay_taken_branch_pc(from.pc, encoded_imm);
+    } else {
+        expected_next_pc = from.pc + ::program::DEFAULT_PC_STEP;
+    }
     if (to.pc != expected_next_pc) {
         preflight_set_error(error, 28);
         return;

--- a/extensions/riscv/circuit/cuda/rvr/src/blt.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/blt.inc.cuh
@@ -122,9 +122,19 @@ __global__ void blt_replay_tracegen(
     bool cmp_lt =
         run_less_than<BLOCK_FE_WIDTH, U16_BITS>(signed_op, rs1, rs2).cmp_result;
     bool should_branch = ge_op ? !cmp_lt : cmp_lt;
-    Fp expected_next_pc_field(from.pc);
-    expected_next_pc_field += Fp(should_branch ? encoded_imm : 4);
-    if (to.pc != expected_next_pc_field.asUInt32()) {
+    uint32_t expected_next_pc;
+    if (should_branch) {
+        // Taken targets must stay inside the implemented PC address space on an aligned
+        // slot (mirrors the CPU trace filler).
+        if (!replay_branch_target_in_bounds(from.pc, encoded_imm)) {
+            preflight_set_error(error, 18);
+            return;
+        }
+        expected_next_pc = replay_taken_branch_pc(from.pc, encoded_imm);
+    } else {
+        expected_next_pc = from.pc + ::program::DEFAULT_PC_STEP;
+    }
+    if (to.pc != expected_next_pc) {
         preflight_set_error(error, 18);
         return;
     }

--- a/extensions/riscv/circuit/cuda/rvr/src/jal_lui.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jal_lui.inc.cuh
@@ -93,7 +93,7 @@ __global__ void jal_lui_replay_tracegen(
         static_cast<uint16_t>(rd),
         static_cast<uint16_t>(rd >> U16_BITS),
         is_jal ? static_cast<uint16_t>(rd >> (2 * U16_BITS)) : sign,
-        is_jal ? 0 : sign,
+        is_jal ? static_cast<uint16_t>(0) : sign,
     };
     ReplayPreviousValue previous = {};
     if (needs_write) {

--- a/extensions/riscv/circuit/cuda/rvr/src/jal_lui.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jal_lui.inc.cuh
@@ -68,10 +68,7 @@ __global__ void jal_lui_replay_tracegen(
     uint32_t rd_low;
     uint32_t expected_pc;
     if (is_jal) {
-        // The return address 4 * (pc_idx + 1) and the jump target must both stay inside the
-        // implemented PC address space (mirrors the CPU trace filler).
-        if (from.pc >= ::program::MAX_ALLOWED_PC ||
-            !replay_branch_target_in_bounds(from.pc, encoded_imm)) {
+        if (!replay_branch_target_in_bounds(from.pc, encoded_imm)) {
             preflight_set_error(error, 189);
             return;
         }
@@ -90,12 +87,13 @@ __global__ void jal_lui_replay_tracegen(
         return;
     }
 
+    uint64_t rd = is_jal ? uint64_t(from.pc) + ::program::DEFAULT_PC_STEP : rd_low;
     uint16_t sign = !is_jal && (rd_low >> 31) ? UINT16_MAX : 0;
     uint16_t expected_data[BLOCK_FE_WIDTH] = {
-        static_cast<uint16_t>(rd_low),
-        static_cast<uint16_t>(rd_low >> U16_BITS),
-        sign,
-        sign,
+        static_cast<uint16_t>(rd),
+        static_cast<uint16_t>(rd >> U16_BITS),
+        is_jal ? static_cast<uint16_t>(rd >> (2 * U16_BITS)) : sign,
+        is_jal ? 0 : sign,
     };
     ReplayPreviousValue previous = {};
     if (needs_write) {

--- a/extensions/riscv/circuit/cuda/rvr/src/jal_lui.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jal_lui.inc.cuh
@@ -68,15 +68,15 @@ __global__ void jal_lui_replay_tracegen(
     uint32_t rd_low;
     uint32_t expected_pc;
     if (is_jal) {
-        constexpr uint32_t MAX_PC = (1u << PC_BITS) - 1;
-        if (from.pc > MAX_PC - ::program::DEFAULT_PC_STEP) {
+        // The return address 4 * (pc_idx + 1) and the jump target must both stay inside the
+        // implemented PC address space (mirrors the CPU trace filler).
+        if (from.pc >= ::program::MAX_ALLOWED_PC ||
+            !replay_branch_target_in_bounds(from.pc, encoded_imm)) {
             preflight_set_error(error, 189);
             return;
         }
         rd_low = from.pc + ::program::DEFAULT_PC_STEP;
-        Fp target(from.pc);
-        target += Fp(encoded_imm);
-        expected_pc = target.asUInt32();
+        expected_pc = replay_taken_branch_pc(from.pc, encoded_imm);
     } else {
         if (encoded_imm >= (1u << LUI_IMM_BITS)) {
             preflight_set_error(error, 189);

--- a/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
@@ -104,8 +104,8 @@ __global__ void jalr_replay_tracegen(
         preflight_set_error(error, 209);
         return;
     }
-    uint32_t unaligned_to_pc = static_cast<uint32_t>(unaligned_signed);
-    uint32_t to_pc = unaligned_to_pc & ~1u;
+    uint32_t raw_target_pc = static_cast<uint32_t>(unaligned_signed);
+    uint32_t to_pc = raw_target_pc & ~1u;
     if (to_pc % DEFAULT_PC_STEP != 0) {
         preflight_set_error(error, 209);
         return;

--- a/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
@@ -98,13 +98,14 @@ __global__ void jalr_replay_tracegen(
     uint32_t imm_extended = imm + imm_sign * 0xffff0000u;
     int64_t unaligned_signed =
         static_cast<int64_t>(rs1_val) + static_cast<int64_t>(static_cast<int32_t>(imm_extended));
-    if (unaligned_signed < 0 ||
-        static_cast<uint64_t>(unaligned_signed) >= (uint64_t(1) << PC_BITS)) {
+    // The target (bit 0 cleared per RISC-V) must be an aligned slot in the implemented PC
+    // address space, and the return address must not overflow it (mirrors `try_run_jalr`).
+    if (unaligned_signed < 0 || unaligned_signed > int64_t(MAX_ALLOWED_PC) ||
+        (static_cast<uint32_t>(unaligned_signed) & ~1u) % DEFAULT_PC_STEP != 0) {
         preflight_set_error(error, 209);
         return;
     }
-    constexpr uint32_t MAX_PC = (1u << PC_BITS) - 1;
-    if (from.pc > MAX_PC - DEFAULT_PC_STEP) {
+    if (from.pc >= MAX_ALLOWED_PC) {
         preflight_set_error(error, 209);
         return;
     }

--- a/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
@@ -110,19 +110,16 @@ __global__ void jalr_replay_tracegen(
         preflight_set_error(error, 209);
         return;
     }
-    if (from.pc >= MAX_ALLOWED_PC) {
-        preflight_set_error(error, 209);
-        return;
-    }
     if (to.pc != to_pc) {
         preflight_set_error(error, 207);
         return;
     }
 
+    uint64_t rd = uint64_t(from.pc) + DEFAULT_PC_STEP;
     uint16_t expected_rd[BLOCK_FE_WIDTH] = {
-        static_cast<uint16_t>(from.pc + DEFAULT_PC_STEP),
-        static_cast<uint16_t>((from.pc + DEFAULT_PC_STEP) >> U16_BITS),
-        0,
+        static_cast<uint16_t>(rd),
+        static_cast<uint16_t>(rd >> U16_BITS),
+        static_cast<uint16_t>(rd >> (2 * U16_BITS)),
         0,
     };
     ReplayPreviousValue write_previous = {};

--- a/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
+++ b/extensions/riscv/circuit/cuda/rvr/src/jalr.inc.cuh
@@ -98,10 +98,15 @@ __global__ void jalr_replay_tracegen(
     uint32_t imm_extended = imm + imm_sign * 0xffff0000u;
     int64_t unaligned_signed =
         static_cast<int64_t>(rs1_val) + static_cast<int64_t>(static_cast<int32_t>(imm_extended));
-    // The target (bit 0 cleared per RISC-V) must be an aligned slot in the implemented PC
-    // address space, and the return address must not overflow it (mirrors `try_run_jalr`).
-    if (unaligned_signed < 0 || unaligned_signed > int64_t(MAX_ALLOWED_PC) ||
-        (static_cast<uint32_t>(unaligned_signed) & ~1u) % DEFAULT_PC_STEP != 0) {
+    // The raw sum must fit in the implemented u32 PC domain. RISC-V then clears bit 0 before
+    // checking instruction alignment (mirrors `try_run_jalr`).
+    if (unaligned_signed < 0 || unaligned_signed > int64_t(UINT32_MAX)) {
+        preflight_set_error(error, 209);
+        return;
+    }
+    uint32_t unaligned_to_pc = static_cast<uint32_t>(unaligned_signed);
+    uint32_t to_pc = unaligned_to_pc & ~1u;
+    if (to_pc % DEFAULT_PC_STEP != 0) {
         preflight_set_error(error, 209);
         return;
     }
@@ -109,8 +114,7 @@ __global__ void jalr_replay_tracegen(
         preflight_set_error(error, 209);
         return;
     }
-    uint32_t unaligned_to_pc = static_cast<uint32_t>(unaligned_signed);
-    if (to.pc != (unaligned_to_pc & ~1u)) {
+    if (to.pc != to_pc) {
         preflight_set_error(error, 207);
         return;
     }

--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -35,8 +35,11 @@ struct AuipcCore {
     __device__ void fill_trace_row(RowSlice row, uint32_t from_pc, uint32_t imm) {
         uint32_t imm_low_8 = imm & ((1u << BYTE_BITS) - 1u);
         uint32_t imm_high_16 = (imm >> BYTE_BITS) & uint32_t(UINT16_MAX);
-        uint16_t pc_limbs[PTR_U16_LIMBS];
-        ptr_to_u16_limbs(pc_limbs, from_pc);
+        // `from_pc` is a byte pc; the trace decomposes its pc *index* into a
+        // PC_IDX_LOW_BITS-bit low part and a u16 high part.
+        uint32_t pc_idx = pc_to_idx(from_pc);
+        uint32_t pc_idx_low = pc_idx & ((1u << PC_IDX_LOW_BITS) - 1u);
+        uint32_t pc_high = pc_idx >> PC_IDX_LOW_BITS;
         uint64_t auipc = run_auipc(from_pc, imm);
         uint64_t auipc_hi = auipc >> 32;
         assert(auipc_hi == 0ull || auipc_hi == 0xffffffffull);
@@ -48,8 +51,8 @@ struct AuipcCore {
         uint32_t is_sign_ext = (auipc_hi != 0) ? 1u : 0u;
         uint32_t imm_sign = (imm_high_16 >> (U16_BITS - 1)) & 1u;
 
-        range_checker.add_count(pc_limbs[0], U16_BITS);
-        range_checker.add_count(pc_limbs[1], PC_BITS - U16_BITS);
+        range_checker.add_count(pc_idx_low, PC_IDX_LOW_BITS);
+        range_checker.add_count(pc_high, U16_BITS);
         range_checker.add_count(imm_low_8, BYTE_BITS);
         range_checker.add_count(imm_high_16, U16_BITS);
         range_checker.add_count(rd_lo, U16_BITS);
@@ -60,7 +63,7 @@ struct AuipcCore {
         uint32_t rd_u16[PTR_U16_LIMBS] = {rd_lo, rd_hi};
         COL_WRITE_VALUE(row, AuipcCoreCols, imm_low_8, imm_low_8);
         COL_WRITE_VALUE(row, AuipcCoreCols, imm_high_16, imm_high_16);
-        COL_WRITE_VALUE(row, AuipcCoreCols, pc_high, pc_limbs[1]);
+        COL_WRITE_VALUE(row, AuipcCoreCols, pc_high, pc_high);
         COL_WRITE_ARRAY(row, AuipcCoreCols, rd_data, rd_u16);
         COL_WRITE_VALUE(row, AuipcCoreCols, is_sign_extend, is_sign_ext);
         COL_WRITE_VALUE(row, AuipcCoreCols, is_valid, 1);

--- a/extensions/riscv/circuit/cuda/src/auipc.cu
+++ b/extensions/riscv/circuit/cuda/src/auipc.cu
@@ -13,7 +13,7 @@ using namespace program;
 
 template <typename T> struct AuipcCoreCols {
     T is_valid;
-    T is_sign_extend;
+    T imm_sign;
     // The immediate is split around the byte shift in AUIPC's `imm << 8`.
     T imm_low_8;
     T imm_high_16;
@@ -42,13 +42,12 @@ struct AuipcCore {
         uint32_t pc_high = pc_idx >> PC_IDX_LOW_BITS;
         uint64_t auipc = run_auipc(from_pc, imm);
         uint64_t auipc_hi = auipc >> 32;
-        assert(auipc_hi == 0ull || auipc_hi == 0xffffffffull);
+        assert(auipc_hi == 0ull || auipc_hi == 1ull || auipc_hi == 0xffffffffull);
         uint32_t auipc_lo = (uint32_t)auipc;
         uint16_t rd_limbs[PTR_U16_LIMBS];
         ptr_to_u16_limbs(rd_limbs, auipc_lo);
         uint32_t rd_lo = rd_limbs[0];
         uint32_t rd_hi = rd_limbs[1];
-        uint32_t is_sign_ext = (auipc_hi != 0) ? 1u : 0u;
         uint32_t imm_sign = (imm_high_16 >> (U16_BITS - 1)) & 1u;
 
         range_checker.add_count(pc_idx_low, PC_IDX_LOW_BITS);
@@ -65,7 +64,7 @@ struct AuipcCore {
         COL_WRITE_VALUE(row, AuipcCoreCols, imm_high_16, imm_high_16);
         COL_WRITE_VALUE(row, AuipcCoreCols, pc_high, pc_high);
         COL_WRITE_ARRAY(row, AuipcCoreCols, rd_data, rd_u16);
-        COL_WRITE_VALUE(row, AuipcCoreCols, is_sign_extend, is_sign_ext);
+        COL_WRITE_VALUE(row, AuipcCoreCols, imm_sign, imm_sign);
         COL_WRITE_VALUE(row, AuipcCoreCols, is_valid, 1);
     }
 };

--- a/extensions/riscv/circuit/cuda/src/hintstore.cu
+++ b/extensions/riscv/circuit/cuda/src/hintstore.cu
@@ -92,7 +92,7 @@ struct HintStore {
         COL_WRITE_VALUE(row, HintStoreCols, is_single, is_single);
         COL_WRITE_VALUE(row, HintStoreCols, is_buffer, !is_single);
         COL_WRITE_VALUE(row, HintStoreCols, rem_words, rem_words);
-        COL_WRITE_VALUE(row, HintStoreCols, from_state.pc, record.from_pc);
+        COL_WRITE_VALUE(row, HintStoreCols, from_state.pc, ::program::pc_to_idx(record.from_pc));
         COL_WRITE_VALUE(row, HintStoreCols, from_state.timestamp, timestamp);
         COL_WRITE_VALUE(row, HintStoreCols, mem_ptr_ptr, record.mem_ptr_ptr);
         COL_WRITE_ARRAY(row, HintStoreCols, mem_ptr_limbs, mem_ptr_limbs);

--- a/extensions/riscv/circuit/cuda/src/jal_lui.cu
+++ b/extensions/riscv/circuit/cuda/src/jal_lui.cu
@@ -8,7 +8,6 @@ using namespace riscv;
 using namespace program;
 
 constexpr uint32_t LUI_IMM_LOW_BITS = U16_BITS - RV_IS_TYPE_IMM_BITS;
-constexpr uint32_t PC_HIGH_U16_SHIFT = 2 * U16_BITS - PC_BITS;
 
 template <typename T> struct JalLuiCoreCols {
     T imm;                             // core_row.imm
@@ -30,19 +29,22 @@ struct JalLuiCore {
         uint32_t rd_lo = rd_data[0];
         uint32_t rd_hi = rd_data[1];
 
-        bool is_sign_extend = (rd_hi >> (U16_BITS - 1)) & 1;
+        // JAL return addresses are zero-extended; only LUI sign-extends bit 31.
+        bool is_sign_extend = is_jal ? false : ((rd_hi >> (U16_BITS - 1)) & 1);
         uint32_t imm_low_4 = is_jal ? 0u : (imm & 0xfu);
 
         range_checker.add_count(rd_lo, U16_BITS);
         range_checker.add_count(rd_hi, U16_BITS);
-        range_checker.add_count(
-            2u * rd_hi - ((uint32_t)is_sign_extend << U16_BITS), U16_BITS
-        );
 
         if (!is_jal) {
+            range_checker.add_count(
+                2u * rd_hi - ((uint32_t)is_sign_extend << U16_BITS), U16_BITS
+            );
             range_checker.add_count(imm_low_4, LUI_IMM_LOW_BITS);
         } else {
-            range_checker.add_count(rd_hi << PC_HIGH_U16_SHIFT, U16_BITS);
+            // The return address is DEFAULT_PC_STEP-aligned with a PC_IDX_LOW_BITS-bit
+            // quotient in the low limb.
+            range_checker.add_count(rd_lo >> PC_STEP_BITS, PC_IDX_LOW_BITS);
         }
 
         uint32_t rd_u16[2] = {rd_lo, rd_hi};

--- a/extensions/riscv/circuit/cuda/src/jal_lui.cu
+++ b/extensions/riscv/circuit/cuda/src/jal_lui.cu
@@ -15,7 +15,8 @@ template <typename T> struct JalLuiCoreCols {
     T imm_low_4;                       // low 4 bits of imm for LUI
     T is_jal;                          // core_row.is_jal
     T is_lui;                          // core_row.is_lui
-    T is_sign_extend;                  // 1 if upper cells are 0xFFFF, 0 if 0x0000
+    T is_sign_extend;
+    T rd_carry;
 };
 
 struct JalLuiCore {
@@ -29,8 +30,8 @@ struct JalLuiCore {
         uint32_t rd_lo = rd_data[0];
         uint32_t rd_hi = rd_data[1];
 
-        // JAL return addresses are zero-extended; only LUI sign-extends bit 31.
-        bool is_sign_extend = is_jal ? false : ((rd_hi >> (U16_BITS - 1)) & 1);
+        bool is_sign_extend = !is_jal && ((rd_hi >> (U16_BITS - 1)) & 1);
+        bool rd_carry = is_jal && rd_data[2];
         uint32_t imm_low_4 = is_jal ? 0u : (imm & 0xfu);
 
         range_checker.add_count(rd_lo, U16_BITS);
@@ -49,6 +50,7 @@ struct JalLuiCore {
 
         uint32_t rd_u16[2] = {rd_lo, rd_hi};
         COL_WRITE_VALUE(row, JalLuiCoreCols, is_sign_extend, is_sign_extend);
+        COL_WRITE_VALUE(row, JalLuiCoreCols, rd_carry, rd_carry);
         COL_WRITE_VALUE(row, JalLuiCoreCols, is_lui, !is_jal);
         COL_WRITE_VALUE(row, JalLuiCoreCols, is_jal, is_jal);
         COL_WRITE_VALUE(row, JalLuiCoreCols, imm_low_4, imm_low_4);

--- a/extensions/riscv/circuit/cuda/src/jalr.cu
+++ b/extensions/riscv/circuit/cuda/src/jalr.cu
@@ -12,7 +12,7 @@ using namespace program;
 template <typename T> struct JalrCoreCols {
     T imm;                                  // 2 bytes
     T rs1_data[PTR_U16_LIMBS];         // low 32 bits of rs1 as u16 cells
-    T rd_high[PTR_U16_LIMBS - 1];      // high u16 limb of low-32 rd
+    T rd_high[PTR_U16_LIMBS];          // high u16 limb and bit-32 carry of rd
     T is_valid;                             // 1 byte
     T to_pc_least_sig_bit;                  // 1 byte
     T to_pc_limbs[PTR_U16_LIMBS];      // target pc index after the low-bit split
@@ -36,12 +36,10 @@ __device__ void run_jalr(
     // RISC-V clears bit 0 before checking instruction alignment.
     assert(to_pc % DEFAULT_PC_STEP == 0);
     out_unaligned_pc = uint32_t(unaligned_to_pc);
-    uint32_t rd_val = pc + DEFAULT_PC_STEP;
-    rd_data[0] = uint16_t(rd_val);
-    rd_data[1] = uint16_t(rd_val >> U16_BITS);
+    uint64_t rd_val = uint64_t(pc) + DEFAULT_PC_STEP;
 #pragma unroll
-    for (size_t i = PTR_U16_LIMBS; i < BLOCK_FE_WIDTH; i++) {
-        rd_data[i] = 0;
+    for (size_t i = 0; i < BLOCK_FE_WIDTH; i++) {
+        rd_data[i] = uint16_t(rd_val >> (i * U16_BITS));
     }
 }
 
@@ -84,7 +82,7 @@ struct JalrCore {
         COL_WRITE_VALUE(row, JalrCoreCols, is_valid, 1);
 
         COL_WRITE_ARRAY(row, JalrCoreCols, rs1_data, rs1_limbs);
-        uint32_t rd_limbs[PTR_U16_LIMBS - 1] = {rd_low_u16_hi};
+        uint32_t rd_limbs[PTR_U16_LIMBS] = {rd_low_u16_hi, rd_data[2]};
         COL_WRITE_ARRAY(row, JalrCoreCols, rd_high, rd_limbs);
         COL_WRITE_VALUE(row, JalrCoreCols, imm, imm);
     }

--- a/extensions/riscv/circuit/cuda/src/jalr.cu
+++ b/extensions/riscv/circuit/cuda/src/jalr.cu
@@ -24,17 +24,18 @@ __device__ void run_jalr(
     uint32_t rs1,
     uint16_t imm,
     bool imm_sign,
-    uint32_t &out_pc,
+    uint32_t &out_unaligned_pc,
     uint16_t rd_data[BLOCK_FE_WIDTH]
 ) {
     uint32_t offset = imm + (imm_sign ? (uint32_t(UINT16_MAX) << U16_BITS) : 0);
     int64_t signed_offset = (int64_t)(int32_t)offset;
-    uint64_t to_pc = uint64_t(rs1) + signed_offset;
+    uint64_t unaligned_to_pc = uint64_t(rs1) + signed_offset;
 
-    assert(to_pc <= uint64_t(MAX_ALLOWED_PC));
-    // Bit 0 is cleared per RISC-V; a set bit 1 (misaligned target) is rejected upstream.
-    assert((uint32_t(to_pc) & 0b10) == 0);
-    out_pc = uint32_t(to_pc);
+    assert(unaligned_to_pc <= uint64_t(UINT32_MAX));
+    uint32_t to_pc = uint32_t(unaligned_to_pc) & ~1u;
+    // RISC-V clears bit 0 before checking instruction alignment.
+    assert(to_pc % DEFAULT_PC_STEP == 0);
+    out_unaligned_pc = uint32_t(unaligned_to_pc);
     uint32_t rd_val = pc + DEFAULT_PC_STEP;
     rd_data[0] = uint16_t(rd_val);
     rd_data[1] = uint16_t(rd_val >> U16_BITS);
@@ -52,12 +53,12 @@ struct JalrCore {
     __device__ void fill_trace_row(
         RowSlice row, uint32_t from_pc, uint32_t rs1_val, uint16_t imm, bool imm_sign
     ) {
-        uint32_t to_pc;
+        uint32_t unaligned_to_pc;
         uint16_t rd_data[BLOCK_FE_WIDTH];
-        run_jalr(from_pc, rs1_val, imm, imm_sign, to_pc, rd_data);
+        run_jalr(from_pc, rs1_val, imm, imm_sign, unaligned_to_pc, rd_data);
 
         // to_pc_limbs decompose the target pc *index* (see the Rust filler).
-        uint32_t to_pc_idx = (to_pc & ~1u) >> PC_STEP_BITS;
+        uint32_t to_pc_idx = (unaligned_to_pc & ~1u) >> PC_STEP_BITS;
         uint32_t to_pc_limbs[2] = {
             to_pc_idx & ((1u << PC_IDX_LOW_BITS) - 1), to_pc_idx >> PC_IDX_LOW_BITS
         };
@@ -77,7 +78,9 @@ struct JalrCore {
 
         COL_WRITE_VALUE(row, JalrCoreCols, imm_sign, imm_sign);
         COL_WRITE_ARRAY(row, JalrCoreCols, to_pc_limbs, to_pc_limbs);
-        COL_WRITE_VALUE(row, JalrCoreCols, to_pc_least_sig_bit, (to_pc & 1) == 1 ? 1 : 0);
+        COL_WRITE_VALUE(
+            row, JalrCoreCols, to_pc_least_sig_bit, (unaligned_to_pc & 1) == 1 ? 1 : 0
+        );
         COL_WRITE_VALUE(row, JalrCoreCols, is_valid, 1);
 
         COL_WRITE_ARRAY(row, JalrCoreCols, rs1_data, rs1_limbs);

--- a/extensions/riscv/circuit/cuda/src/jalr.cu
+++ b/extensions/riscv/circuit/cuda/src/jalr.cu
@@ -14,8 +14,8 @@ template <typename T> struct JalrCoreCols {
     T rs1_data[PTR_U16_LIMBS];         // low 32 bits of rs1 as u16 cells
     T rd_high[PTR_U16_LIMBS];          // high u16 limb and bit-32 carry of rd
     T is_valid;                             // 1 byte
-    T to_pc_least_sig_bit;                  // 1 byte
-    T to_pc_limbs[PTR_U16_LIMBS];      // target pc index after the low-bit split
+    T raw_target_bit0;                  // bit zero of the target before JALR masking
+    T to_pc_idx_limbs[PTR_U16_LIMBS];  // target pc index after the low-bit split
     T imm_sign;                             // 1 byte
 };
 
@@ -24,18 +24,18 @@ __device__ void run_jalr(
     uint32_t rs1,
     uint16_t imm,
     bool imm_sign,
-    uint32_t &out_unaligned_pc,
+    uint32_t &out_raw_target_pc,
     uint16_t rd_data[BLOCK_FE_WIDTH]
 ) {
     uint32_t offset = imm + (imm_sign ? (uint32_t(UINT16_MAX) << U16_BITS) : 0);
     int64_t signed_offset = (int64_t)(int32_t)offset;
-    uint64_t unaligned_to_pc = uint64_t(rs1) + signed_offset;
+    uint64_t raw_target_pc = uint64_t(rs1) + signed_offset;
 
-    assert(unaligned_to_pc <= uint64_t(UINT32_MAX));
-    uint32_t to_pc = uint32_t(unaligned_to_pc) & ~1u;
+    assert(raw_target_pc <= uint64_t(UINT32_MAX));
+    uint32_t to_pc = uint32_t(raw_target_pc) & ~1u;
     // RISC-V clears bit 0 before checking instruction alignment.
     assert(to_pc % DEFAULT_PC_STEP == 0);
-    out_unaligned_pc = uint32_t(unaligned_to_pc);
+    out_raw_target_pc = uint32_t(raw_target_pc);
     uint64_t rd_val = uint64_t(pc) + DEFAULT_PC_STEP;
 #pragma unroll
     for (size_t i = 0; i < BLOCK_FE_WIDTH; i++) {
@@ -51,17 +51,17 @@ struct JalrCore {
     __device__ void fill_trace_row(
         RowSlice row, uint32_t from_pc, uint32_t rs1_val, uint16_t imm, bool imm_sign
     ) {
-        uint32_t unaligned_to_pc;
+        uint32_t raw_target_pc;
         uint16_t rd_data[BLOCK_FE_WIDTH];
-        run_jalr(from_pc, rs1_val, imm, imm_sign, unaligned_to_pc, rd_data);
+        run_jalr(from_pc, rs1_val, imm, imm_sign, raw_target_pc, rd_data);
 
-        // to_pc_limbs decompose the target pc *index* (see the Rust filler).
-        uint32_t to_pc_idx = (unaligned_to_pc & ~1u) >> PC_STEP_BITS;
-        uint32_t to_pc_limbs[2] = {
+        // to_pc_idx_limbs decompose the target pc *index* (see the Rust filler).
+        uint32_t to_pc_idx = (raw_target_pc & ~1u) >> PC_STEP_BITS;
+        uint32_t to_pc_idx_limbs[2] = {
             to_pc_idx & ((1u << PC_IDX_LOW_BITS) - 1), to_pc_idx >> PC_IDX_LOW_BITS
         };
-        rc.add_count(to_pc_limbs[0], PC_IDX_LOW_BITS);
-        rc.add_count(to_pc_limbs[1], U16_BITS);
+        rc.add_count(to_pc_idx_limbs[0], PC_IDX_LOW_BITS);
+        rc.add_count(to_pc_idx_limbs[1], U16_BITS);
 
         uint32_t rd_low_u16_lo = rd_data[0];
         uint32_t rd_low_u16_hi = rd_data[1];
@@ -75,9 +75,9 @@ struct JalrCore {
         ptr_to_u16_limbs(rs1_limbs, rs1_val);
 
         COL_WRITE_VALUE(row, JalrCoreCols, imm_sign, imm_sign);
-        COL_WRITE_ARRAY(row, JalrCoreCols, to_pc_limbs, to_pc_limbs);
+        COL_WRITE_ARRAY(row, JalrCoreCols, to_pc_idx_limbs, to_pc_idx_limbs);
         COL_WRITE_VALUE(
-            row, JalrCoreCols, to_pc_least_sig_bit, (unaligned_to_pc & 1) == 1 ? 1 : 0
+            row, JalrCoreCols, raw_target_bit0, (raw_target_pc & 1) == 1 ? 1 : 0
         );
         COL_WRITE_VALUE(row, JalrCoreCols, is_valid, 1);
 

--- a/extensions/riscv/circuit/cuda/src/jalr.cu
+++ b/extensions/riscv/circuit/cuda/src/jalr.cu
@@ -15,7 +15,7 @@ template <typename T> struct JalrCoreCols {
     T rd_high[PTR_U16_LIMBS - 1];      // high u16 limb of low-32 rd
     T is_valid;                             // 1 byte
     T to_pc_least_sig_bit;                  // 1 byte
-    T to_pc_limbs[PTR_U16_LIMBS];      // `to_pc * 2` after the low-bit split
+    T to_pc_limbs[PTR_U16_LIMBS];      // target pc index after the low-bit split
     T imm_sign;                             // 1 byte
 };
 
@@ -31,7 +31,9 @@ __device__ void run_jalr(
     int64_t signed_offset = (int64_t)(int32_t)offset;
     uint64_t to_pc = uint64_t(rs1) + signed_offset;
 
-    assert(to_pc < (uint64_t(1) << PC_BITS));
+    assert(to_pc <= uint64_t(MAX_ALLOWED_PC));
+    // Bit 0 is cleared per RISC-V; a set bit 1 (misaligned target) is rejected upstream.
+    assert((uint32_t(to_pc) & 0b10) == 0);
     out_pc = uint32_t(to_pc);
     uint32_t rd_val = pc + DEFAULT_PC_STEP;
     rd_data[0] = uint16_t(rd_val);
@@ -54,21 +56,21 @@ struct JalrCore {
         uint16_t rd_data[BLOCK_FE_WIDTH];
         run_jalr(from_pc, rs1_val, imm, imm_sign, to_pc, rd_data);
 
-        uint16_t to_pc_u16[PTR_U16_LIMBS];
-        ptr_to_u16_limbs(to_pc_u16, to_pc);
-        uint32_t to_pc_limbs[2] = {uint32_t(to_pc_u16[0] >> 1), uint32_t(to_pc_u16[1])};
-        // to_pc_limbs[0] is 15 bits because it is doubled to reconstruct
-        // the aligned JALR target.
-        rc.add_count(to_pc_limbs[0], U16_BITS - 1);
-        rc.add_count(to_pc_limbs[1], PC_BITS - U16_BITS);
+        // to_pc_limbs decompose the target pc *index* (see the Rust filler).
+        uint32_t to_pc_idx = (to_pc & ~1u) >> PC_STEP_BITS;
+        uint32_t to_pc_limbs[2] = {
+            to_pc_idx & ((1u << PC_IDX_LOW_BITS) - 1), to_pc_idx >> PC_IDX_LOW_BITS
+        };
+        rc.add_count(to_pc_limbs[0], PC_IDX_LOW_BITS);
+        rc.add_count(to_pc_limbs[1], U16_BITS);
 
         uint32_t rd_low_u16_lo = rd_data[0];
         uint32_t rd_low_u16_hi = rd_data[1];
 
-        // rd writes the low 32 bits of from_pc + DEFAULT_PC_STEP. The high
-        // limb is narrowed to the remaining PC bits because from_pc is program-bus bounded.
-        rc.add_count(rd_low_u16_lo, U16_BITS);
-        rc.add_count(rd_low_u16_hi, PC_BITS - U16_BITS);
+        // rd writes the byte return address 4 * (from_pc_idx + 1). The low limb is
+        // DEFAULT_PC_STEP-aligned with a PC_IDX_LOW_BITS-bit quotient; the high limb is a u16.
+        rc.add_count(rd_low_u16_lo >> PC_STEP_BITS, PC_IDX_LOW_BITS);
+        rc.add_count(rd_low_u16_hi, U16_BITS);
 
         uint16_t rs1_limbs[PTR_U16_LIMBS];
         ptr_to_u16_limbs(rs1_limbs, rs1_val);

--- a/extensions/riscv/circuit/cuda/src/reveal.cu
+++ b/extensions/riscv/circuit/cuda/src/reveal.cu
@@ -44,7 +44,7 @@ struct Reveal {
 
     __device__ void fill_trace_row(RowSlice row, ReplayRevealInput const &input) {
         COL_WRITE_VALUE(row, RevealCols, is_valid, 1);
-        COL_WRITE_VALUE(row, RevealCols, from_state.pc, input.from_pc);
+        COL_WRITE_VALUE(row, RevealCols, from_state.pc, ::program::pc_to_idx(input.from_pc));
         COL_WRITE_VALUE(row, RevealCols, from_state.timestamp, input.from_timestamp);
         COL_WRITE_VALUE(row, RevealCols, base_ptr, input.base_ptr);
 

--- a/extensions/riscv/circuit/src/README.md
+++ b/extensions/riscv/circuit/src/README.md
@@ -270,13 +270,16 @@ Given:
 This circuit proves that:
 
 - Each limb of `rd` is in the range `[0, 2^BYTE_BITS)`
-- If `opcode` is `jal`, then
-  - `to_pc == pc + imm`
-  - `compose(rd) == pc + 4`
-  - The most significant limb of `rd` is in the range `[0, 2^(PC_BITS - BYTE_BITS * (WORD_NUM_LIMBS - 1))`
+- If `opcode` is `jal`, then (with `pc` and `to_pc` as pc *indices*, i.e. byte pcs divided by 4,
+  and `imm` a 4-byte-aligned byte offset)
+  - `to_pc == pc + imm / 4`
+  - `compose(rd) == 4 * (pc + 1)`, the byte return address; the low u16 limb of `rd` is a
+    multiple of 4 whose quotient is in the range `[0, 2^PC_IDX_LOW_BITS)`, which pins the
+    decomposition and keeps the return address inside the 32-bit PC address space
+  - The upper register cells of `rd` are zero (return addresses are zero-extended)
 - If `opcode` is `lui`, then
-  - `to_pc == pc + 4`
-  - `compose(rd) == imm * 2^12`
+  - `to_pc == pc + 1`
+  - `compose(rd) == imm * 2^12`, sign-extended into the upper register cells
 
 #### 7. [JALR](./jalr/core.rs)
 
@@ -286,17 +289,20 @@ Given:
 - `rd` is the decomposition of the result
 - `imm` is the immediate value
 - `to_pc_least_sig_bit` is the least significant bit of `compose(rs1) + imm`
-- `to_pc_limbs` is the decomposition of the remaining destination program address bits, where `to_pc_limbs[0]` is 15 bits and `to_pc_limbs[1]` contains the upper bits
+- `to_pc_limbs` is the decomposition of the destination pc *index* (the byte target divided
+  by 4), where `to_pc_limbs[0]` is its low `PC_IDX_LOW_BITS` bits and `to_pc_limbs[1]` its
+  high u16 limb
 
 This circuit proves that:
 
-- `to_pc_least_sig_bit + 2 * compose(to_pc_limbs) == compose(rs1) + imm`
-- The destination program address is `2 * compose(to_pc_limbs)`, so the least significant bit is cleared as required by `jalr`
-- `compose(rd) == pc + 4`
-- Each limb of `rd` is in the range `[0, 2^BYTE_BITS)`
-- The most significant limb of `rd` is in the range `[0, 2^(PC_BITS - BYTE_BITS * (WORD_NUM_LIMBS - 1))`
-- `to_pc_limbs[0]` is in the range `[0, 2^15)`
-- `to_pc_limbs[1]` is in the range `[0, 2^(PC_BITS - 16))`
+- `to_pc_least_sig_bit + 4 * compose(to_pc_limbs) == compose(rs1) + imm` as a low-32-bit
+  addition with boolean carries; a byte target with bit 1 set (misaligned) is unsatisfiable
+- The destination pc index is `compose(to_pc_limbs)`, so the least significant bit of the
+  byte target is cleared as required by `jalr`
+- `compose(rd) == 4 * (pc + 1)`, the byte return address (with `pc` the pc index); the low
+  u16 limb of `rd` is a multiple of 4 whose quotient is in the range `[0, 2^PC_IDX_LOW_BITS)`
+- The high u16 limb of `rd` and `to_pc_limbs[1]` are in the range `[0, 2^16)`
+- `to_pc_limbs[0]` is in the range `[0, 2^PC_IDX_LOW_BITS)`
 
 #### 8. [AUIPC](./auipc/core.rs)
 
@@ -308,10 +314,12 @@ Given:
 
 This circuit proves that:
 
-- `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^8`
-- `compose(pc_limbs) == pc`
-- Each limb of `rd`, `imm_limbs`, and `pc_limbs` is in the range `[0, 2^BYTE_BITS)`
-- The most significant limb of `pc_limbs` is in the range `[0, 2^(PC_BITS - BYTE_BITS * (WORD_NUM_LIMBS - 1))`
+- `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^8` mod `2^32`, with negative
+  results sign-extended into the upper register cells and results at or above `2^32`
+  unsatisfiable
+- `compose(pc_limbs) == 4 * pc`, the byte pc for the pc index `pc`: the low u16 limb is
+  `4 * pc_idx_low` with `pc_idx_low` in the range `[0, 2^PC_IDX_LOW_BITS)` and the high u16
+  limb in the range `[0, 2^16)`
 
 #### 9. Less Than
 

--- a/extensions/riscv/circuit/src/adapters/alu_imm.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_imm.rs
@@ -13,7 +13,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{IMM_AS, REGISTER_AS, REGISTER_NUM_LIMBS},
 };
 use openvm_stark_backend::{
@@ -116,7 +116,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluImmAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -179,7 +179,7 @@ impl BaseAluImmAdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((input, output))
     }

--- a/extensions/riscv/circuit/src/adapters/alu_imm.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_imm.rs
@@ -105,7 +105,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluImmAdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -116,12 +116,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluImmAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &BaseAluImmAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/alu_imm_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_imm_u16.rs
@@ -98,7 +98,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluImmU16AdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -109,12 +109,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluImmU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &BaseAluImmU16AdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/alu_imm_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_imm_u16.rs
@@ -13,7 +13,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{IMM_AS, REGISTER_AS},
 };
 use openvm_stark_backend::{
@@ -109,7 +109,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluImmU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -171,7 +171,7 @@ impl BaseAluImmU16AdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((rs1.value, output))
     }

--- a/extensions/riscv/circuit/src/adapters/alu_reg.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_reg.rs
@@ -114,7 +114,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluRegAdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -125,12 +125,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluRegAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &BaseAluRegAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/alu_reg.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_reg.rs
@@ -14,7 +14,7 @@ use openvm_circuit::{
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{REGISTER_AS, REGISTER_NUM_LIMBS},
 };
 use openvm_stark_backend::{
@@ -125,7 +125,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluRegAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -191,7 +191,7 @@ impl BaseAluRegAdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((inputs, output))
     }

--- a/extensions/riscv/circuit/src/adapters/alu_reg_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_reg_u16.rs
@@ -111,7 +111,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluRegU16AdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -122,12 +122,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluRegU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &BaseAluRegU16AdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/alu_reg_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_reg_u16.rs
@@ -13,7 +13,10 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::REGISTER_AS};
+use openvm_instructions::{
+    program::{pc_to_idx, DEFAULT_PC_STEP},
+    riscv::REGISTER_AS,
+};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
@@ -119,7 +122,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluRegU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -184,7 +187,7 @@ impl BaseAluRegU16AdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok(([rs1.value, rs2.value], output))
     }

--- a/extensions/riscv/circuit/src/adapters/alu_w_imm_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_imm_u16.rs
@@ -128,7 +128,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluWImmU16AdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -139,12 +139,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluWImmU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let local: &BaseAluWImmU16AdapterCols<_> = local.borrow();
         local.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/alu_w_imm_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_imm_u16.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{IMM_AS, REGISTER_AS},
 };
 use openvm_stark_backend::{
@@ -139,7 +139,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluWImmU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -221,7 +221,7 @@ impl BaseAluWImmU16AdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((input, output))
     }

--- a/extensions/riscv/circuit/src/adapters/alu_w_reg_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_reg_u16.rs
@@ -16,7 +16,10 @@ use openvm_circuit_primitives::{
     ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::REGISTER_AS};
+use openvm_instructions::{
+    program::{pc_to_idx, DEFAULT_PC_STEP},
+    riscv::REGISTER_AS,
+};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
@@ -152,7 +155,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluWRegU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -241,7 +244,7 @@ impl BaseAluWRegU16AdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((inputs, output))
     }

--- a/extensions/riscv/circuit/src/adapters/alu_w_reg_u16.rs
+++ b/extensions/riscv/circuit/src/adapters/alu_w_reg_u16.rs
@@ -144,7 +144,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluWRegU16AdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -155,12 +155,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BaseAluWRegU16AdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &BaseAluWRegU16AdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/branch.rs
+++ b/extensions/riscv/circuit/src/adapters/branch.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::REGISTER_AS};
+use openvm_instructions::{program::pc_to_idx, riscv::REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
@@ -97,7 +97,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BranchAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -151,7 +151,7 @@ impl BranchAdapterFiller {
             rs1.timestamp,
             adapter_row.reads_aux[0].as_mut(),
         );
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rs2_ptr = F::from_u32(rs2_ptr);

--- a/extensions/riscv/circuit/src/adapters/branch.rs
+++ b/extensions/riscv/circuit/src/adapters/branch.rs
@@ -86,7 +86,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BranchAdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rs1_ptr.into(),
@@ -97,12 +97,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for BranchAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &BranchAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/jalr.rs
+++ b/extensions/riscv/circuit/src/adapters/jalr.rs
@@ -103,7 +103,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for JalrAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx
+            .to_pc_idx
+            .unwrap_or(local_cols.from_state.pc + AB::F::ONE);
 
         // regardless of `needs_write`, must always execute instruction when `is_valid`.
         self.execution_bridge
@@ -127,7 +129,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for JalrAdapterAir {
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &JalrAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/jalr.rs
+++ b/extensions/riscv/circuit/src/adapters/jalr.rs
@@ -103,7 +103,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for JalrAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
 
         // regardless of `needs_write`, must always execute instruction when `is_valid`.
         self.execution_bridge
@@ -120,7 +120,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for JalrAdapterAir {
                 ],
                 local_cols.from_state,
                 ExecutionState {
-                    pc: to_pc,
+                    pc: to_pc_idx,
                     timestamp: timestamp + AB::F::from_usize(timestamp_delta),
                 },
             )

--- a/extensions/riscv/circuit/src/adapters/jalr.rs
+++ b/extensions/riscv/circuit/src/adapters/jalr.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::REGISTER_AS};
+use openvm_instructions::{program::pc_to_idx, riscv::REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
@@ -103,9 +103,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for JalrAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx
-            .to_pc
-            .unwrap_or(local_cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP));
+        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
 
         // regardless of `needs_write`, must always execute instruction when `is_valid`.
         self.execution_bridge
@@ -219,7 +217,7 @@ impl JalrAdapterFiller {
         );
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((rs1.value, to_pc, rd_data))
     }

--- a/extensions/riscv/circuit/src/adapters/jalr.rs
+++ b/extensions/riscv/circuit/src/adapters/jalr.rs
@@ -189,7 +189,7 @@ impl JalrAdapterFiller {
         let rd_u16_ptr = checked_register_u16_pointer(rd_ptr)?;
         let mut replay = postflight.replay(step);
         let rs1 = replay.read_u16(REGISTER_AS, rs1_u16_ptr)?;
-        let (to_pc, rd_data) = compute(from_pc, rs1.value, immediate as u16, imm_sign)?;
+        let (raw_target_pc, rd_data) = compute(from_pc, rs1.value, immediate as u16, imm_sign)?;
 
         adapter_row.needs_write = F::from_bool(needs_write);
         if needs_write {
@@ -208,7 +208,7 @@ impl JalrAdapterFiller {
             mem_helper.fill_zero(adapter_row.rd_aux_cols.as_mut());
             adapter_row.rd_ptr = F::ZERO;
         }
-        replay.finish(to_pc & !1)?;
+        replay.finish(raw_target_pc & !1)?;
 
         mem_helper.fill(
             rs1.previous_timestamp,
@@ -219,6 +219,6 @@ impl JalrAdapterFiller {
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
         adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
-        Ok((rs1.value, to_pc, rd_data))
+        Ok((rs1.value, raw_target_pc, rd_data))
     }
 }

--- a/extensions/riscv/circuit/src/adapters/load/byte.rs
+++ b/extensions/riscv/circuit/src/adapters/load/byte.rs
@@ -179,7 +179,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadByteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -194,7 +194,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadByteAdapterAir {
                 ],
                 local_cols.from_state,
                 ExecutionState {
-                    pc: to_pc,
+                    pc: to_pc_idx,
                     timestamp: timestamp + AB::F::from_usize(timestamp_delta),
                 },
             )

--- a/extensions/riscv/circuit/src/adapters/load/byte.rs
+++ b/extensions/riscv/circuit/src/adapters/load/byte.rs
@@ -179,7 +179,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadByteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx
+            .to_pc_idx
+            .unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -201,7 +203,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadByteAdapterAir {
             .eval(builder, is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let local_cols: &LoadByteAdapterCols<AB::Var> = local.borrow();
         local_cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/load/byte.rs
+++ b/extensions/riscv/circuit/src/adapters/load/byte.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_stark_backend::{
@@ -179,9 +179,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadByteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx
-            .to_pc
-            .unwrap_or(local_cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP));
+        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -345,7 +343,7 @@ impl LoadByteAdapterFiller {
         adapter_row.rs1_data = ptr_to_field_u16_limbs(rs1_val);
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((memory.value, shift_amount, output))
     }

--- a/extensions/riscv/circuit/src/adapters/load/multi_byte.rs
+++ b/extensions/riscv/circuit/src/adapters/load/multi_byte.rs
@@ -196,7 +196,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadMultiByteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx
+            .to_pc_idx
+            .unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -218,7 +220,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadMultiByteAdapterAir {
             .eval(builder, is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let local_cols: &LoadMultiByteAdapterCols<AB::Var> = local.borrow();
         local_cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/load/multi_byte.rs
+++ b/extensions/riscv/circuit/src/adapters/load/multi_byte.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_stark_backend::{
@@ -196,9 +196,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadMultiByteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx
-            .to_pc
-            .unwrap_or(local_cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP));
+        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -395,7 +393,7 @@ impl LoadMultiByteAdapterFiller {
         adapter_row.rs1_data = ptr_to_field_u16_limbs(rs1_val);
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((read_data, shift, output))
     }

--- a/extensions/riscv/circuit/src/adapters/load/multi_byte.rs
+++ b/extensions/riscv/circuit/src/adapters/load/multi_byte.rs
@@ -196,7 +196,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadMultiByteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -211,7 +211,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for LoadMultiByteAdapterAir {
                 ],
                 local_cols.from_state,
                 ExecutionState {
-                    pc: to_pc,
+                    pc: to_pc_idx,
                     timestamp: timestamp + AB::F::from_usize(timestamp_delta),
                 },
             )

--- a/extensions/riscv/circuit/src/adapters/mod.rs
+++ b/extensions/riscv/circuit/src/adapters/mod.rs
@@ -14,6 +14,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::{
     instruction::InstructionOperand,
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_BITS, PC_STEP_BITS},
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_platform::memory::MEM_SIZE;
@@ -53,6 +54,14 @@ pub use store::*;
 
 /// Number of u16 limbs needed for a low-32-bit RV64 pointer.
 pub const PTR_U16_LIMBS: usize = WORD_NUM_LIMBS / 2;
+/// Number of low bits of a pc index (`pc / DEFAULT_PC_STEP`) packed into the low u16 limb of the
+/// corresponding byte pc: the low limb is `DEFAULT_PC_STEP * (pc_idx % 2^PC_IDX_LOW_BITS)`.
+pub const PC_IDX_LOW_BITS: usize = U16_BITS - PC_STEP_BITS;
+/// Number of high bits of a pc index; equals the high u16 limb of the corresponding byte pc.
+pub const PC_IDX_HIGH_BITS: usize = PC_BITS - PC_IDX_LOW_BITS;
+// The pc-arithmetic chips (JAL/JALR/AUIPC) assume a byte pc is exactly two u16 limbs with the
+// high limb equal to the high PC_IDX_HIGH_BITS bits of the pc index.
+const _: () = assert!(PC_IDX_HIGH_BITS == U16_BITS && PC_BITS + PC_STEP_BITS == 32);
 /// Bit width covered by [`PTR_U16_LIMBS`].
 pub const PTR_BITS: usize = U16_BITS * PTR_U16_LIMBS;
 /// Number of u16 limbs in a 32-bit RV64 word (e.g. an `ADDW`/`SUBW` operand, or one half of a
@@ -254,6 +263,25 @@ pub fn sign_extend_imm16(imm: u32, sign: u32) -> u32 {
 #[inline(always)]
 pub fn sext32_to_u64(value: u32) -> u64 {
     value as i32 as i64 as u64
+}
+
+/// Byte program counter after a taken branch: `pc + imm` with the interpreter's wrap-around
+/// semantics (`imm` is a signed byte offset).
+#[inline(always)]
+pub fn taken_branch_pc(pc: u32, imm: i32) -> u32 {
+    pc.wrapping_add_signed(imm)
+}
+
+/// Validates that a taken branch from byte pc `from_pc` with the given signed immediate
+/// lands inside the implemented PC address space on a DEFAULT_PC_STEP-aligned address.
+pub fn checked_branch_target(from_pc: u32, imm: i32) -> Result<(), PostflightError> {
+    let target = from_pc as i64 + imm as i64;
+    if target < 0 || target > MAX_ALLOWED_PC as i64 || target % DEFAULT_PC_STEP as i64 != 0 {
+        return Err(PostflightError::new(
+            "branch target outside implemented PC address space",
+        ));
+    }
+    Ok(())
 }
 
 // For soundness, should be <= 16

--- a/extensions/riscv/circuit/src/adapters/mod.rs
+++ b/extensions/riscv/circuit/src/adapters/mod.rs
@@ -14,7 +14,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::{
     instruction::InstructionOperand,
-    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_BITS, PC_STEP_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_IDX_BITS, PC_STEP_BITS},
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_platform::memory::MEM_SIZE;
@@ -58,10 +58,10 @@ pub const PTR_U16_LIMBS: usize = WORD_NUM_LIMBS / 2;
 /// corresponding byte pc: the low limb is `DEFAULT_PC_STEP * (pc_idx % 2^PC_IDX_LOW_BITS)`.
 pub const PC_IDX_LOW_BITS: usize = U16_BITS - PC_STEP_BITS;
 /// Number of high bits of a pc index; equals the high u16 limb of the corresponding byte pc.
-pub const PC_IDX_HIGH_BITS: usize = PC_BITS - PC_IDX_LOW_BITS;
+pub const PC_IDX_HIGH_BITS: usize = PC_IDX_BITS - PC_IDX_LOW_BITS;
 // The pc-arithmetic chips (JAL/JALR/AUIPC) assume a byte pc is exactly two u16 limbs with the
 // high limb equal to the high PC_IDX_HIGH_BITS bits of the pc index.
-const _: () = assert!(PC_IDX_HIGH_BITS == U16_BITS && PC_BITS + PC_STEP_BITS == 32);
+const _: () = assert!(PC_IDX_HIGH_BITS == U16_BITS && PC_IDX_BITS + PC_STEP_BITS == 32);
 /// Bit width covered by [`PTR_U16_LIMBS`].
 pub const PTR_BITS: usize = U16_BITS * PTR_U16_LIMBS;
 /// Number of u16 limbs in a 32-bit RV64 word (e.g. an `ADDW`/`SUBW` operand, or one half of a

--- a/extensions/riscv/circuit/src/adapters/mod.rs
+++ b/extensions/riscv/circuit/src/adapters/mod.rs
@@ -448,6 +448,12 @@ pub fn u32_to_u16_block(value: u32) -> [u16; BLOCK_FE_WIDTH] {
     })
 }
 
+/// Converts an RV64 register value to one u16 block.
+#[inline(always)]
+pub fn u64_to_u16_block(value: u64) -> [u16; BLOCK_FE_WIDTH] {
+    std::array::from_fn(|i| (value >> (U16_BITS * i)) as u16)
+}
+
 /// Splits a 32-bit RV64 pointer into low-to-high u16 limbs.
 #[inline(always)]
 pub fn ptr_to_u16_limbs(ptr: u32) -> [u16; PTR_U16_LIMBS] {

--- a/extensions/riscv/circuit/src/adapters/mul.rs
+++ b/extensions/riscv/circuit/src/adapters/mul.rs
@@ -13,7 +13,10 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::REGISTER_AS};
+use openvm_instructions::{
+    program::{pc_to_idx, DEFAULT_PC_STEP},
+    riscv::REGISTER_AS,
+};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::BaseAir,
@@ -124,7 +127,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for MultAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -191,7 +194,7 @@ impl MultAdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok(ReplayResult {
             inputs,

--- a/extensions/riscv/circuit/src/adapters/mul.rs
+++ b/extensions/riscv/circuit/src/adapters/mul.rs
@@ -116,7 +116,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for MultAdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -127,12 +127,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for MultAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &MultAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/mul_w.rs
+++ b/extensions/riscv/circuit/src/adapters/mul_w.rs
@@ -17,7 +17,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{BYTE_BITS, REGISTER_AS, REGISTER_NUM_LIMBS, WORD_NUM_LIMBS},
 };
 use openvm_stark_backend::{
@@ -157,7 +157,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for MultWAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (DEFAULT_PC_STEP, ctx.to_pc),
+                (1, ctx.to_pc),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
@@ -244,7 +244,7 @@ impl MultWAdapterFiller {
         adapter_row.rs1_ptr = F::from_u32(rs1_ptr);
         adapter_row.rd_ptr = F::from_u32(rd_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok(ReplayResult {
             inputs,

--- a/extensions/riscv/circuit/src/adapters/mul_w.rs
+++ b/extensions/riscv/circuit/src/adapters/mul_w.rs
@@ -146,7 +146,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for MultWAdapterAir {
             .eval(builder, ctx.instruction.is_valid.clone());
 
         self.execution_bridge
-            .execute_and_increment_or_set_pc(
+            .execute_and_increment_or_set_pc_idx(
                 ctx.instruction.opcode,
                 [
                     local.rd_ptr.into(),
@@ -157,12 +157,12 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for MultWAdapterAir {
                 ],
                 local.from_state,
                 AB::F::from_usize(timestamp_delta),
-                (1, ctx.to_pc),
+                (1, ctx.to_pc_idx),
             )
             .eval(builder, ctx.instruction.is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &MultWAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/rdwrite.rs
+++ b/extensions/riscv/circuit/src/adapters/rdwrite.rs
@@ -102,7 +102,9 @@ impl RdWriteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx
+            .to_pc_idx
+            .unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         // regardless of `needs_write`, must always execute instruction when `is_valid`.
         self.execution_bridge
             .execute(
@@ -139,7 +141,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for RdWriteAdapterAir {
         self.conditional_eval(builder, local_cols, ctx, None);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &RdWriteAdapterCols<_> = local.borrow();
         cols.from_state.pc
     }
@@ -170,7 +172,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for CondRdWriteAdapterAir {
         );
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let cols: &CondRdWriteAdapterCols<_> = local.borrow();
         cols.inner.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/rdwrite.rs
+++ b/extensions/riscv/circuit/src/adapters/rdwrite.rs
@@ -102,7 +102,7 @@ impl RdWriteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         // regardless of `needs_write`, must always execute instruction when `is_valid`.
         self.execution_bridge
             .execute(
@@ -117,7 +117,7 @@ impl RdWriteAdapterAir {
                 ],
                 local_cols.from_state,
                 ExecutionState {
-                    pc: to_pc,
+                    pc: to_pc_idx,
                     timestamp: timestamp + AB::F::from_usize(timestamp_delta),
                 },
             )

--- a/extensions/riscv/circuit/src/adapters/rdwrite.rs
+++ b/extensions/riscv/circuit/src/adapters/rdwrite.rs
@@ -12,7 +12,7 @@ use openvm_circuit::{
 };
 use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::DEFAULT_PC_STEP, riscv::REGISTER_AS};
+use openvm_instructions::{program::pc_to_idx, riscv::REGISTER_AS};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
     p3_air::{AirBuilder, BaseAir},
@@ -102,9 +102,7 @@ impl RdWriteAdapterAir {
             )
             .eval(builder, write_count);
 
-        let to_pc = ctx
-            .to_pc
-            .unwrap_or(local_cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP));
+        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         // regardless of `needs_write`, must always execute instruction when `is_valid`.
         self.execution_bridge
             .execute(
@@ -268,7 +266,7 @@ fn replay_rd_write<F: PrimeField32>(
     }
     replay.finish(next_pc)?;
     adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-    adapter_row.from_state.pc = F::from_u32(from_pc);
+    adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
     Ok((output, next_pc))
 }

--- a/extensions/riscv/circuit/src/adapters/store/byte.rs
+++ b/extensions/riscv/circuit/src/adapters/store/byte.rs
@@ -18,7 +18,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_stark_backend::{
@@ -175,9 +175,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreByteAdapterAir {
             )
             .eval(builder, is_valid.clone());
 
-        let to_pc = ctx
-            .to_pc
-            .unwrap_or(local_cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP));
+        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -323,7 +321,7 @@ impl StoreByteAdapterFiller {
         adapter_row.rs1_data = ptr_to_field_u16_limbs(rs1_val);
         adapter_row.rs1_ptr = F::from_u8(rs1_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((read_data.value, prev_data, shift_amount))
     }

--- a/extensions/riscv/circuit/src/adapters/store/byte.rs
+++ b/extensions/riscv/circuit/src/adapters/store/byte.rs
@@ -175,7 +175,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreByteAdapterAir {
             )
             .eval(builder, is_valid.clone());
 
-        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -190,7 +190,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreByteAdapterAir {
                 ],
                 local_cols.from_state,
                 ExecutionState {
-                    pc: to_pc,
+                    pc: to_pc_idx,
                     timestamp: timestamp + AB::F::from_usize(timestamp_delta),
                 },
             )

--- a/extensions/riscv/circuit/src/adapters/store/byte.rs
+++ b/extensions/riscv/circuit/src/adapters/store/byte.rs
@@ -175,7 +175,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreByteAdapterAir {
             )
             .eval(builder, is_valid.clone());
 
-        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx
+            .to_pc_idx
+            .unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -197,7 +199,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreByteAdapterAir {
             .eval(builder, is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let local_cols: &StoreByteAdapterCols<AB::Var> = local.borrow();
         local_cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/store/multi_byte.rs
+++ b/extensions/riscv/circuit/src/adapters/store/multi_byte.rs
@@ -199,7 +199,9 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreMultiByteAdapterAir {
             )
             .eval(builder, cross);
 
-        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx
+            .to_pc_idx
+            .unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -221,7 +223,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreMultiByteAdapterAir {
             .eval(builder, is_valid);
     }
 
-    fn get_from_pc(&self, local: &[AB::Var]) -> AB::Var {
+    fn get_from_pc_idx(&self, local: &[AB::Var]) -> AB::Var {
         let local_cols: &StoreMultiByteAdapterCols<AB::Var> = local.borrow();
         local_cols.from_state.pc
     }

--- a/extensions/riscv/circuit/src/adapters/store/multi_byte.rs
+++ b/extensions/riscv/circuit/src/adapters/store/multi_byte.rs
@@ -18,7 +18,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS},
 };
 use openvm_stark_backend::{
@@ -199,9 +199,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreMultiByteAdapterAir {
             )
             .eval(builder, cross);
 
-        let to_pc = ctx
-            .to_pc
-            .unwrap_or(local_cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP));
+        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -403,7 +401,7 @@ impl StoreMultiByteAdapterFiller {
         adapter_row.rs1_data = ptr_to_field_u16_limbs(rs1_val);
         adapter_row.rs1_ptr = F::from_u8(rs1_ptr);
         adapter_row.from_state.timestamp = F::from_u32(from_timestamp);
-        adapter_row.from_state.pc = F::from_u32(from_pc);
+        adapter_row.from_state.pc = F::from_u32(pc_to_idx(from_pc));
 
         Ok((read_data.value, prev_data, shift))
     }

--- a/extensions/riscv/circuit/src/adapters/store/multi_byte.rs
+++ b/extensions/riscv/circuit/src/adapters/store/multi_byte.rs
@@ -199,7 +199,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreMultiByteAdapterAir {
             )
             .eval(builder, cross);
 
-        let to_pc = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
+        let to_pc_idx = ctx.to_pc.unwrap_or(local_cols.from_state.pc + AB::F::ONE);
         self.execution_bridge
             .execute(
                 ctx.instruction.opcode,
@@ -214,7 +214,7 @@ impl<AB: InteractionBuilder> VmAdapterAir<AB> for StoreMultiByteAdapterAir {
                 ],
                 local_cols.from_state,
                 ExecutionState {
-                    pc: to_pc,
+                    pc: to_pc_idx,
                     timestamp: timestamp + AB::F::from_usize(timestamp_delta),
                 },
             )

--- a/extensions/riscv/circuit/src/add_sub/core.rs
+++ b/extensions/riscv/circuit/src/add_sub/core.rs
@@ -71,7 +71,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &AddSubCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [cols.opcode_add_flag, cols.opcode_sub_flag];
@@ -137,7 +137,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/addi/core.rs
+++ b/extensions/riscv/circuit/src/addi/core.rs
@@ -75,7 +75,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         assert!(NUM_LIMBS > 0 && (12..=U16_BITS).contains(&LIMB_BITS));
 
@@ -121,7 +121,7 @@ where
             VmCoreAir::<AB, I>::expr_to_global_expr(self, AB::Expr::from_usize(self.local_opcode));
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.rs1.map(Into::into)].into(),
             writes: [cols.rd.map(Into::into)].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -135,7 +135,7 @@ where
         ];
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, AUIPC);
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [].into(),
             writes: [write_data].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -16,14 +16,14 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    ptr_to_u16_limbs, sext32_to_u64, BYTE_BITS, PC_IDX_LOW_BITS, PTR_U16_LIMBS, U16_BITS,
+    sext32_to_u64, u64_to_u16_block, BYTE_BITS, PC_IDX_LOW_BITS, PTR_U16_LIMBS, U16_BITS,
 };
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow, StructReflection)]
 pub struct AuipcCoreCols<T> {
     pub is_valid: T,
-    pub is_sign_extend: T,
+    pub imm_sign: T,
     // The immediate is split around the byte shift in AUIPC's `imm << 8`.
     pub imm_low_8: T,
     pub imm_high_16: T,
@@ -64,14 +64,14 @@ where
 
         let AuipcCoreCols {
             is_valid,
-            is_sign_extend,
+            imm_sign,
             imm_low_8,
             imm_high_16,
             pc_high,
             rd_data,
         } = *cols;
         builder.assert_bool(is_valid);
-        builder.assert_bool(is_sign_extend);
+        builder.assert_bool(imm_sign);
 
         // We want to constrain rd = byte pc + (imm << BYTE_BITS) where:
         // - rd_data represents the low 32 bits of rd as u16 cells
@@ -100,8 +100,7 @@ where
         let carry_top = (pc_high + imm_high_16 + carry_low - rd_data[1]) * carry_divide;
         builder.when(is_valid).assert_bool(carry_top.clone());
 
-        // Check that the computed sign matches the top bit of `imm_high_16`.
-        let imm_sign = is_sign_extend + carry_top;
+        // Check that imm_sign matches the top bit of `imm_high_16`.
         self.range_bus
             .range_check(
                 AB::Expr::from_u32(2) * imm_high_16 - imm_sign * AB::Expr::from_u32(1 << U16_BITS),
@@ -123,11 +122,15 @@ where
             .range_check(imm_high_16, U16_BITS)
             .eval(builder, is_valid);
 
-        let sign_extend_cell = is_sign_extend * AB::Expr::from_u32(u16::MAX as u32);
+        // A negative immediate sign-extends unless the low-32-bit addition carries; a positive
+        // immediate that carries contributes bit 32 instead.
+        let sign_extend = imm_sign * (AB::Expr::ONE - carry_top.clone());
+        let positive_carry = (AB::Expr::ONE - imm_sign) * carry_top;
+        let sign_extend_cell = sign_extend * AB::Expr::from_u32(u16::MAX as u32);
         let write_data: [AB::Expr; BLOCK_FE_WIDTH] = [
             rd_data[0].into(),
             rd_data[1].into(),
-            sign_extend_cell.clone(),
+            sign_extend_cell.clone() + positive_carry,
             sign_extend_cell,
         ];
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, AUIPC);
@@ -163,10 +166,6 @@ pub(super) fn run_auipc(pc: u32, imm: u32) -> [u16; BLOCK_FE_WIDTH] {
     let offset = imm << BYTE_BITS;
     let auipc = (pc as u64).wrapping_add(sext32_to_u64(offset));
     let auipc_hi = auipc >> 32;
-    debug_assert!(auipc_hi == 0 || auipc_hi == u64::from(u32::MAX));
-    let auipc_lo = auipc as u32;
-
-    let [lo, hi] = ptr_to_u16_limbs(auipc_lo);
-    let sign = if auipc_hi != 0 { u16::MAX } else { 0 };
-    [lo, hi, sign, sign]
+    debug_assert!(auipc_hi == 0 || auipc_hi == 1 || auipc_hi == u64::from(u32::MAX));
+    u64_to_u16_block(auipc)
 }

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -6,7 +6,7 @@ use openvm_circuit_primitives::{
     ColumnsAir, StructReflection, StructReflectionHelper,
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
-use openvm_instructions::{program::PC_BITS, LocalOpcode};
+use openvm_instructions::{program::DEFAULT_PC_STEP, LocalOpcode};
 use openvm_riscv_transpiler::AuipcOpcode::{self, *};
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -15,7 +15,9 @@ use openvm_stark_backend::{
     BaseAirWithPublicValues,
 };
 
-use crate::adapters::{ptr_to_u16_limbs, sext32_to_u64, BYTE_BITS, PTR_U16_LIMBS, U16_BITS};
+use crate::adapters::{
+    ptr_to_u16_limbs, sext32_to_u64, BYTE_BITS, PC_IDX_LOW_BITS, PTR_U16_LIMBS, U16_BITS,
+};
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow, StructReflection)]
@@ -77,14 +79,18 @@ where
         let limb_base = AB::F::from_u32(1 << U16_BITS);
         let carry_divide = limb_base.inverse();
         let imm = imm_low_8 + imm_high_16 * AB::Expr::from_u32(1 << BYTE_BITS);
-        let pc_low = from_pc - pc_high * limb_base;
+        // `from_pc` is a pc index; the byte pc is 4 * from_pc, whose u16 limbs are
+        // [4 * pc_idx_low, pc_high] with pc_idx_low = from_pc - pc_high * 2^PC_IDX_LOW_BITS.
+        let pc_idx_low = from_pc - pc_high * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
+        let pc_low = pc_idx_low.clone() * AB::F::from_u32(DEFAULT_PC_STEP);
 
-        // `from_pc` is bounded to `PC_BITS` by the program bus.
+        // `from_pc` is bounded to `PC_BITS` by the program bus, so the split into a
+        // PC_IDX_LOW_BITS-bit low part and a u16 high part is unique.
         self.range_bus
-            .range_check(pc_low.clone(), U16_BITS)
+            .range_check(pc_idx_low, PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
         self.range_bus
-            .range_check(pc_high, PC_BITS - U16_BITS)
+            .range_check(pc_high, U16_BITS)
             .eval(builder, is_valid);
 
         let carry_low =

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -27,7 +27,7 @@ pub struct AuipcCoreCols<T> {
     // The immediate is split around the byte shift in AUIPC's `imm << 8`.
     pub imm_low_8: T,
     pub imm_high_16: T,
-    // High u16 limb of `from_pc`; the low limb is derived from `from_pc`.
+    // High u16 limb of the byte pc; the low limb is derived from `from_pc_idx`.
     pub pc_high: T,
     pub rd_data: [T; PTR_U16_LIMBS],
 }
@@ -58,7 +58,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &AuipcCoreCols<AB::Var> = (*local_core).borrow();
 
@@ -73,18 +73,18 @@ where
         builder.assert_bool(is_valid);
         builder.assert_bool(is_sign_extend);
 
-        // We want to constrain rd = from_pc + (imm << BYTE_BITS) where:
+        // We want to constrain rd = byte pc + (imm << BYTE_BITS) where:
         // - rd_data represents the low 32 bits of rd as u16 cells
         // - imm_low_8 and imm_high_16 decompose the 24-bit instruction immediate
         let limb_base = AB::F::from_u32(1 << U16_BITS);
         let carry_divide = limb_base.inverse();
         let imm = imm_low_8 + imm_high_16 * AB::Expr::from_u32(1 << BYTE_BITS);
-        // `from_pc` is a pc index; the byte pc is 4 * from_pc, whose u16 limbs are
-        // [4 * pc_idx_low, pc_high] with pc_idx_low = from_pc - pc_high * 2^PC_IDX_LOW_BITS.
-        let pc_idx_low = from_pc - pc_high * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
+        // The byte pc is 4 * from_pc_idx, whose u16 limbs are [4 * pc_idx_low, pc_high]
+        // with pc_idx_low = from_pc_idx - pc_high * 2^PC_IDX_LOW_BITS.
+        let pc_idx_low = from_pc_idx - pc_high * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
         let pc_low = pc_idx_low.clone() * AB::F::from_u32(DEFAULT_PC_STEP);
 
-        // `from_pc` is bounded to `PC_BITS` by the program bus, so the split into a
+        // `from_pc_idx` is bounded to `PC_BITS` by the program bus, so the split into a
         // PC_IDX_LOW_BITS-bit low part and a u16 high part is unique.
         self.range_bus
             .range_check(pc_idx_low, PC_IDX_LOW_BITS)

--- a/extensions/riscv/circuit/src/auipc/core.rs
+++ b/extensions/riscv/circuit/src/auipc/core.rs
@@ -84,7 +84,7 @@ where
         let pc_idx_low = from_pc_idx - pc_high * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
         let pc_low = pc_idx_low.clone() * AB::F::from_u32(DEFAULT_PC_STEP);
 
-        // `from_pc_idx` is bounded to `PC_BITS` by the program bus, so the split into a
+        // `from_pc_idx` is bounded to `PC_IDX_BITS` by the program bus, so the split into a
         // PC_IDX_LOW_BITS-bit low part and a u16 high part is unique.
         self.range_bus
             .range_check(pc_idx_low, PC_IDX_LOW_BITS)

--- a/extensions/riscv/circuit/src/auipc/tests.rs
+++ b/extensions/riscv/circuit/src/auipc/tests.rs
@@ -38,8 +38,8 @@ use {
 use super::trace::generate_trace_from_postflight;
 use crate::{
     adapters::{
-        sext32_to_u64, u16_block_to_bytes, RdWriteAdapterAir, RdWriteAdapterCols, BYTE_BITS,
-        PTR_U16_LIMBS, WORD_NUM_LIMBS,
+        u16_block_to_bytes, RdWriteAdapterAir, RdWriteAdapterCols, BYTE_BITS, PTR_U16_LIMBS,
+        WORD_NUM_LIMBS,
     },
     auipc::{run_auipc, AuipcCoreCols},
     AuipcAir, AuipcChip, AuipcCoreAir, AuipcExecutor, AuipcFiller,
@@ -105,13 +105,7 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
     let imm = imm.unwrap_or(rng.random_range(0..(1 << IMM_BITS))) as usize;
     let a = rng.random_range(1..32) << 3;
 
-    let initial_pc = initial_pc.unwrap_or_else(|| {
-        // An aligned byte pc over the full 32-bit range such that pc + sext(imm << 8) stays
-        // below 2^32 (larger results are rejected by tracegen).
-        let offset = sext32_to_u64((imm as u32) << BYTE_BITS) as i64;
-        let max_pc = ((u32::MAX as i64 - offset.max(0)) as u32) & !3;
-        (rng.random::<u32>() & !3).min(max_pc)
-    });
+    let initial_pc = initial_pc.unwrap_or_else(|| rng.random::<u32>() & !3);
     tester.execute_with_pc(
         executor,
         preflight,
@@ -159,9 +153,7 @@ fn rand_auipc_test() {
 
 #[test]
 fn auipc_max_pc_test() {
-    // AUIPC at the second-to-last instruction slot of the 32-bit PC address space (the last
-    // slot cannot fall through) with a negative offset (a positive offset would push the
-    // result past 2^32, which is rejected).
+    // 0xfffffff8 + 0x1000 = 0x1_00000ff8.
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
     let (mut harness, bitwise) = create_harness(&tester);
@@ -172,8 +164,8 @@ fn auipc_max_pc_test() {
         &mut harness.preflight,
         &mut rng,
         AUIPC,
-        Some((1 << 24) - 1),
-        Some((u32::MAX & !3) - 4),
+        Some(0x10),
+        Some(0xffff_fff8),
     );
 
     let tester = tester
@@ -193,7 +185,7 @@ fn auipc_max_pc_test() {
 
 #[derive(Clone, Copy, Default, PartialEq)]
 struct AuipcPrankValues {
-    pub is_sign_extend: Option<u32>,
+    pub imm_sign: Option<u32>,
     pub rd_data: Option<[u32; PTR_U16_LIMBS]>,
     pub imm_low_8: Option<u32>,
     pub imm_high_16: Option<u32>,
@@ -238,8 +230,8 @@ fn run_negative_auipc_test(
         let (_, core_row) = trace_row.split_at_mut(adapter_width);
         let core_cols: &mut AuipcCoreCols<F> = core_row.borrow_mut();
 
-        if let Some(val) = prank_vals.is_sign_extend {
-            core_cols.is_sign_extend = F::from_u32(val);
+        if let Some(val) = prank_vals.imm_sign {
+            core_cols.imm_sign = F::from_u32(val);
         }
         if let Some(data) = prank_vals.rd_data {
             core_cols.rd_data = data.map(F::from_u32);
@@ -370,27 +362,23 @@ fn rd_upper_bytes_trace_tamper_negative_test() {
 }
 
 #[test]
-fn sign_extend_flag_negative_tests() {
-    // Prank is_sign_extend = 1 when the result has bit 31 unset (MSB of rd_data[1] is 0).
-    // pc=4, imm=0 ⟹ rd = 4 ⟹ rd low 32 bits = [4, 0].
+fn immediate_sign_flag_negative_tests() {
     run_negative_auipc_test(
         AUIPC,
         Some(0),
         Some(4),
         AuipcPrankValues {
-            is_sign_extend: Some(1),
+            imm_sign: Some(1),
             ..Default::default()
         },
         true,
     );
-    // Prank is_sign_extend = 0 when the result has bit 31 set (MSB of rd_data[1] is 1).
-    // pc=0, imm=2^23 ⟹ rd = 2^31 ⟹ rd low 32 bits = [0, 0x8000].
     run_negative_auipc_test(
         AUIPC,
         Some(1 << 23),
         Some(0),
         AuipcPrankValues {
-            is_sign_extend: Some(0),
+            imm_sign: Some(0),
             ..Default::default()
         },
         true,
@@ -398,13 +386,13 @@ fn sign_extend_flag_negative_tests() {
 }
 
 #[test]
-fn positive_offset_crossing_sign_extend_negative_tests() {
+fn positive_offset_imm_sign_negative_tests() {
     run_negative_auipc_test(
         AUIPC,
         Some(0x7f_fff0),
         Some(0x1000),
         AuipcPrankValues {
-            is_sign_extend: Some(1),
+            imm_sign: Some(1),
             ..Default::default()
         },
         true,
@@ -546,6 +534,15 @@ fn test_cuda_rand_auipc_tracegen() {
             None,
         );
     }
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        AUIPC,
+        Some(0x10),
+        Some(0xffff_fff8),
+    );
 
     tester
         .build()

--- a/extensions/riscv/circuit/src/auipc/tests.rs
+++ b/extensions/riscv/circuit/src/auipc/tests.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives::{
     },
     var_range::SharedVariableRangeCheckerChip,
 };
-use openvm_instructions::{instruction::Instruction, program::PC_BITS, LocalOpcode};
+use openvm_instructions::{instruction::Instruction, LocalOpcode};
 use openvm_riscv_transpiler::AuipcOpcode::{self, *};
 use openvm_stark_backend::{
     p3_air::BaseAir,
@@ -38,8 +38,8 @@ use {
 use super::trace::generate_trace_from_postflight;
 use crate::{
     adapters::{
-        u16_block_to_bytes, RdWriteAdapterAir, RdWriteAdapterCols, BYTE_BITS, PTR_U16_LIMBS,
-        WORD_NUM_LIMBS,
+        sext32_to_u64, u16_block_to_bytes, RdWriteAdapterAir, RdWriteAdapterCols, BYTE_BITS,
+        PTR_U16_LIMBS, WORD_NUM_LIMBS,
     },
     auipc::{run_auipc, AuipcCoreCols},
     AuipcAir, AuipcChip, AuipcCoreAir, AuipcExecutor, AuipcFiller,
@@ -105,13 +105,20 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
     let imm = imm.unwrap_or(rng.random_range(0..(1 << IMM_BITS))) as usize;
     let a = rng.random_range(1..32) << 3;
 
+    let initial_pc = initial_pc.unwrap_or_else(|| {
+        // An aligned byte pc over the full 32-bit range such that pc + sext(imm << 8) stays
+        // below 2^32 (larger results are rejected by tracegen).
+        let offset = sext32_to_u64((imm as u32) << BYTE_BITS) as i64;
+        let max_pc = ((u32::MAX as i64 - offset.max(0)) as u32) & !3;
+        (rng.random::<u32>() & !3).min(max_pc)
+    });
     tester.execute_with_pc(
         executor,
         preflight,
         &Instruction::from_usize(opcode.global_opcode(), [a, 0, imm, 1, 0]),
-        initial_pc.unwrap_or(rng.random_range(0..(1 << PC_BITS))),
+        initial_pc,
     );
-    let initial_pc = tester.last_from_pc().as_canonical_u32();
+    let initial_pc = tester.last_from_pc();
     let rd_data = run_auipc(initial_pc, imm as u32);
     let rd_bytes = u16_block_to_bytes(rd_data);
     assert_eq!(rd_bytes.map(F::from_u8), tester.read_bytes::<8>(1, a));
@@ -142,6 +149,33 @@ fn rand_auipc_test() {
             None,
         );
     }
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
+    tester.simple_test().expect("Verification failed");
+}
+
+#[test]
+fn auipc_max_pc_test() {
+    // AUIPC at the second-to-last instruction slot of the 32-bit PC address space (the last
+    // slot cannot fall through) with a negative offset (a positive offset would push the
+    // result past 2^32, which is rejected).
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let (mut harness, bitwise) = create_harness(&tester);
+
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        AUIPC,
+        Some((1 << 24) - 1),
+        Some((u32::MAX & !3) - 4),
+    );
+
     let tester = tester
         .build()
         .load(harness)
@@ -239,7 +273,7 @@ fn invalid_limb_negative_tests() {
     let (imm_low_8, imm_high_16) = split_imm_u8_limbs([107, 46, 81]);
     run_negative_auipc_test(
         AUIPC,
-        Some(9722891),
+        Some(9722892),
         None,
         AuipcPrankValues {
             imm_low_8: Some(imm_low_8),
@@ -283,7 +317,7 @@ fn invalid_limb_negative_tests() {
     run_negative_auipc_test(
         AUIPC,
         None,
-        Some(876487877),
+        Some(876487876),
         AuipcPrankValues {
             rd_data: Some(pack_rd_u8_limbs([197, 202, 49, 70])),
             imm_low_8: Some(imm_low_8),
@@ -416,7 +450,7 @@ fn overflow_negative_tests() {
     run_negative_auipc_test(
         AUIPC,
         Some(0),
-        Some(255),
+        Some(256),
         AuipcPrankValues {
             rd_data: Some([F::NEG_ONE.as_canonical_u32(), 1]),
             imm_low_8: Some(0),

--- a/extensions/riscv/circuit/src/auipc/trace.rs
+++ b/extensions/riscv/circuit/src/auipc/trace.rs
@@ -5,7 +5,7 @@ use openvm_circuit::{
     utils::next_power_of_two_or_zero,
 };
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP, PC_BITS},
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::AuipcOpcode::AUIPC;
@@ -13,7 +13,7 @@ use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMat
 
 use super::{run_auipc, AuipcChip, AuipcCoreCols};
 use crate::adapters::{
-    ptr_to_u16_limbs, RdWriteAdapterCols, RdWriteAdapterFiller, BYTE_BITS, U16_BITS,
+    sext32_to_u64, RdWriteAdapterCols, RdWriteAdapterFiller, BYTE_BITS, PC_IDX_LOW_BITS, U16_BITS,
 };
 
 /// Generates the AUIPC trace directly from immutable preflight history.
@@ -37,6 +37,14 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
                 "AUIPC immediate exceeds its 24-bit instruction encoding",
             ));
         }
+        // The circuit sign-extends negative results but cannot represent results at or above
+        // 2^32 (a positive-immediate carry out of the low 32 bits is unsatisfiable).
+        let result = from_pc as i64 + sext32_to_u64(immediate << BYTE_BITS) as i64;
+        if result > u32::MAX as i64 {
+            return Err(PostflightError::new(
+                "AUIPC result exceeds implemented PC address space",
+            ));
+        }
         let (rd_data, _) = RdWriteAdapterFiller::replay(
             postflight,
             step,
@@ -49,7 +57,9 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
         let imm_bytes = immediate.to_le_bytes();
         let imm_low_8 = imm_bytes[0];
         let imm_high_16 = (imm_bytes[1] as u32) | ((imm_bytes[2] as u32) << BYTE_BITS);
-        let [pc_low, pc_high] = ptr_to_u16_limbs(from_pc);
+        let pc_idx = pc_to_idx(from_pc);
+        let pc_idx_low = pc_idx & ((1 << PC_IDX_LOW_BITS) - 1);
+        let pc_high = pc_idx >> PC_IDX_LOW_BITS;
         let rd_lo = rd_data[0];
         let rd_hi = rd_data[1];
         let is_sign_extend = rd_data[2] != 0;
@@ -58,10 +68,8 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
 
         chip.inner
             .range_checker_chip
-            .add_count(pc_low as u32, U16_BITS);
-        chip.inner
-            .range_checker_chip
-            .add_count(pc_high as u32, PC_BITS - U16_BITS);
+            .add_count(pc_idx_low, PC_IDX_LOW_BITS);
+        chip.inner.range_checker_chip.add_count(pc_high, U16_BITS);
         chip.inner
             .range_checker_chip
             .add_count(imm_low_8 as u32, BYTE_BITS);
@@ -82,7 +90,7 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
         core_row.is_sign_extend = F::from_bool(is_sign_extend);
         core_row.imm_low_8 = F::from_u8(imm_low_8);
         core_row.imm_high_16 = F::from_u32(imm_high_16);
-        core_row.pc_high = F::from_u16(pc_high);
+        core_row.pc_high = F::from_u32(pc_high);
         core_row.rd_data = [F::from_u16(rd_lo), F::from_u16(rd_hi)];
         Ok(())
     })?;

--- a/extensions/riscv/circuit/src/auipc/trace.rs
+++ b/extensions/riscv/circuit/src/auipc/trace.rs
@@ -13,7 +13,7 @@ use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMat
 
 use super::{run_auipc, AuipcChip, AuipcCoreCols};
 use crate::adapters::{
-    sext32_to_u64, RdWriteAdapterCols, RdWriteAdapterFiller, BYTE_BITS, PC_IDX_LOW_BITS, U16_BITS,
+    RdWriteAdapterCols, RdWriteAdapterFiller, BYTE_BITS, PC_IDX_LOW_BITS, U16_BITS,
 };
 
 /// Generates the AUIPC trace directly from immutable preflight history.
@@ -37,14 +37,6 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
                 "AUIPC immediate exceeds its 24-bit instruction encoding",
             ));
         }
-        // The circuit sign-extends negative results but cannot represent results at or above
-        // 2^32 (a positive-immediate carry out of the low 32 bits is unsatisfiable).
-        let result = from_pc as i64 + sext32_to_u64(immediate << BYTE_BITS) as i64;
-        if result > u32::MAX as i64 {
-            return Err(PostflightError::new(
-                "AUIPC result exceeds implemented PC address space",
-            ));
-        }
         let (rd_data, _) = RdWriteAdapterFiller::replay(
             postflight,
             step,
@@ -62,7 +54,6 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
         let pc_high = pc_idx >> PC_IDX_LOW_BITS;
         let rd_lo = rd_data[0];
         let rd_hi = rd_data[1];
-        let is_sign_extend = rd_data[2] != 0;
         let imm_sign = (imm_high_16 >> (U16_BITS - 1)) & 1;
         let imm_magnitude_check = 2u32 * imm_high_16 - imm_sign * (1 << U16_BITS);
 
@@ -87,7 +78,7 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             .add_count(imm_magnitude_check, U16_BITS);
 
         core_row.is_valid = F::ONE;
-        core_row.is_sign_extend = F::from_bool(is_sign_extend);
+        core_row.imm_sign = F::from_bool(imm_sign != 0);
         core_row.imm_low_8 = F::from_u8(imm_low_8);
         core_row.imm_high_16 = F::from_u32(imm_high_16);
         core_row.pc_high = F::from_u32(pc_high);

--- a/extensions/riscv/circuit/src/bitwise_logic/core.rs
+++ b/extensions/riscv/circuit/src/bitwise_logic/core.rs
@@ -58,7 +58,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &BitwiseLogicCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [
@@ -100,7 +100,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/bitwise_logic_imm/core.rs
+++ b/extensions/riscv/circuit/src/bitwise_logic_imm/core.rs
@@ -62,7 +62,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &BitwiseLogicImmCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [
@@ -117,7 +117,7 @@ where
             + cols.imm_sign * AB::Expr::from_u32(0xff_f800);
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/branch_eq/core.rs
+++ b/extensions/riscv/circuit/src/branch_eq/core.rs
@@ -58,7 +58,7 @@ where
         &self,
         builder: &mut AB,
         local: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &BranchEqualCoreCols<_, NUM_LIMBS> = local.borrow();
         let flags = [cols.opcode_beq_flag, cols.opcode_bne_flag];
@@ -110,13 +110,13 @@ where
         // element) and `pc_step` is a byte step; pc values on the buses are pc indices, so the
         // byte delta is scaled down by DEFAULT_PC_STEP.
         let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
-        let to_pc = from_pc
+        let to_pc_idx = from_pc_idx
             + (cols.cmp_result * cols.imm
                 + not(cols.cmp_result) * AB::Expr::from_u32(self.pc_step))
                 * pc_step_inv;
 
         AdapterAirContext {
-            to_pc: Some(to_pc),
+            to_pc: Some(to_pc_idx),
             reads: [cols.a.map(Into::into), cols.b.map(Into::into)].into(),
             writes: Default::default(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/branch_eq/core.rs
+++ b/extensions/riscv/circuit/src/branch_eq/core.rs
@@ -116,7 +116,7 @@ where
                 * pc_step_inv;
 
         AdapterAirContext {
-            to_pc: Some(to_pc_idx),
+            to_pc_idx: Some(to_pc_idx),
             reads: [cols.a.map(Into::into), cols.b.map(Into::into)].into(),
             writes: Default::default(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/branch_eq/core.rs
+++ b/extensions/riscv/circuit/src/branch_eq/core.rs
@@ -3,6 +3,7 @@ use std::borrow::Borrow;
 use openvm_circuit::arch::*;
 use openvm_circuit_primitives::{utils::not, ColumnsAir, StructReflection, StructReflectionHelper};
 use openvm_circuit_primitives_derive::AlignedBorrow;
+use openvm_instructions::program::DEFAULT_PC_STEP;
 use openvm_riscv_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{
     interaction::InteractionBuilder,
@@ -105,9 +106,14 @@ where
             })
             + AB::Expr::from_usize(self.offset);
 
+        // `imm` is a byte offset (a multiple of DEFAULT_PC_STEP, possibly negative as a field
+        // element) and `pc_step` is a byte step; pc values on the buses are pc indices, so the
+        // byte delta is scaled down by DEFAULT_PC_STEP.
+        let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
         let to_pc = from_pc
-            + cols.cmp_result * cols.imm
-            + not(cols.cmp_result) * AB::Expr::from_u32(self.pc_step);
+            + (cols.cmp_result * cols.imm
+                + not(cols.cmp_result) * AB::Expr::from_u32(self.pc_step))
+                * pc_step_inv;
 
         AdapterAirContext {
             to_pc: Some(to_pc),

--- a/extensions/riscv/circuit/src/branch_eq/tests.rs
+++ b/extensions/riscv/circuit/src/branch_eq/tests.rs
@@ -11,13 +11,13 @@ use openvm_circuit::{
 };
 use openvm_instructions::{
     instruction::Instruction,
-    program::{DEFAULT_PC_STEP, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
-    p3_field::{PrimeCharacteristicRing, PrimeField32},
+    p3_field::PrimeCharacteristicRing,
     p3_matrix::{
         dense::{DenseMatrix, RowMajorMatrix},
         Matrix,
@@ -95,12 +95,20 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
         array::from_fn(|_| rng.random_range(0..=u8::MAX))
     });
 
-    let imm = imm.unwrap_or(rng.random_range((-ABS_MAX_IMM)..ABS_MAX_IMM));
+    // Branch offsets are DEFAULT_PC_STEP-aligned byte offsets.
+    let imm = imm.unwrap_or(
+        rng.random_range(
+            (-ABS_MAX_IMM / DEFAULT_PC_STEP as i32)..(ABS_MAX_IMM / DEFAULT_PC_STEP as i32),
+        ) * DEFAULT_PC_STEP as i32,
+    );
     let [rs1, rs2] = gen_distinct_register_pointers(rng, REGISTER_NUM_LIMBS);
     tester.write_bytes::<REGISTER_NUM_LIMBS>(1, rs1, a.map(F::from_u8));
     tester.write_bytes::<REGISTER_NUM_LIMBS>(1, rs2, b.map(F::from_u8));
 
-    let initial_pc = rng.random_range(imm.unsigned_abs()..(1 << (PC_BITS - 1)));
+    // An aligned byte pc over the full 32-bit range, keeping the taken target in bounds.
+    let lo = (-imm).max(0) as u32 / DEFAULT_PC_STEP;
+    let hi = (MAX_ALLOWED_PC - DEFAULT_PC_STEP - imm.max(0) as u32) / DEFAULT_PC_STEP;
+    let initial_pc = rng.random_range(lo..=hi) * DEFAULT_PC_STEP;
     tester.execute_with_pc(
         executor,
         preflight,
@@ -116,9 +124,9 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
     );
 
     let cmp_result = fast_run_eq(opcode, &bytes_to_u16_block(a), &bytes_to_u16_block(b));
-    let from_pc = tester.last_from_pc().as_canonical_u32() as i32;
-    let to_pc = tester.last_to_pc().as_canonical_u32() as i32;
-    let pc_inc = if cmp_result { imm } else { 4 };
+    let from_pc = tester.last_from_pc() as i64;
+    let to_pc = tester.last_to_pc() as i64;
+    let pc_inc = if cmp_result { imm as i64 } else { 4 };
 
     assert_eq!(to_pc, from_pc + pc_inc);
 }

--- a/extensions/riscv/circuit/src/branch_eq/trace.rs
+++ b/extensions/riscv/circuit/src/branch_eq/trace.rs
@@ -10,7 +10,9 @@ use openvm_riscv_transpiler::BranchEqualOpcode;
 use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix};
 
 use super::{fast_run_eq, run_eq, BranchEqualChip, BranchEqualCoreCols};
-use crate::adapters::{BranchAdapterCols, BranchAdapterFiller};
+use crate::adapters::{
+    checked_branch_target, taken_branch_pc, BranchAdapterCols, BranchAdapterFiller,
+};
 
 /// Generates the RV64 equality-branch trace directly from immutable preflight history.
 pub fn generate_trace_from_postflight<F: PrimeField32>(
@@ -32,6 +34,7 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
         let steps = postflight.steps(local_opcode.global_opcode());
         fill_trace_rows(&mut trace, row_index, steps, |row, step| {
             let (adapter_row, core_row) = row.split_at_mut(adapter_width);
+            let mut taken = false;
             let (inputs, _) = BranchAdapterFiller::replay(
                 postflight,
                 step,
@@ -39,12 +42,17 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
                 adapter_row.borrow_mut(),
                 |from_pc, [rs1, rs2], immediate| {
                     if fast_run_eq(local_opcode, &rs1, &rs2) {
-                        from_pc.wrapping_add_signed(immediate)
+                        taken = true;
+                        taken_branch_pc(from_pc, immediate)
                     } else {
                         from_pc.wrapping_add(chip.inner.pc_step)
                     }
                 },
             )?;
+            if taken {
+                let instruction = postflight.instruction(step);
+                checked_branch_target(postflight.pc(step), instruction.c.as_i32())?;
+            }
             let [a, b] = inputs;
             let core_row: &mut BranchEqualCoreCols<F, BLOCK_FE_WIDTH> = core_row.borrow_mut();
             let instruction = postflight.instruction(step);

--- a/extensions/riscv/circuit/src/branch_lt/core.rs
+++ b/extensions/riscv/circuit/src/branch_lt/core.rs
@@ -170,7 +170,7 @@ where
                 * pc_step_inv;
 
         AdapterAirContext {
-            to_pc: Some(to_pc_idx),
+            to_pc_idx: Some(to_pc_idx),
             reads: [cols.a.map(Into::into), cols.b.map(Into::into)].into(),
             writes: Default::default(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/branch_lt/core.rs
+++ b/extensions/riscv/circuit/src/branch_lt/core.rs
@@ -79,7 +79,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &BranchLessThanCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [
@@ -164,13 +164,13 @@ where
         // element); pc values on the buses are pc indices, so the byte delta is scaled down by
         // DEFAULT_PC_STEP.
         let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
-        let to_pc = from_pc
+        let to_pc_idx = from_pc_idx
             + (cols.cmp_result * cols.imm
                 + not(cols.cmp_result) * AB::Expr::from_u32(DEFAULT_PC_STEP))
                 * pc_step_inv;
 
         AdapterAirContext {
-            to_pc: Some(to_pc),
+            to_pc: Some(to_pc_idx),
             reads: [cols.a.map(Into::into), cols.b.map(Into::into)].into(),
             writes: Default::default(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/branch_lt/core.rs
+++ b/extensions/riscv/circuit/src/branch_lt/core.rs
@@ -160,9 +160,14 @@ where
             })
             + AB::Expr::from_usize(self.offset);
 
+        // `imm` is a byte offset (a multiple of DEFAULT_PC_STEP, possibly negative as a field
+        // element); pc values on the buses are pc indices, so the byte delta is scaled down by
+        // DEFAULT_PC_STEP.
+        let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
         let to_pc = from_pc
-            + cols.cmp_result * cols.imm
-            + not(cols.cmp_result) * AB::Expr::from_u32(DEFAULT_PC_STEP);
+            + (cols.cmp_result * cols.imm
+                + not(cols.cmp_result) * AB::Expr::from_u32(DEFAULT_PC_STEP))
+                * pc_step_inv;
 
         AdapterAirContext {
             to_pc: Some(to_pc),

--- a/extensions/riscv/circuit/src/branch_lt/tests.rs
+++ b/extensions/riscv/circuit/src/branch_lt/tests.rs
@@ -15,7 +15,11 @@ use openvm_circuit::{
 use openvm_circuit_primitives::var_range::SharedVariableRangeCheckerChip;
 #[cfg(all(feature = "cuda", feature = "rvr"))]
 use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
-use openvm_instructions::{instruction::Instruction, program::PC_BITS, LocalOpcode};
+use openvm_instructions::{
+    instruction::Instruction,
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
+    LocalOpcode,
+};
 use openvm_riscv_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::{
     p3_air::BaseAir,
@@ -106,13 +110,22 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
         array::from_fn(|_| rng.random_range(0..=u16::MAX))
     });
 
-    let imm = imm.unwrap_or(rng.random_range((-ABS_MAX_IMM)..ABS_MAX_IMM));
+    // Branch offsets are DEFAULT_PC_STEP-aligned byte offsets.
+    let imm = imm.unwrap_or(
+        rng.random_range(
+            (-ABS_MAX_IMM / DEFAULT_PC_STEP as i32)..(ABS_MAX_IMM / DEFAULT_PC_STEP as i32),
+        ) * DEFAULT_PC_STEP as i32,
+    );
     let [rs1, rs2] = gen_distinct_register_pointers(rng, REGISTER_NUM_LIMBS);
     let a_bytes: [F; REGISTER_NUM_LIMBS] = u16_block_to_bytes(a).map(F::from_u8);
     let b_bytes: [F; REGISTER_NUM_LIMBS] = u16_block_to_bytes(b).map(F::from_u8);
     tester.write_bytes::<REGISTER_NUM_LIMBS>(1, rs1, a_bytes);
     tester.write_bytes::<REGISTER_NUM_LIMBS>(1, rs2, b_bytes);
 
+    // An aligned byte pc over the full 32-bit range, keeping the taken target in bounds.
+    let lo = (-imm).max(0) as u32 / DEFAULT_PC_STEP;
+    let hi = (MAX_ALLOWED_PC - DEFAULT_PC_STEP - imm.max(0) as u32) / DEFAULT_PC_STEP;
+    let initial_pc = rng.random_range(lo..=hi) * DEFAULT_PC_STEP;
     tester.execute_with_pc(
         executor,
         preflight,
@@ -124,14 +137,14 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
             1,
             1,
         ),
-        rng.random_range(imm.unsigned_abs()..(1 << (PC_BITS - 1))),
+        initial_pc,
     );
 
     let (cmp_result, _, _, _) =
         run_cmp::<BLOCK_FE_WIDTH, U16_BITS>(opcode.local_usize() as u8, &a, &b);
-    let from_pc = tester.last_from_pc().as_canonical_u32() as i32;
-    let to_pc = tester.last_to_pc().as_canonical_u32() as i32;
-    let pc_inc = if cmp_result { imm } else { 4 };
+    let from_pc = tester.last_from_pc() as i64;
+    let to_pc = tester.last_to_pc() as i64;
+    let pc_inc = if cmp_result { imm as i64 } else { 4 };
 
     assert_eq!(to_pc, from_pc + pc_inc);
 }

--- a/extensions/riscv/circuit/src/branch_lt/trace.rs
+++ b/extensions/riscv/circuit/src/branch_lt/trace.rs
@@ -10,7 +10,9 @@ use openvm_riscv_transpiler::BranchLessThanOpcode;
 use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix};
 
 use super::{run_cmp, BranchLessThanChip, BranchLessThanCoreCols};
-use crate::adapters::{BranchAdapterCols, BranchAdapterFiller, U16_BITS};
+use crate::adapters::{
+    checked_branch_target, taken_branch_pc, BranchAdapterCols, BranchAdapterFiller, U16_BITS,
+};
 
 /// Generates the RV64 less-than-branch trace directly from immutable preflight history.
 pub fn generate_trace_from_postflight<F: PrimeField32>(
@@ -47,12 +49,16 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
                 |from_pc, [rs1, rs2], immediate| {
                     comparison = run_cmp::<BLOCK_FE_WIDTH, U16_BITS>(local_opcode_u8, &rs1, &rs2);
                     if comparison.0 {
-                        from_pc.wrapping_add_signed(immediate)
+                        taken_branch_pc(from_pc, immediate)
                     } else {
                         from_pc.wrapping_add(DEFAULT_PC_STEP)
                     }
                 },
             )?;
+            if comparison.0 {
+                let instruction = postflight.instruction(step);
+                checked_branch_target(postflight.pc(step), instruction.c.as_i32())?;
+            }
             let [a, b] = inputs;
             let core_row: &mut BranchLessThanCoreCols<F, BLOCK_FE_WIDTH, U16_BITS> =
                 core_row.borrow_mut();

--- a/extensions/riscv/circuit/src/divrem/core.rs
+++ b/extensions/riscv/circuit/src/divrem/core.rs
@@ -92,7 +92,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &DivRemCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [
@@ -330,7 +330,7 @@ where
         let a = array::from_fn(|i| select(is_div.clone(), q[i], r[i]));
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/hintstore/mod.rs
+++ b/extensions/riscv/circuit/src/hintstore/mod.rs
@@ -212,7 +212,7 @@ impl<AB: InteractionBuilder> Air<AB> for HintStoreAir {
             + (local_cols.is_buffer * AB::F::from_usize(HINT_BUFFER as usize + self.offset));
 
         self.execution_bridge
-            .execute_and_increment_pc(
+            .execute_and_increment_pc_idx(
                 expected_opcode,
                 [
                     local_cols.is_buffer * (local_cols.num_words_ptr),

--- a/extensions/riscv/circuit/src/hintstore/trace.rs
+++ b/extensions/riscv/circuit/src/hintstore/trace.rs
@@ -9,7 +9,7 @@ use openvm_circuit::{
     utils::next_power_of_two_or_zero,
 };
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
     riscv::{MEMORY_AS, REGISTER_AS, REGISTER_NUM_LIMBS},
     LocalOpcode,
 };
@@ -251,7 +251,7 @@ fn fill_row<F: PrimeField32>(
     range_checker.add_count(byte_limbs[1], pointer_max_bits - U16_BITS);
     cols.mem_ptr_ptr = F::from_u32(input.mem_ptr_ptr);
     cols.from_state.timestamp = F::from_u32(timestamp);
-    cols.from_state.pc = F::from_u32(input.from_pc);
+    cols.from_state.pc = F::from_u32(pc_to_idx(input.from_pc));
     cols.rem_words = F::from_u32(input.num_words - local_index);
     cols.is_buffer = F::from_bool(!is_single);
     cols.is_single = F::from_bool(is_single);

--- a/extensions/riscv/circuit/src/jal_lui/core.rs
+++ b/extensions/riscv/circuit/src/jal_lui/core.rs
@@ -160,7 +160,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: Some(to_pc_idx),
+            to_pc_idx: Some(to_pc_idx),
             reads: [].into(),
             writes: [write_data].into(),
             instruction: ImmInstruction {
@@ -195,7 +195,7 @@ pub(super) fn get_signed_imm(is_jal: bool, imm: InstructionOperand) -> Option<i3
     }
 }
 
-// returns (to_pc, rd_data)
+// Returns the target byte PC and rd data.
 #[inline(always)]
 pub(super) fn run_jal_lui(is_jal: bool, pc: u32, imm: i32) -> (u32, [u16; BLOCK_FE_WIDTH]) {
     if is_jal {

--- a/extensions/riscv/circuit/src/jal_lui/core.rs
+++ b/extensions/riscv/circuit/src/jal_lui/core.rs
@@ -8,7 +8,7 @@ use openvm_circuit_primitives::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::InstructionOperand,
-    program::{DEFAULT_PC_STEP, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalLuiOpcode::{self, *};
@@ -20,12 +20,11 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    ptr_to_u16_limbs, u32_to_u16_block, PTR_U16_LIMBS, RV_IS_TYPE_IMM_BITS, RV_J_TYPE_IMM_BITS,
-    U16_BITS,
+    ptr_to_u16_limbs, u32_to_u16_block, PC_IDX_LOW_BITS, PTR_U16_LIMBS, RV_IS_TYPE_IMM_BITS,
+    RV_J_TYPE_IMM_BITS, U16_BITS,
 };
 
 pub(super) const LUI_IMM_LOW_BITS: usize = U16_BITS - RV_IS_TYPE_IMM_BITS;
-pub(super) const PC_HIGH_U16_SHIFT: usize = 2 * U16_BITS - PC_BITS;
 
 #[repr(C)]
 #[derive(Debug, Clone, AlignedBorrow, StructReflection)]
@@ -99,11 +98,13 @@ where
             .eval(builder, is_lui);
 
         let limb_base = AB::F::from_u32(1 << U16_BITS);
+        let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
 
-        // JAL: constrain rd_low_32 = from_pc + DEFAULT_PC_STEP.
+        // JAL: constrain rd_low_32 = 4 * (from_pc + 1), the byte return address for the pc
+        // index `from_pc`.
         builder.when(is_jal).assert_eq(
             rd[0],
-            from_pc + AB::F::from_u32(DEFAULT_PC_STEP) - rd[1] * limb_base,
+            (from_pc + AB::F::ONE) * AB::F::from_u32(DEFAULT_PC_STEP) - rd[1] * limb_base,
         );
 
         // Range-check the low 32-bit rd cells.
@@ -114,20 +115,26 @@ where
             .range_check(rd[1], U16_BITS)
             .eval(builder, is_valid.clone());
 
-        // Tie is_sign_extend to bit 31 of rd.
+        // Tie is_sign_extend to bit 31 of rd for LUI. JAL return addresses are zero-extended
+        // low-32-bit values (the bus address convention), so is_sign_extend must be 0.
         self.range_bus
             .range_check(
                 AB::Expr::from_u32(2) * rd[1] - is_sign_extend * AB::Expr::from_u32(1 << U16_BITS),
                 U16_BITS,
             )
-            .eval(builder, is_valid.clone());
+            .eval(builder, is_lui);
+        builder.when(is_jal).assert_zero(is_sign_extend);
 
-        // JAL cannot write a return address outside PC_BITS.
+        // JAL return addresses are DEFAULT_PC_STEP-aligned: rd[0] = 4 * x with
+        // x < 2^PC_IDX_LOW_BITS. Together with rd[1] < 2^16 this makes the decomposition
+        // rd = 4 * (from_pc + 1) unique: the composed pc index rd[1] * 2^PC_IDX_LOW_BITS + x
+        // is < 2^PC_BITS < p, so it must equal from_pc + 1 over the integers. A JAL at the
+        // last pc index (from_pc + 1 = 2^PC_BITS) is unsatisfiable, hence unprovable.
         self.range_bus
-            .range_check(rd[1] * AB::F::from_u32(1 << PC_HIGH_U16_SHIFT), U16_BITS)
+            .range_check(rd[0] * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_jal);
 
-        // Sign-extend bit 31 into the upper RV64 register cells.
+        // Sign-extend bit 31 into the upper RV64 register cells (LUI only; see above).
         let sign_extend_cell = is_sign_extend * AB::Expr::from_u32(u16::MAX as u32);
         let write_data: [AB::Expr; BLOCK_FE_WIDTH] = [
             rd[0].into(),
@@ -136,7 +143,9 @@ where
             sign_extend_cell,
         ];
 
-        let to_pc = from_pc + is_lui * AB::F::from_u32(DEFAULT_PC_STEP) + is_jal * imm;
+        // `imm` is a byte offset (a multiple of DEFAULT_PC_STEP, possibly negative as a field
+        // element); pc values on the buses are pc indices, so scale it down by DEFAULT_PC_STEP.
+        let to_pc = from_pc + is_lui * AB::Expr::ONE + is_jal * imm * pc_step_inv;
 
         let expected_opcode = VmCoreAir::<AB, I>::expr_to_global_expr(
             self,
@@ -184,8 +193,9 @@ pub(super) fn get_signed_imm(is_jal: bool, imm: InstructionOperand) -> Option<i3
 pub(super) fn run_jal_lui(is_jal: bool, pc: u32, imm: i32) -> (u32, [u16; BLOCK_FE_WIDTH]) {
     if is_jal {
         let rd_low = pc.wrapping_add(DEFAULT_PC_STEP);
-        let next_pc = pc.wrapping_add_signed(imm);
-        (next_pc, u32_to_u16_block(rd_low))
+        let next_pc = (pc as i64).wrapping_add(imm as i64);
+        debug_assert!(next_pc >= 0 && next_pc <= MAX_ALLOWED_PC as i64);
+        (next_pc as u32, u32_to_u16_block(rd_low))
     } else {
         let imm = imm as u32;
         let rd_low = imm << RV_IS_TYPE_IMM_BITS;

--- a/extensions/riscv/circuit/src/jal_lui/core.rs
+++ b/extensions/riscv/circuit/src/jal_lui/core.rs
@@ -8,7 +8,7 @@ use openvm_circuit_primitives::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::InstructionOperand,
-    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_IDX_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalLuiOpcode::{self, *};
@@ -107,7 +107,7 @@ where
         builder.when(is_jal).assert_eq(
             rd[0] * pc_step_inv
                 + rd[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS)
-                + rd_carry * AB::F::from_u32(1 << PC_BITS),
+                + rd_carry * AB::F::from_u32(1 << PC_IDX_BITS),
             from_pc_idx + AB::F::ONE,
         );
         // A carry leaves all low-32-bit return-address limbs zero. This prevents field wrap in
@@ -136,7 +136,7 @@ where
         // JAL return addresses are DEFAULT_PC_STEP-aligned: rd[0] = 4 * x with
         // x < 2^PC_IDX_LOW_BITS. Together with rd[1] < 2^16 this makes the decomposition
         // rd = 4 * (from_pc_idx + 1) unique: the composed pc index rd[1] * 2^PC_IDX_LOW_BITS + x
-        // is at most 2^PC_BITS < p, so it must equal from_pc_idx + 1 over the integers.
+        // is at most 2^PC_IDX_BITS < p, so it must equal from_pc_idx + 1 over the integers.
         self.range_bus
             .range_check(rd[0] * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_jal);

--- a/extensions/riscv/circuit/src/jal_lui/core.rs
+++ b/extensions/riscv/circuit/src/jal_lui/core.rs
@@ -8,7 +8,7 @@ use openvm_circuit_primitives::{
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
     instruction::InstructionOperand,
-    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalLuiOpcode::{self, *};
@@ -20,7 +20,7 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    ptr_to_u16_limbs, u32_to_u16_block, PC_IDX_LOW_BITS, PTR_U16_LIMBS, RV_IS_TYPE_IMM_BITS,
+    ptr_to_u16_limbs, u64_to_u16_block, PC_IDX_LOW_BITS, PTR_U16_LIMBS, RV_IS_TYPE_IMM_BITS,
     RV_J_TYPE_IMM_BITS, U16_BITS,
 };
 
@@ -30,12 +30,13 @@ pub(super) const LUI_IMM_LOW_BITS: usize = U16_BITS - RV_IS_TYPE_IMM_BITS;
 #[derive(Debug, Clone, AlignedBorrow, StructReflection)]
 pub struct JalLuiCoreCols<T> {
     pub imm: T,
-    // Low 32 bits of rd as u16 cells. Upper register cells are sign extension.
+    // Low 32 bits of rd as u16 cells.
     pub rd_data: [T; PTR_U16_LIMBS],
     pub imm_low_4: T,
     pub is_jal: T,
     pub is_lui: T,
     pub is_sign_extend: T,
+    pub rd_carry: T,
 }
 
 #[derive(Debug, Clone, Copy, derive_new::new, ColumnsAir)]
@@ -74,6 +75,7 @@ where
             is_jal,
             is_lui,
             is_sign_extend,
+            rd_carry,
         } = *cols;
 
         builder.assert_bool(is_lui);
@@ -81,6 +83,7 @@ where
         let is_valid = is_lui + is_jal;
         builder.assert_bool(is_valid.clone());
         builder.assert_bool(is_sign_extend);
+        builder.assert_bool(rd_carry);
 
         // LUI: constrain rd = imm << RV_IS_TYPE_IMM_BITS.
         builder
@@ -97,15 +100,20 @@ where
             .range_check(imm_low_4, LUI_IMM_LOW_BITS)
             .eval(builder, is_lui);
 
-        let limb_base = AB::F::from_u32(1 << U16_BITS);
         let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
 
-        // JAL: constrain rd_low_32 = 4 * (from_pc_idx + 1), the byte return address for the
-        // pc index `from_pc_idx`.
+        // JAL: constrain all 33 possible return-address bits. Dividing the aligned low limb by
+        // DEFAULT_PC_STEP keeps the equality below the field modulus.
         builder.when(is_jal).assert_eq(
-            rd[0],
-            (from_pc_idx + AB::F::ONE) * AB::F::from_u32(DEFAULT_PC_STEP) - rd[1] * limb_base,
+            rd[0] * pc_step_inv
+                + rd[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS)
+                + rd_carry * AB::F::from_u32(1 << PC_BITS),
+            from_pc_idx + AB::F::ONE,
         );
+        // A carry leaves all low-32-bit return-address limbs zero. This prevents field wrap in
+        // the decomposition and pins the carry to the final pc index.
+        builder.when(rd_carry).assert_zero(rd[0]);
+        builder.when(rd_carry).assert_zero(rd[1]);
 
         // Range-check the low 32-bit rd cells.
         self.range_bus
@@ -115,8 +123,7 @@ where
             .range_check(rd[1], U16_BITS)
             .eval(builder, is_valid.clone());
 
-        // Tie is_sign_extend to bit 31 of rd for LUI. JAL return addresses are zero-extended
-        // low-32-bit values (the bus address convention), so is_sign_extend must be 0.
+        // Tie is_sign_extend to bit 31 of rd for LUI. The two result flags are opcode-specific.
         self.range_bus
             .range_check(
                 AB::Expr::from_u32(2) * rd[1] - is_sign_extend * AB::Expr::from_u32(1 << U16_BITS),
@@ -124,22 +131,22 @@ where
             )
             .eval(builder, is_lui);
         builder.when(is_jal).assert_zero(is_sign_extend);
+        builder.when(is_lui).assert_zero(rd_carry);
 
         // JAL return addresses are DEFAULT_PC_STEP-aligned: rd[0] = 4 * x with
         // x < 2^PC_IDX_LOW_BITS. Together with rd[1] < 2^16 this makes the decomposition
         // rd = 4 * (from_pc_idx + 1) unique: the composed pc index rd[1] * 2^PC_IDX_LOW_BITS + x
-        // is < 2^PC_BITS < p, so it must equal from_pc_idx + 1 over the integers. A JAL at the
-        // last pc index (from_pc_idx + 1 = 2^PC_BITS) is unsatisfiable, hence unprovable.
+        // is at most 2^PC_BITS < p, so it must equal from_pc_idx + 1 over the integers.
         self.range_bus
             .range_check(rd[0] * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_jal);
 
-        // Sign-extend bit 31 into the upper RV64 register cells (LUI only; see above).
+        // LUI sign-extends bit 31; JAL writes its carry into bit 32.
         let sign_extend_cell = is_sign_extend * AB::Expr::from_u32(u16::MAX as u32);
         let write_data: [AB::Expr; BLOCK_FE_WIDTH] = [
             rd[0].into(),
             rd[1].into(),
-            sign_extend_cell.clone(),
+            sign_extend_cell.clone() + rd_carry,
             sign_extend_cell,
         ];
 
@@ -192,10 +199,10 @@ pub(super) fn get_signed_imm(is_jal: bool, imm: InstructionOperand) -> Option<i3
 #[inline(always)]
 pub(super) fn run_jal_lui(is_jal: bool, pc: u32, imm: i32) -> (u32, [u16; BLOCK_FE_WIDTH]) {
     if is_jal {
-        let rd_low = pc.wrapping_add(DEFAULT_PC_STEP);
+        let rd = u64::from(pc) + u64::from(DEFAULT_PC_STEP);
         let next_pc = (pc as i64).wrapping_add(imm as i64);
         debug_assert!(next_pc >= 0 && next_pc <= MAX_ALLOWED_PC as i64);
-        (next_pc as u32, u32_to_u16_block(rd_low))
+        (next_pc as u32, u64_to_u16_block(rd))
     } else {
         let imm = imm as u32;
         let rd_low = imm << RV_IS_TYPE_IMM_BITS;

--- a/extensions/riscv/circuit/src/jal_lui/core.rs
+++ b/extensions/riscv/circuit/src/jal_lui/core.rs
@@ -64,7 +64,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &JalLuiCoreCols<AB::Var> = (*local_core).borrow();
         let JalLuiCoreCols::<AB::Var> {
@@ -100,11 +100,11 @@ where
         let limb_base = AB::F::from_u32(1 << U16_BITS);
         let pc_step_inv = AB::F::from_u32(DEFAULT_PC_STEP).inverse();
 
-        // JAL: constrain rd_low_32 = 4 * (from_pc + 1), the byte return address for the pc
-        // index `from_pc`.
+        // JAL: constrain rd_low_32 = 4 * (from_pc_idx + 1), the byte return address for the
+        // pc index `from_pc_idx`.
         builder.when(is_jal).assert_eq(
             rd[0],
-            (from_pc + AB::F::ONE) * AB::F::from_u32(DEFAULT_PC_STEP) - rd[1] * limb_base,
+            (from_pc_idx + AB::F::ONE) * AB::F::from_u32(DEFAULT_PC_STEP) - rd[1] * limb_base,
         );
 
         // Range-check the low 32-bit rd cells.
@@ -127,9 +127,9 @@ where
 
         // JAL return addresses are DEFAULT_PC_STEP-aligned: rd[0] = 4 * x with
         // x < 2^PC_IDX_LOW_BITS. Together with rd[1] < 2^16 this makes the decomposition
-        // rd = 4 * (from_pc + 1) unique: the composed pc index rd[1] * 2^PC_IDX_LOW_BITS + x
-        // is < 2^PC_BITS < p, so it must equal from_pc + 1 over the integers. A JAL at the
-        // last pc index (from_pc + 1 = 2^PC_BITS) is unsatisfiable, hence unprovable.
+        // rd = 4 * (from_pc_idx + 1) unique: the composed pc index rd[1] * 2^PC_IDX_LOW_BITS + x
+        // is < 2^PC_BITS < p, so it must equal from_pc_idx + 1 over the integers. A JAL at the
+        // last pc index (from_pc_idx + 1 = 2^PC_BITS) is unsatisfiable, hence unprovable.
         self.range_bus
             .range_check(rd[0] * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_jal);
@@ -145,7 +145,7 @@ where
 
         // `imm` is a byte offset (a multiple of DEFAULT_PC_STEP, possibly negative as a field
         // element); pc values on the buses are pc indices, so scale it down by DEFAULT_PC_STEP.
-        let to_pc = from_pc + is_lui * AB::Expr::ONE + is_jal * imm * pc_step_inv;
+        let to_pc_idx = from_pc_idx + is_lui * AB::Expr::ONE + is_jal * imm * pc_step_inv;
 
         let expected_opcode = VmCoreAir::<AB, I>::expr_to_global_expr(
             self,
@@ -153,7 +153,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: Some(to_pc),
+            to_pc: Some(to_pc_idx),
             reads: [].into(),
             writes: [write_data].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/jal_lui/tests.rs
+++ b/extensions/riscv/circuit/src/jal_lui/tests.rs
@@ -199,8 +199,7 @@ fn rand_jal_lui_test(opcode: JalLuiOpcode, num_ops: usize) {
 
 #[test]
 fn jal_max_pc_test() {
-    // JAL from the second-to-last instruction slot of the 32-bit PC address space, jumping
-    // backward; the return address is the last slot.
+    // JAL at 0xfffffffc writes the 64-bit link address 0x1_00000000.
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
     let (mut harness, bitwise) = create_harness(&tester);
@@ -212,7 +211,7 @@ fn jal_max_pc_test() {
         &mut rng,
         JAL,
         Some(-4096),
-        Some(MAX_ALLOWED_PC - 2 * DEFAULT_PC_STEP),
+        Some(MAX_ALLOWED_PC),
         None,
     );
 
@@ -239,6 +238,7 @@ struct JalLuiPrankValues {
     pub is_jal: Option<bool>,
     pub is_lui: Option<bool>,
     pub is_sign_extend: Option<bool>,
+    pub rd_carry: Option<bool>,
     pub rd_ptr: Option<u32>,
     pub needs_write: Option<bool>,
 }
@@ -295,6 +295,9 @@ fn run_negative_jal_lui_test_with_rd_ptr(
         }
         if let Some(is_sign_extend) = prank_vals.is_sign_extend {
             core_cols.is_sign_extend = F::from_bool(is_sign_extend);
+        }
+        if let Some(rd_carry) = prank_vals.rd_carry {
+            core_cols.rd_carry = F::from_bool(rd_carry);
         }
         if let Some(rd_ptr) = prank_vals.rd_ptr {
             adapter_cols.inner.rd_ptr = F::from_u32(rd_ptr);
@@ -448,7 +451,7 @@ fn rd_upper_bytes_trace_tamper_negative_test() {
 }
 
 #[test]
-fn sign_extend_flag_negative_tests() {
+fn rd_high_flags_negative_tests() {
     // LUI with imm small enough that imm << 12 has bit 31 unset (MSB of rd[1] is 0).
     // is_sign_extend pranked to true should fail.
     run_negative_jal_lui_test(
@@ -461,14 +464,13 @@ fn sign_extend_flag_negative_tests() {
         },
         true,
     );
-    // JAL writes pc+4 with pc < 2^30, so MSB of rd[1] is always 0.
-    // is_sign_extend pranked to true should fail.
+    // This non-boundary JAL has no bit-32 carry, so rd_carry pranked to true should fail.
     run_negative_jal_lui_test(
         JAL,
         None,
         None,
         JalLuiPrankValues {
-            is_sign_extend: Some(true),
+            rd_carry: Some(true),
             ..Default::default()
         },
         true,
@@ -717,6 +719,18 @@ fn test_cuda_rand_jal_lui_tracegen(opcode: JalLuiOpcode, num_ops: usize) {
             opcode,
             None,
             None,
+            None,
+        );
+    }
+    if opcode == JAL {
+        set_and_execute(
+            &mut tester,
+            &mut harness.executor,
+            &mut harness.preflight,
+            &mut rng,
+            JAL,
+            Some(-4096),
+            Some(MAX_ALLOWED_PC),
             None,
         );
     }

--- a/extensions/riscv/circuit/src/jal_lui/tests.rs
+++ b/extensions/riscv/circuit/src/jal_lui/tests.rs
@@ -18,7 +18,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::{
     instruction::{Instruction, InstructionOperand},
-    program::PC_BITS,
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalLuiOpcode::{self, *};
@@ -114,7 +114,10 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
     let is_jal = opcode == JAL;
     let imm = imm.unwrap_or_else(|| {
         if is_jal {
-            let raw: i32 = rng.random_range(0..(1 << (RV_J_TYPE_IMM_BITS - 1)));
+            // JAL offsets are DEFAULT_PC_STEP-aligned byte offsets.
+            let raw: i32 = rng
+                .random_range(0..(1 << (RV_J_TYPE_IMM_BITS - 1)) / DEFAULT_PC_STEP as i32)
+                * DEFAULT_PC_STEP as i32;
             if rng.random_bool(0.5) {
                 -raw
             } else {
@@ -127,10 +130,14 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
     let a = rd_ptr.unwrap_or_else(|| (rng.random_range(0..32) << 3) as usize);
 
     let initial_pc = initial_pc.unwrap_or_else(|| {
-        if is_jal && imm < 0 {
-            rng.random_range((-imm as u32)..(1u32 << 30))
+        // An aligned byte pc over the full 32-bit range; for JAL, keep the target and the
+        // return address inside the implemented PC address space.
+        if is_jal {
+            let lo = (-imm).max(0) as u32 / DEFAULT_PC_STEP;
+            let hi = (MAX_ALLOWED_PC - DEFAULT_PC_STEP - imm.max(0) as u32) / DEFAULT_PC_STEP;
+            rng.random_range(lo..=hi) * DEFAULT_PC_STEP
         } else {
-            rng.random_range(0..(1u32 << 30).min(1u32 << PC_BITS))
+            (rng.random::<u32>() & !3).min(MAX_ALLOWED_PC - DEFAULT_PC_STEP)
         }
     });
     tester.execute_with_pc(
@@ -182,6 +189,33 @@ fn rand_jal_lui_test(opcode: JalLuiOpcode, num_ops: usize) {
             None,
         );
     }
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
+    tester.simple_test().expect("Verification failed");
+}
+
+#[test]
+fn jal_max_pc_test() {
+    // JAL from the second-to-last instruction slot of the 32-bit PC address space, jumping
+    // backward; the return address is the last slot.
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let (mut harness, bitwise) = create_harness(&tester);
+
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        JAL,
+        Some(-4096),
+        Some(MAX_ALLOWED_PC - 2 * DEFAULT_PC_STEP),
+        None,
+    );
+
     let tester = tester
         .build()
         .load(harness)
@@ -342,7 +376,7 @@ fn opcode_flag_negative_test() {
 fn write_suppression_boundary_negative_test() {
     run_negative_jal_lui_test_with_rd_ptr(
         JAL,
-        Some((1 << 19) + 2),
+        Some((1 << 19) + 4),
         Some(28120),
         Some(0),
         JalLuiPrankValues {
@@ -354,7 +388,7 @@ fn write_suppression_boundary_negative_test() {
 
     run_negative_jal_lui_test_with_rd_ptr(
         JAL,
-        Some((1 << 19) + 2),
+        Some((1 << 19) + 4),
         Some(28120),
         Some(8),
         JalLuiPrankValues {
@@ -456,7 +490,7 @@ fn overflow_negative_tests() {
     run_negative_jal_lui_test(
         JAL,
         None,
-        Some((1u32 << 28) - 6),
+        Some((1u32 << 28) - 8),
         JalLuiPrankValues {
             rd_data: Some([0, 0]),
             ..Default::default()
@@ -544,7 +578,8 @@ fn execute_roundtrip_sanity_test() {
         &mut harness.preflight,
         &mut rng,
         JAL,
-        Some((1i32 << (RV_J_TYPE_IMM_BITS - 1)) - 1),
+        // The largest DEFAULT_PC_STEP-aligned J-type offset.
+        Some((1i32 << (RV_J_TYPE_IMM_BITS - 1)) - DEFAULT_PC_STEP as i32),
         None,
         None,
     );
@@ -571,7 +606,7 @@ fn jal_x0_write_suppression_test() {
         &mut harness.preflight,
         &mut rng,
         JAL,
-        Some((1 << 19) + 2),
+        Some((1 << 19) + 4),
         Some(28120),
         Some(0),
     );

--- a/extensions/riscv/circuit/src/jal_lui/trace.rs
+++ b/extensions/riscv/circuit/src/jal_lui/trace.rs
@@ -5,14 +5,17 @@ use openvm_circuit::{
     system::program::trace::instruction_operand_to_field,
     utils::next_power_of_two_or_zero,
 };
-use openvm_instructions::LocalOpcode;
+use openvm_instructions::{
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_STEP_BITS},
+    LocalOpcode,
+};
 use openvm_riscv_transpiler::JalLuiOpcode::{self, JAL, LUI};
 use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix};
 
-use super::{
-    get_signed_imm, run_jal_lui, JalLuiChip, JalLuiCoreCols, LUI_IMM_LOW_BITS, PC_HIGH_U16_SHIFT,
+use super::{get_signed_imm, run_jal_lui, JalLuiChip, JalLuiCoreCols, LUI_IMM_LOW_BITS};
+use crate::adapters::{
+    CondRdWriteAdapterCols, CondRdWriteAdapterFiller, PC_IDX_LOW_BITS, U16_BITS,
 };
-use crate::adapters::{CondRdWriteAdapterCols, CondRdWriteAdapterFiller, U16_BITS};
 
 /// Generates the JAL/LUI trace directly from immutable preflight history.
 pub fn generate_trace_from_postflight<F: PrimeField32>(
@@ -38,6 +41,23 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             let is_jal = local_opcode == JalLuiOpcode::JAL;
             let signed_imm = get_signed_imm(is_jal, instruction.c)
                 .ok_or_else(|| PostflightError::new("JAL/LUI instruction has invalid immediate"))?;
+            if is_jal {
+                let from_pc = postflight.pc(step);
+                if from_pc >= MAX_ALLOWED_PC {
+                    return Err(PostflightError::new(
+                        "JAL return address exceeds implemented PC address space",
+                    ));
+                }
+                let target = from_pc as i64 + signed_imm as i64;
+                if target < 0
+                    || target > MAX_ALLOWED_PC as i64
+                    || target % DEFAULT_PC_STEP as i64 != 0
+                {
+                    return Err(PostflightError::new(
+                        "JAL target outside implemented PC address space",
+                    ));
+                }
+            }
             let (rd_data, _) = CondRdWriteAdapterFiller::replay(
                 postflight,
                 step,
@@ -52,8 +72,12 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             let core_row: &mut JalLuiCoreCols<F> = core_row.borrow_mut();
             let rd_lo = rd_data[0];
             let rd_hi = rd_data[1];
-            let is_sign_extend = (rd_hi >> (U16_BITS - 1)) & 1;
-            let sign_check = 2u32 * (rd_hi as u32) - (is_sign_extend as u32) * (1 << U16_BITS);
+            // JAL return addresses are zero-extended; only LUI sign-extends bit 31.
+            let is_sign_extend = if is_jal {
+                0
+            } else {
+                (rd_hi >> (U16_BITS - 1)) & 1
+            };
             let imm_low_4 = if is_jal {
                 0
             } else {
@@ -66,14 +90,15 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             chip.inner
                 .range_checker_chip
                 .add_count(rd_hi as u32, U16_BITS);
-            chip.inner
-                .range_checker_chip
-                .add_count(sign_check, U16_BITS);
             if is_jal {
                 chip.inner
                     .range_checker_chip
-                    .add_count((rd_hi as u32) << PC_HIGH_U16_SHIFT, U16_BITS);
+                    .add_count((rd_lo as u32) >> PC_STEP_BITS, PC_IDX_LOW_BITS);
             } else {
+                let sign_check = 2u32 * (rd_hi as u32) - (is_sign_extend as u32) * (1 << U16_BITS);
+                chip.inner
+                    .range_checker_chip
+                    .add_count(sign_check, U16_BITS);
                 chip.inner
                     .range_checker_chip
                     .add_count(imm_low_4 as u32, LUI_IMM_LOW_BITS);

--- a/extensions/riscv/circuit/src/jal_lui/trace.rs
+++ b/extensions/riscv/circuit/src/jal_lui/trace.rs
@@ -43,11 +43,6 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
                 .ok_or_else(|| PostflightError::new("JAL/LUI instruction has invalid immediate"))?;
             if is_jal {
                 let from_pc = postflight.pc(step);
-                if from_pc >= MAX_ALLOWED_PC {
-                    return Err(PostflightError::new(
-                        "JAL return address exceeds implemented PC address space",
-                    ));
-                }
                 let target = from_pc as i64 + signed_imm as i64;
                 if target < 0
                     || target > MAX_ALLOWED_PC as i64
@@ -72,12 +67,8 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             let core_row: &mut JalLuiCoreCols<F> = core_row.borrow_mut();
             let rd_lo = rd_data[0];
             let rd_hi = rd_data[1];
-            // JAL return addresses are zero-extended; only LUI sign-extends bit 31.
-            let is_sign_extend = if is_jal {
-                0
-            } else {
-                (rd_hi >> (U16_BITS - 1)) & 1
-            };
+            let is_sign_extend = !is_jal && (rd_hi >> (U16_BITS - 1)) & 1 != 0;
+            let rd_carry = if is_jal { rd_data[2] } else { 0 };
             let imm_low_4 = if is_jal {
                 0
             } else {
@@ -109,7 +100,8 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             core_row.imm_low_4 = F::from_u8(imm_low_4);
             core_row.is_jal = F::from_bool(is_jal);
             core_row.is_lui = F::from_bool(!is_jal);
-            core_row.is_sign_extend = F::from_bool(is_sign_extend != 0);
+            core_row.is_sign_extend = F::from_bool(is_sign_extend);
+            core_row.rd_carry = F::from_bool(rd_carry != 0);
             Ok(())
         })?;
         row_index += steps.len();

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -29,12 +29,12 @@ pub struct JalrCoreCols<T> {
     pub imm: T,
     // Low 32 bits of rs1 as u16 cells.
     pub rs1_data: [T; PTR_U16_LIMBS],
-    // The high u16 limb and bit-32 carry of rd; the low limb is derived from from_pc.
+    // The high u16 limb and bit-32 carry of rd; the low limb is derived from from_pc_idx.
     pub rd_high: [T; PTR_U16_LIMBS],
     pub is_valid: T,
 
     pub raw_target_bit0: T,
-    /// Limbs of the target pc *index* (`to_pc / DEFAULT_PC_STEP`) after the low-bit split:
+    /// Limbs of the target PC index (`target_pc / DEFAULT_PC_STEP`) after the low-bit split:
     /// `[to_pc_idx % 2^PC_IDX_LOW_BITS, to_pc_idx >> PC_IDX_LOW_BITS]`.
     pub to_pc_idx_limbs: [T; 2],
     pub imm_sign: T,
@@ -150,7 +150,7 @@ where
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, JALR);
 
         AdapterAirContext {
-            to_pc: Some(to_pc_idx),
+            to_pc_idx: Some(to_pc_idx),
             reads: [rs1_data].into(),
             writes: [rd_data].into(),
             instruction: SignedImmInstruction {

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP, PC_BITS, PC_STEP_BITS},
+    program::{DEFAULT_PC_STEP, PC_IDX_BITS, PC_STEP_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalrOpcode::{self, *};
@@ -33,10 +33,10 @@ pub struct JalrCoreCols<T> {
     pub rd_high: [T; PTR_U16_LIMBS],
     pub is_valid: T,
 
-    pub to_pc_least_sig_bit: T,
+    pub raw_target_bit0: T,
     /// Limbs of the target pc *index* (`to_pc / DEFAULT_PC_STEP`) after the low-bit split:
     /// `[to_pc_idx % 2^PC_IDX_LOW_BITS, to_pc_idx >> PC_IDX_LOW_BITS]`.
-    pub to_pc_limbs: [T; 2],
+    pub to_pc_idx_limbs: [T; 2],
     pub imm_sign: T,
 }
 
@@ -75,8 +75,8 @@ where
             rd_high,
             is_valid,
             imm_sign,
-            to_pc_least_sig_bit,
-            to_pc_limbs,
+            raw_target_bit0,
+            to_pc_idx_limbs,
         } = *cols;
 
         builder.assert_bool(is_valid);
@@ -88,7 +88,7 @@ where
         // coefficient remains below the field modulus, including the possible bit-32 carry.
         let least_sig_limb = (from_pc_idx + AB::F::ONE
             - rd_high[0] * AB::F::from_u32(1 << PC_IDX_LOW_BITS)
-            - rd_high[1] * AB::F::from_u32(1 << PC_BITS))
+            - rd_high[1] * AB::F::from_u32(1 << PC_IDX_BITS))
             * pc_step;
         // A carry leaves all low-32-bit return-address limbs zero. This prevents field wrap in
         // the decomposition and pins the carry to the final pc index.
@@ -98,8 +98,8 @@ where
         // The low limb is DEFAULT_PC_STEP-aligned with a PC_IDX_LOW_BITS-bit quotient (which
         // also implies it is a u16), and the high limb is a u16. This pins the decomposition:
         // the composed pc index rd_high[0] * 2^PC_IDX_LOW_BITS + least_sig_limb / 4 is
-        // < 2^PC_BITS < p, so it equals from_pc_idx + 1 over the integers.
-        // Assumes only from_pc_idx in [0, 2^PC_BITS) is allowed by program bus.
+        // < 2^PC_IDX_BITS < p, so it equals from_pc_idx + 1 over the integers.
+        // Assumes only from_pc_idx in [0, 2^PC_IDX_BITS) is allowed by program bus.
         self.range_bus
             .range_check(least_sig_limb.clone() * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
@@ -112,30 +112,31 @@ where
 
         let inv = AB::F::from_u32(1 << U16_BITS).inverse();
 
-        // Constrain to_pc_least_sig_bit + 4 * to_pc_limbs = rs1 + imm as a
-        // low-32-bit addition with two u16 limbs, where to_pc_limbs decompose the target pc
+        // Constrain raw_target_bit0 + 4 * to_pc_idx_limbs = rs1 + imm as a
+        // low-32-bit addition with two u16 limbs, where to_pc_idx_limbs decompose the target pc
         // *index*. RISC-V explicitly clears the least significant bit of the JALR target;
         // a target with bit 1 set (misaligned) makes the low carry non-boolean, so it is
         // unprovable.
-        builder.assert_bool(to_pc_least_sig_bit);
-        let carry = (rs1[0] + imm - to_pc_limbs[0] * pc_step - to_pc_least_sig_bit) * inv;
+        builder.assert_bool(raw_target_bit0);
+        let carry = (rs1[0] + imm - to_pc_idx_limbs[0] * pc_step - raw_target_bit0) * inv;
         builder.when(is_valid).assert_bool(carry.clone());
 
         // Sign-extend the 16-bit immediate into the high u16 limb.
         let imm_extend_limb = imm_sign * AB::F::from_u32(u16::MAX as u32);
-        let carry = (rs1[1] + imm_extend_limb + carry - to_pc_limbs[1]) * inv;
+        let carry = (rs1[1] + imm_extend_limb + carry - to_pc_idx_limbs[1]) * inv;
         builder.when(is_valid).assert_bool(carry.clone());
         builder.when(is_valid).assert_eq(carry, imm_sign);
 
-        // The limb widths bound the target pc index by 2^PC_BITS, i.e. the byte target by
+        // The limb widths bound the target pc index by 2^PC_IDX_BITS, i.e. the byte target by
         // 2^32; together with the boolean carries this pins the integer value of rs1 + imm.
         self.range_bus
-            .range_check(to_pc_limbs[1], U16_BITS)
+            .range_check(to_pc_idx_limbs[1], U16_BITS)
             .eval(builder, is_valid);
         self.range_bus
-            .range_check(to_pc_limbs[0], PC_IDX_LOW_BITS)
+            .range_check(to_pc_idx_limbs[0], PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
-        let to_pc_idx = to_pc_limbs[0] + to_pc_limbs[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
+        let to_pc_idx =
+            to_pc_idx_limbs[0] + to_pc_idx_limbs[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
 
         // Zero-extend low-32 rs1; rd additionally includes its bit-32 carry.
         let rs1_data = expand_to_block(&rs1);
@@ -189,20 +190,21 @@ impl JalrFiller {
         rs1_val: u32,
         imm: u16,
         imm_sign: bool,
-        to_pc: u32,
+        raw_target_pc: u32,
         rd_data: [u16; BLOCK_FE_WIDTH],
     ) {
-        // `to_pc` is the raw byte target; bit 0 is cleared per RISC-V and bit 1 is zero
+        // `raw_target_pc` is the target before JALR masking; bit 0 is cleared and bit 1 is zero
         // (misaligned targets are rejected by `try_run_jalr`).
-        debug_assert_eq!(to_pc & 0b10, 0);
-        let to_pc_idx = (to_pc & !1) >> PC_STEP_BITS;
-        let to_pc_limbs = [
+        debug_assert_eq!(raw_target_pc & 0b10, 0);
+        let to_pc_idx = (raw_target_pc & !1) >> PC_STEP_BITS;
+        let to_pc_idx_limbs = [
             to_pc_idx & ((1 << PC_IDX_LOW_BITS) - 1),
             to_pc_idx >> PC_IDX_LOW_BITS,
         ];
         self.range_checker_chip
-            .add_count(to_pc_limbs[0], PC_IDX_LOW_BITS);
-        self.range_checker_chip.add_count(to_pc_limbs[1], U16_BITS);
+            .add_count(to_pc_idx_limbs[0], PC_IDX_LOW_BITS);
+        self.range_checker_chip
+            .add_count(to_pc_idx_limbs[1], U16_BITS);
 
         let rd_low_u16_lo = rd_data[0];
         let rd_low_u16_hi = rd_data[1];
@@ -214,8 +216,8 @@ impl JalrFiller {
 
         // Write in reverse order
         core_row.imm_sign = F::from_bool(imm_sign);
-        core_row.to_pc_limbs = to_pc_limbs.map(F::from_u32);
-        core_row.to_pc_least_sig_bit = F::from_bool(to_pc & 1 == 1);
+        core_row.to_pc_idx_limbs = to_pc_idx_limbs.map(F::from_u32);
+        core_row.raw_target_bit0 = F::from_bool(raw_target_pc & 1 == 1);
         // fill_trace_row is called only on valid rows
         core_row.is_valid = F::ONE;
         core_row.rs1_data = ptr_to_u16_limbs(rs1_val).map(F::from_u16);
@@ -224,7 +226,7 @@ impl JalrFiller {
     }
 }
 
-// returns (to_pc, rd_data)
+// Returns the target pc before JALR masking and the rd data.
 #[cfg(test)]
 #[inline(always)]
 pub(super) fn run_jalr(
@@ -244,20 +246,20 @@ pub(super) fn try_run_jalr(
     imm_sign: bool,
 ) -> Option<(u32, [u16; BLOCK_FE_WIDTH])> {
     let imm_extended = imm as u32 + (imm_sign as u32 * ((u16::MAX as u32) << U16_BITS));
-    let (unaligned_to_pc, _) = checked_jalr_target(rs1, imm_extended)?;
+    let (raw_target_pc, _) = checked_jalr_target(rs1, imm_extended)?;
 
     let rd_data = u64_to_u16_block(u64::from(pc) + u64::from(DEFAULT_PC_STEP));
     // Trace generation keeps the raw target so the AIR can witness its cleared low bit. The
     // adapter applies the mask when it checks the next execution state.
-    Some((unaligned_to_pc, rd_data))
+    Some((raw_target_pc, rd_data))
 }
 
 #[inline(always)]
 pub(super) fn checked_jalr_target(rs1: u32, imm_extended: u32) -> Option<(u32, u32)> {
-    let unaligned_to_pc = u32::try_from(address_add_imm(rs1, imm_extended)).ok()?;
+    let raw_target_pc = u32::try_from(address_add_imm(rs1, imm_extended)).ok()?;
     // RISC-V clears bit 0 before checking instruction alignment.
-    let to_pc = unaligned_to_pc & !1;
+    let to_pc = raw_target_pc & !1;
     to_pc
         .is_multiple_of(DEFAULT_PC_STEP)
-        .then_some((unaligned_to_pc, to_pc))
+        .then_some((raw_target_pc, to_pc))
 }

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -66,7 +66,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        from_pc: AB::Var,
+        from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &JalrCoreCols<AB::Var> = (*local_core).borrow();
         let JalrCoreCols::<AB::Var> {
@@ -87,8 +87,8 @@ where
         let pc_step = AB::F::from_u32(DEFAULT_PC_STEP);
         let pc_step_inv = pc_step.inverse();
 
-        // The byte return address is 4 * (from_pc + 1), where `from_pc` is a pc index.
-        let least_sig_limb = (from_pc + AB::F::ONE) * pc_step - composed;
+        // The byte return address is 4 * (from_pc_idx + 1).
+        let least_sig_limb = (from_pc_idx + AB::F::ONE) * pc_step - composed;
 
         // rd_data_low is the low-32-bit decomposition of the byte return address.
         let rd_data_low: [AB::Expr; PTR_U16_LIMBS] = [least_sig_limb.clone(), rd_high[0].into()];
@@ -96,8 +96,8 @@ where
         // The low limb is DEFAULT_PC_STEP-aligned with a PC_IDX_LOW_BITS-bit quotient (which
         // also implies it is a u16), and the high limb is a u16. This pins the decomposition:
         // the composed pc index rd_high[0] * 2^PC_IDX_LOW_BITS + least_sig_limb / 4 is
-        // < 2^PC_BITS < p, so it equals from_pc + 1 over the integers.
-        // Assumes only from_pc in [0, 2^PC_BITS) is allowed by program bus.
+        // < 2^PC_BITS < p, so it equals from_pc_idx + 1 over the integers.
+        // Assumes only from_pc_idx in [0, 2^PC_BITS) is allowed by program bus.
         self.range_bus
             .range_check(least_sig_limb.clone() * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
@@ -132,7 +132,7 @@ where
         self.range_bus
             .range_check(to_pc_limbs[0], PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
-        let to_pc = to_pc_limbs[0] + to_pc_limbs[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
+        let to_pc_idx = to_pc_limbs[0] + to_pc_limbs[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
 
         // Zero-extend low-32 rs1/rd at the adapter interface.
         let rs1_data = expand_to_block(&rs1);
@@ -141,7 +141,7 @@ where
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, JALR);
 
         AdapterAirContext {
-            to_pc: Some(to_pc),
+            to_pc: Some(to_pc_idx),
             reads: [rs1_data].into(),
             writes: [rd_data].into(),
             instruction: SignedImmInstruction {

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_BITS},
+    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_STEP_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalrOpcode::{self, *};
@@ -19,7 +19,8 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    address_add_imm, expand_to_block, ptr_to_u16_limbs, u32_to_u16_block, PTR_U16_LIMBS, U16_BITS,
+    address_add_imm, expand_to_block, ptr_to_u16_limbs, u32_to_u16_block, PC_IDX_LOW_BITS,
+    PTR_U16_LIMBS, U16_BITS,
 };
 
 #[repr(C)]
@@ -33,7 +34,8 @@ pub struct JalrCoreCols<T> {
     pub is_valid: T,
 
     pub to_pc_least_sig_bit: T,
-    /// These are the limbs of `to_pc * 2` after the low-bit split.
+    /// Limbs of the target pc *index* (`to_pc / DEFAULT_PC_STEP`) after the low-bit split:
+    /// `[to_pc_idx % 2^PC_IDX_LOW_BITS, to_pc_idx >> PC_IDX_LOW_BITS]`.
     pub to_pc_limbs: [T; 2],
     pub imm_sign: T,
 }
@@ -82,31 +84,38 @@ where
         // composed is the high u16 limb of low-32 rd.
         let composed = rd_high[0] * AB::F::from_u32(1 << U16_BITS);
 
-        let least_sig_limb = from_pc + AB::F::from_u32(DEFAULT_PC_STEP) - composed;
+        let pc_step = AB::F::from_u32(DEFAULT_PC_STEP);
+        let pc_step_inv = pc_step.inverse();
 
-        // rd_data_low is the low-32-bit decomposition of `from_pc + DEFAULT_PC_STEP`.
-        // The range check on `least_sig_limb` also ensures that `rd_data_low` correctly
-        // represents `from_pc + DEFAULT_PC_STEP`.
+        // The byte return address is 4 * (from_pc + 1), where `from_pc` is a pc index.
+        let least_sig_limb = (from_pc + AB::F::ONE) * pc_step - composed;
+
+        // rd_data_low is the low-32-bit decomposition of the byte return address.
         let rd_data_low: [AB::Expr; PTR_U16_LIMBS] = [least_sig_limb.clone(), rd_high[0].into()];
 
-        // Constrain rd_data_low.
-        // Assumes only from_pc in [0, 2^PC_BITS) is allowed by program bus
+        // The low limb is DEFAULT_PC_STEP-aligned with a PC_IDX_LOW_BITS-bit quotient (which
+        // also implies it is a u16), and the high limb is a u16. This pins the decomposition:
+        // the composed pc index rd_high[0] * 2^PC_IDX_LOW_BITS + least_sig_limb / 4 is
+        // < 2^PC_BITS < p, so it equals from_pc + 1 over the integers.
+        // Assumes only from_pc in [0, 2^PC_BITS) is allowed by program bus.
         self.range_bus
-            .range_check(least_sig_limb.clone(), U16_BITS)
+            .range_check(least_sig_limb.clone() * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
         self.range_bus
-            .range_check(rd_data_low[1].clone(), PC_BITS - U16_BITS)
+            .range_check(rd_data_low[1].clone(), U16_BITS)
             .eval(builder, is_valid);
 
         builder.assert_bool(imm_sign);
 
         let inv = AB::F::from_u32(1 << U16_BITS).inverse();
 
-        // Constrain to_pc_least_sig_bit + 2 * to_pc_limbs = rs1 + imm as a
-        // low-32-bit addition with two u16 limbs. RISC-V explicitly clears the
-        // least significant bit of the JALR target.
+        // Constrain to_pc_least_sig_bit + 4 * to_pc_limbs = rs1 + imm as a
+        // low-32-bit addition with two u16 limbs, where to_pc_limbs decompose the target pc
+        // *index*. RISC-V explicitly clears the least significant bit of the JALR target;
+        // a target with bit 1 set (misaligned) makes the low carry non-boolean, so it is
+        // unprovable.
         builder.assert_bool(to_pc_least_sig_bit);
-        let carry = (rs1[0] + imm - to_pc_limbs[0] * AB::F::TWO - to_pc_least_sig_bit) * inv;
+        let carry = (rs1[0] + imm - to_pc_limbs[0] * pc_step - to_pc_least_sig_bit) * inv;
         builder.when(is_valid).assert_bool(carry.clone());
 
         // Sign-extend the 16-bit immediate into the high u16 limb.
@@ -115,15 +124,15 @@ where
         builder.when(is_valid).assert_bool(carry.clone());
         builder.when(is_valid).assert_eq(carry, imm_sign);
 
-        // Prevent to_pc overflow. to_pc_limbs[0] is 15 bits because it is
-        // multiplied by 2 when reconstructing the aligned target.
+        // The limb widths bound the target pc index by 2^PC_BITS, i.e. the byte target by
+        // 2^32; together with the boolean carries this pins the integer value of rs1 + imm.
         self.range_bus
-            .range_check(to_pc_limbs[1], PC_BITS - U16_BITS)
+            .range_check(to_pc_limbs[1], U16_BITS)
             .eval(builder, is_valid);
         self.range_bus
-            .range_check(to_pc_limbs[0], U16_BITS - 1)
+            .range_check(to_pc_limbs[0], PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
-        let to_pc = to_pc_limbs[0] * AB::F::TWO + to_pc_limbs[1] * AB::F::from_u32(1 << U16_BITS);
+        let to_pc = to_pc_limbs[0] + to_pc_limbs[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
 
         // Zero-extend low-32 rs1/rd at the adapter interface.
         let rs1_data = expand_to_block(&rs1);
@@ -175,20 +184,25 @@ impl JalrFiller {
         to_pc: u32,
         rd_data: [u16; BLOCK_FE_WIDTH],
     ) {
-        let [to_pc_low, to_pc_high] = ptr_to_u16_limbs(to_pc);
-        let to_pc_limbs = [u32::from(to_pc_low >> 1), u32::from(to_pc_high)];
+        // `to_pc` is the raw byte target; bit 0 is cleared per RISC-V and bit 1 is zero
+        // (misaligned targets are rejected by `try_run_jalr`).
+        debug_assert_eq!(to_pc & 0b10, 0);
+        let to_pc_idx = (to_pc & !1) >> PC_STEP_BITS;
+        let to_pc_limbs = [
+            to_pc_idx & ((1 << PC_IDX_LOW_BITS) - 1),
+            to_pc_idx >> PC_IDX_LOW_BITS,
+        ];
         self.range_checker_chip
-            .add_count(to_pc_limbs[0], U16_BITS - 1);
-        self.range_checker_chip
-            .add_count(to_pc_limbs[1], PC_BITS - U16_BITS);
+            .add_count(to_pc_limbs[0], PC_IDX_LOW_BITS);
+        self.range_checker_chip.add_count(to_pc_limbs[1], U16_BITS);
 
         let rd_low_u16_lo = rd_data[0];
         let rd_low_u16_hi = rd_data[1];
 
         self.range_checker_chip
-            .add_count(rd_low_u16_lo as u32, U16_BITS);
+            .add_count(u32::from(rd_low_u16_lo) >> PC_STEP_BITS, PC_IDX_LOW_BITS);
         self.range_checker_chip
-            .add_count(rd_low_u16_hi as u32, PC_BITS - U16_BITS);
+            .add_count(rd_low_u16_hi as u32, U16_BITS);
 
         // Write in reverse order
         core_row.imm_sign = F::from_bool(imm_sign);
@@ -226,6 +240,11 @@ pub(super) fn try_run_jalr(
         return None;
     }
     let to_pc = to_pc as u32;
+    // RISC-V clears bit 0 of the target; a set bit 1 leaves the target misaligned, which is
+    // rejected (and unprovable in the circuit).
+    if to_pc & 0b10 != 0 {
+        return None;
+    }
 
     let rd_low_u32 = pc.wrapping_add(DEFAULT_PC_STEP);
     let rd_data = u32_to_u16_block(rd_low_u32);

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC, PC_STEP_BITS},
+    program::{DEFAULT_PC_STEP, PC_STEP_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalrOpcode::{self, *};
@@ -225,7 +225,8 @@ pub(super) fn run_jalr(
     imm: u16,
     imm_sign: bool,
 ) -> (u32, [u16; BLOCK_FE_WIDTH]) {
-    try_run_jalr(pc, rs1, imm, imm_sign).expect("JALR target exceeds implemented PC address space")
+    try_run_jalr(pc, rs1, imm, imm_sign)
+        .expect("JALR target is outside implemented PC address space or misaligned")
 }
 
 pub(super) fn try_run_jalr(
@@ -235,18 +236,16 @@ pub(super) fn try_run_jalr(
     imm_sign: bool,
 ) -> Option<(u32, [u16; BLOCK_FE_WIDTH])> {
     let imm_extended = imm as u32 + (imm_sign as u32 * ((u16::MAX as u32) << U16_BITS));
-    let to_pc = address_add_imm(rs1, imm_extended);
-    if to_pc > u64::from(MAX_ALLOWED_PC) {
-        return None;
-    }
-    let to_pc = to_pc as u32;
-    // RISC-V clears bit 0 of the target; a set bit 1 leaves the target misaligned, which is
-    // rejected (and unprovable in the circuit).
-    if to_pc & 0b10 != 0 {
+    let unaligned_to_pc = u32::try_from(address_add_imm(rs1, imm_extended)).ok()?;
+    // RISC-V clears bit 0 before checking instruction alignment.
+    let to_pc = unaligned_to_pc & !1;
+    if !to_pc.is_multiple_of(DEFAULT_PC_STEP) {
         return None;
     }
 
     let rd_low_u32 = pc.wrapping_add(DEFAULT_PC_STEP);
     let rd_data = u32_to_u16_block(rd_low_u32);
-    Some((to_pc, rd_data))
+    // Trace generation keeps the raw target so the AIR can witness its cleared low bit. The
+    // adapter applies the mask when it checks the next execution state.
+    Some((unaligned_to_pc, rd_data))
 }

--- a/extensions/riscv/circuit/src/jalr/core.rs
+++ b/extensions/riscv/circuit/src/jalr/core.rs
@@ -7,7 +7,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::{DEFAULT_PC_STEP, PC_STEP_BITS},
+    program::{DEFAULT_PC_STEP, PC_BITS, PC_STEP_BITS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalrOpcode::{self, *};
@@ -19,7 +19,7 @@ use openvm_stark_backend::{
 };
 
 use crate::adapters::{
-    address_add_imm, expand_to_block, ptr_to_u16_limbs, u32_to_u16_block, PC_IDX_LOW_BITS,
+    address_add_imm, expand_to_block, ptr_to_u16_limbs, u64_to_u16_block, PC_IDX_LOW_BITS,
     PTR_U16_LIMBS, U16_BITS,
 };
 
@@ -29,8 +29,8 @@ pub struct JalrCoreCols<T> {
     pub imm: T,
     // Low 32 bits of rs1 as u16 cells.
     pub rs1_data: [T; PTR_U16_LIMBS],
-    // High u16 limb of low-32 rd; the low limb is derived from from_pc.
-    pub rd_high: [T; PTR_U16_LIMBS - 1],
+    // The high u16 limb and bit-32 carry of rd; the low limb is derived from from_pc.
+    pub rd_high: [T; PTR_U16_LIMBS],
     pub is_valid: T,
 
     pub to_pc_least_sig_bit: T,
@@ -81,17 +81,19 @@ where
 
         builder.assert_bool(is_valid);
 
-        // composed is the high u16 limb of low-32 rd.
-        let composed = rd_high[0] * AB::F::from_u32(1 << U16_BITS);
-
         let pc_step = AB::F::from_u32(DEFAULT_PC_STEP);
         let pc_step_inv = pc_step.inverse();
 
-        // The byte return address is 4 * (from_pc_idx + 1).
-        let least_sig_limb = (from_pc_idx + AB::F::ONE) * pc_step - composed;
-
-        // rd_data_low is the low-32-bit decomposition of the byte return address.
-        let rd_data_low: [AB::Expr; PTR_U16_LIMBS] = [least_sig_limb.clone(), rd_high[0].into()];
+        // The byte return address is 4 * (from_pc_idx + 1). Work in pc-index units so every
+        // coefficient remains below the field modulus, including the possible bit-32 carry.
+        let least_sig_limb = (from_pc_idx + AB::F::ONE
+            - rd_high[0] * AB::F::from_u32(1 << PC_IDX_LOW_BITS)
+            - rd_high[1] * AB::F::from_u32(1 << PC_BITS))
+            * pc_step;
+        // A carry leaves all low-32-bit return-address limbs zero. This prevents field wrap in
+        // the decomposition and pins the carry to the final pc index.
+        builder.when(rd_high[1]).assert_zero(least_sig_limb.clone());
+        builder.when(rd_high[1]).assert_zero(rd_high[0]);
 
         // The low limb is DEFAULT_PC_STEP-aligned with a PC_IDX_LOW_BITS-bit quotient (which
         // also implies it is a u16), and the high limb is a u16. This pins the decomposition:
@@ -102,8 +104,9 @@ where
             .range_check(least_sig_limb.clone() * pc_step_inv, PC_IDX_LOW_BITS)
             .eval(builder, is_valid);
         self.range_bus
-            .range_check(rd_data_low[1].clone(), U16_BITS)
+            .range_check(rd_high[0], U16_BITS)
             .eval(builder, is_valid);
+        builder.assert_bool(rd_high[1]);
 
         builder.assert_bool(imm_sign);
 
@@ -134,9 +137,14 @@ where
             .eval(builder, is_valid);
         let to_pc_idx = to_pc_limbs[0] + to_pc_limbs[1] * AB::F::from_u32(1 << PC_IDX_LOW_BITS);
 
-        // Zero-extend low-32 rs1/rd at the adapter interface.
+        // Zero-extend low-32 rs1; rd additionally includes its bit-32 carry.
         let rs1_data = expand_to_block(&rs1);
-        let rd_data = expand_to_block(&rd_data_low);
+        let rd_data = [
+            least_sig_limb,
+            rd_high[0].into(),
+            rd_high[1].into(),
+            AB::Expr::ZERO,
+        ];
 
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, JALR);
 
@@ -211,7 +219,7 @@ impl JalrFiller {
         // fill_trace_row is called only on valid rows
         core_row.is_valid = F::ONE;
         core_row.rs1_data = ptr_to_u16_limbs(rs1_val).map(F::from_u16);
-        core_row.rd_high = [F::from_u16(rd_low_u16_hi)];
+        core_row.rd_high = [F::from_u16(rd_low_u16_hi), F::from_u16(rd_data[2])];
         core_row.imm = F::from_u16(imm);
     }
 }
@@ -236,16 +244,20 @@ pub(super) fn try_run_jalr(
     imm_sign: bool,
 ) -> Option<(u32, [u16; BLOCK_FE_WIDTH])> {
     let imm_extended = imm as u32 + (imm_sign as u32 * ((u16::MAX as u32) << U16_BITS));
-    let unaligned_to_pc = u32::try_from(address_add_imm(rs1, imm_extended)).ok()?;
-    // RISC-V clears bit 0 before checking instruction alignment.
-    let to_pc = unaligned_to_pc & !1;
-    if !to_pc.is_multiple_of(DEFAULT_PC_STEP) {
-        return None;
-    }
+    let (unaligned_to_pc, _) = checked_jalr_target(rs1, imm_extended)?;
 
-    let rd_low_u32 = pc.wrapping_add(DEFAULT_PC_STEP);
-    let rd_data = u32_to_u16_block(rd_low_u32);
+    let rd_data = u64_to_u16_block(u64::from(pc) + u64::from(DEFAULT_PC_STEP));
     // Trace generation keeps the raw target so the AIR can witness its cleared low bit. The
     // adapter applies the mask when it checks the next execution state.
     Some((unaligned_to_pc, rd_data))
+}
+
+#[inline(always)]
+pub(super) fn checked_jalr_target(rs1: u32, imm_extended: u32) -> Option<(u32, u32)> {
+    let unaligned_to_pc = u32::try_from(address_add_imm(rs1, imm_extended)).ok()?;
+    // RISC-V clears bit 0 before checking instruction alignment.
+    let to_pc = unaligned_to_pc & !1;
+    to_pc
+        .is_multiple_of(DEFAULT_PC_STEP)
+        .then_some((unaligned_to_pc, to_pc))
 }

--- a/extensions/riscv/circuit/src/jalr/execution.rs
+++ b/extensions/riscv/circuit/src/jalr/execution.rs
@@ -15,7 +15,8 @@ use openvm_riscv_transpiler::JalrOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
 use super::core::{checked_jalr_target, JalrExecutor};
-use crate::adapters::bytes_to_u32;
+use crate::adapters::try_bytes_to_u32;
+
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
 struct JalrPreCompute {
@@ -150,7 +151,10 @@ unsafe fn execute_e12_impl<CTX: ExecutionCtxTrait, const ENABLED: bool>(
 ) -> Result<(), ExecutionError> {
     let pc = exec_state.pc();
     let rs1 = exec_state.vm_read_bytes::<REGISTER_NUM_LIMBS>(REGISTER_AS, pre_compute.b as u32);
-    let rs1 = bytes_to_u32(rs1);
+    let rs1 = try_bytes_to_u32(rs1).ok_or(ExecutionError::Fail {
+        pc,
+        msg: "JALR source register has nonzero upper 32 bits",
+    })?;
     let (_, to_pc) =
         checked_jalr_target(rs1, pre_compute.imm_extended).ok_or(ExecutionError::Fail {
             pc,
@@ -196,7 +200,7 @@ unsafe fn execute_e2_impl<CTX: MeteredExecutionCtxTrait, const ENABLED: bool>(
 #[cfg(test)]
 mod tests {
     use openvm_circuit::arch::{
-        execution_mode::{ExecutionCtx, MeteredCostCtx},
+        execution_mode::{ExecutionCtx, MeteredCostCtx, PreflightCtx},
         InterpretedInstance, Streams, VmExecutionConfig,
     };
     use openvm_instructions::{
@@ -209,7 +213,7 @@ mod tests {
     use super::*;
     use crate::Rv64IConfig;
 
-    fn jalr_exe(rs1: u32, imm: usize) -> VmExe {
+    fn jalr_exe(rs1: u64, imm: usize) -> VmExe {
         let jalr = Instruction::from_usize(
             JalrOpcode::JALR.global_opcode(),
             [16, 8, imm, REGISTER_AS as usize, 0, 1, 0],
@@ -219,7 +223,7 @@ mod tests {
             ..Default::default()
         };
         let mut init_memory = SparseMemoryImage::new();
-        for (i, byte) in u64::from(rs1).to_le_bytes().into_iter().enumerate() {
+        for (i, byte) in rs1.to_le_bytes().into_iter().enumerate() {
             init_memory.insert((REGISTER_AS, 8 + i as u32), byte);
         }
         VmExe::new(Program::new_without_debug_infos(
@@ -229,13 +233,13 @@ mod tests {
         .with_init_memory(init_memory)
     }
 
-    fn assert_invalid_target(error: ExecutionError) {
+    fn assert_jalr_failure(error: ExecutionError, expected_msg: &'static str) {
         assert!(matches!(
             error,
             ExecutionError::Fail {
                 pc: 0,
-                msg: "JALR target is outside implemented PC address space or misaligned"
-            }
+                msg
+            } if msg == expected_msg
         ));
     }
 
@@ -244,14 +248,27 @@ mod tests {
         let config = Rv64IConfig::default();
         let inventory =
             <Rv64IConfig as VmExecutionConfig<BabyBear>>::create_executors(&config).unwrap();
-        for exe in [jalr_exe(0xffff_fff8, 16), jalr_exe(0, 2)] {
+        for (exe, expected_msg) in [
+            (
+                jalr_exe(0xffff_fff8, 16),
+                "JALR target is outside implemented PC address space or misaligned",
+            ),
+            (
+                jalr_exe(0, 2),
+                "JALR target is outside implemented PC address space or misaligned",
+            ),
+            (
+                jalr_exe(0x1_0000_0000, 0),
+                "JALR source register has nonzero upper 32 bits",
+            ),
+        ] {
             let interpreter =
                 InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe).unwrap();
             let error = interpreter
                 .execute(Streams::default())
                 .err()
-                .expect("invalid JALR target must fail");
-            assert_invalid_target(error);
+                .expect("invalid JALR execution must fail");
+            assert_jalr_failure(error, expected_msg);
         }
     }
 
@@ -261,7 +278,20 @@ mod tests {
         let inventory =
             <Rv64IConfig as VmExecutionConfig<BabyBear>>::create_executors(&config).unwrap();
         let executor_idx_to_air_idx = vec![0; inventory.executors.len()];
-        for exe in [jalr_exe(0xffff_fff8, 16), jalr_exe(0, 2)] {
+        for (exe, expected_msg) in [
+            (
+                jalr_exe(0xffff_fff8, 16),
+                "JALR target is outside implemented PC address space or misaligned",
+            ),
+            (
+                jalr_exe(0, 2),
+                "JALR target is outside implemented PC address space or misaligned",
+            ),
+            (
+                jalr_exe(0x1_0000_0000, 0),
+                "JALR source register has nonzero upper 32 bits",
+            ),
+        ] {
             let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
                 &inventory,
                 &exe,
@@ -271,8 +301,25 @@ mod tests {
             let error = interpreter
                 .execute_metered_cost(Streams::default(), MeteredCostCtx::new(vec![0]))
                 .err()
-                .expect("invalid JALR target must fail");
-            assert_invalid_target(error);
+                .expect("invalid JALR execution must fail");
+            assert_jalr_failure(error, expected_msg);
         }
+    }
+
+    #[test]
+    fn jalr_invalid_source_preflight_execution() {
+        let config = Rv64IConfig::default();
+        let inventory =
+            <Rv64IConfig as VmExecutionConfig<BabyBear>>::create_executors(&config).unwrap();
+        let exe = jalr_exe(0x1_0000_0000, 0);
+        let interpreter =
+            InterpretedInstance::<PreflightCtx>::new::<BabyBear, _>(&inventory, &exe).unwrap();
+        let state = interpreter.create_initial_vm_state(Streams::default());
+        let error = interpreter
+            .execute_preflight_from_state::<BabyBear>(state, Some(1))
+            .err()
+            .expect("invalid JALR source must fail");
+
+        assert_jalr_failure(error, "JALR source register has nonzero upper 32 bits");
     }
 }

--- a/extensions/riscv/circuit/src/jalr/execution.rs
+++ b/extensions/riscv/circuit/src/jalr/execution.rs
@@ -7,15 +7,15 @@ use openvm_circuit::{arch::*, system::memory::online::GuestMemory};
 use openvm_circuit_primitives_derive::AlignedBytesBorrow;
 use openvm_instructions::{
     instruction::Instruction,
-    program::{DEFAULT_PC_STEP, MAX_ALLOWED_PC},
+    program::DEFAULT_PC_STEP,
     riscv::{REGISTER_AS, REGISTER_NUM_LIMBS},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalrOpcode;
 use openvm_stark_backend::p3_field::PrimeField32;
 
-use super::core::JalrExecutor;
-use crate::adapters::{address_add_imm, bytes_to_u32};
+use super::core::{checked_jalr_target, JalrExecutor};
+use crate::adapters::bytes_to_u32;
 #[derive(AlignedBytesBorrow, Clone)]
 #[repr(C)]
 struct JalrPreCompute {
@@ -147,17 +147,16 @@ where
 unsafe fn execute_e12_impl<CTX: ExecutionCtxTrait, const ENABLED: bool>(
     pre_compute: &JalrPreCompute,
     exec_state: &mut VmExecState<GuestMemory, CTX>,
-) {
+) -> Result<(), ExecutionError> {
     let pc = exec_state.pc();
     let rs1 = exec_state.vm_read_bytes::<REGISTER_NUM_LIMBS>(REGISTER_AS, pre_compute.b as u32);
     let rs1 = bytes_to_u32(rs1);
-    let unaligned_to_pc = address_add_imm(rs1, pre_compute.imm_extended);
-    // JALR clears bit 0 before jumping.
-    let to_pc = unaligned_to_pc & !1;
-    debug_assert!(to_pc <= u64::from(MAX_ALLOWED_PC));
-    let to_pc = to_pc as u32;
-    let mut rd = [0u8; REGISTER_NUM_LIMBS];
-    rd[..4].copy_from_slice(&(pc + DEFAULT_PC_STEP).to_le_bytes());
+    let (_, to_pc) =
+        checked_jalr_target(rs1, pre_compute.imm_extended).ok_or(ExecutionError::Fail {
+            pc,
+            msg: "JALR target is outside implemented PC address space or misaligned",
+        })?;
+    let rd = (u64::from(pc) + u64::from(DEFAULT_PC_STEP)).to_le_bytes();
 
     if ENABLED {
         exec_state.vm_write_bytes(REGISTER_AS, pre_compute.a as u32, &rd);
@@ -166,6 +165,7 @@ unsafe fn execute_e12_impl<CTX: ExecutionCtxTrait, const ENABLED: bool>(
     }
 
     exec_state.set_pc(to_pc);
+    Ok(())
 }
 
 #[create_handler]
@@ -173,10 +173,10 @@ unsafe fn execute_e12_impl<CTX: ExecutionCtxTrait, const ENABLED: bool>(
 unsafe fn execute_e1_impl<CTX: ExecutionCtxTrait, const ENABLED: bool>(
     pre_compute: *const u8,
     exec_state: &mut VmExecState<GuestMemory, CTX>,
-) {
+) -> Result<(), ExecutionError> {
     let pre_compute: &JalrPreCompute =
         std::slice::from_raw_parts(pre_compute, size_of::<JalrPreCompute>()).borrow();
-    execute_e12_impl::<CTX, ENABLED>(pre_compute, exec_state);
+    execute_e12_impl::<CTX, ENABLED>(pre_compute, exec_state)
 }
 
 #[create_handler]
@@ -184,11 +184,95 @@ unsafe fn execute_e1_impl<CTX: ExecutionCtxTrait, const ENABLED: bool>(
 unsafe fn execute_e2_impl<CTX: MeteredExecutionCtxTrait, const ENABLED: bool>(
     pre_compute: *const u8,
     exec_state: &mut VmExecState<GuestMemory, CTX>,
-) {
+) -> Result<(), ExecutionError> {
     let pre_compute: &E2PreCompute<JalrPreCompute> =
         std::slice::from_raw_parts(pre_compute, size_of::<E2PreCompute<JalrPreCompute>>()).borrow();
     exec_state
         .ctx
         .on_height_change(pre_compute.chip_idx as usize, 1);
-    execute_e12_impl::<CTX, ENABLED>(&pre_compute.data, exec_state);
+    execute_e12_impl::<CTX, ENABLED>(&pre_compute.data, exec_state)
+}
+
+#[cfg(test)]
+mod tests {
+    use openvm_circuit::arch::{
+        execution_mode::{ExecutionCtx, MeteredCostCtx},
+        InterpretedInstance, Streams, VmExecutionConfig,
+    };
+    use openvm_instructions::{
+        exe::{SparseMemoryImage, VmExe},
+        program::Program,
+        SystemOpcode,
+    };
+    use openvm_stark_sdk::p3_baby_bear::BabyBear;
+
+    use super::*;
+    use crate::Rv64IConfig;
+
+    fn jalr_exe(rs1: u32, imm: usize) -> VmExe {
+        let jalr = Instruction::from_usize(
+            JalrOpcode::JALR.global_opcode(),
+            [16, 8, imm, REGISTER_AS as usize, 0, 1, 0],
+        );
+        let terminate = Instruction {
+            opcode: SystemOpcode::TERMINATE.global_opcode(),
+            ..Default::default()
+        };
+        let mut init_memory = SparseMemoryImage::new();
+        for (i, byte) in u64::from(rs1).to_le_bytes().into_iter().enumerate() {
+            init_memory.insert((REGISTER_AS, 8 + i as u32), byte);
+        }
+        VmExe::new(Program::new_without_debug_infos(
+            &[jalr, terminate.clone(), terminate],
+            0,
+        ))
+        .with_init_memory(init_memory)
+    }
+
+    fn assert_invalid_target(error: ExecutionError) {
+        assert!(matches!(
+            error,
+            ExecutionError::Fail {
+                pc: 0,
+                msg: "JALR target is outside implemented PC address space or misaligned"
+            }
+        ));
+    }
+
+    #[test]
+    fn jalr_invalid_targets_pure_or_tco_execution() {
+        let config = Rv64IConfig::default();
+        let inventory =
+            <Rv64IConfig as VmExecutionConfig<BabyBear>>::create_executors(&config).unwrap();
+        for exe in [jalr_exe(0xffff_fff8, 16), jalr_exe(0, 2)] {
+            let interpreter =
+                InterpretedInstance::<ExecutionCtx>::new::<BabyBear, _>(&inventory, &exe).unwrap();
+            let error = interpreter
+                .execute(Streams::default())
+                .err()
+                .expect("invalid JALR target must fail");
+            assert_invalid_target(error);
+        }
+    }
+
+    #[test]
+    fn jalr_invalid_targets_metered_or_tco_execution() {
+        let config = Rv64IConfig::default();
+        let inventory =
+            <Rv64IConfig as VmExecutionConfig<BabyBear>>::create_executors(&config).unwrap();
+        let executor_idx_to_air_idx = vec![0; inventory.executors.len()];
+        for exe in [jalr_exe(0xffff_fff8, 16), jalr_exe(0, 2)] {
+            let interpreter = InterpretedInstance::<MeteredCostCtx>::new_metered::<BabyBear, _>(
+                &inventory,
+                &exe,
+                &executor_idx_to_air_idx,
+            )
+            .unwrap();
+            let error = interpreter
+                .execute_metered_cost(Streams::default(), MeteredCostCtx::new(vec![0]))
+                .err()
+                .expect("invalid JALR target must fail");
+            assert_invalid_target(error);
+        }
+    }
 }

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -423,7 +423,7 @@ fn invalid_cols_negative_tests() {
 }
 
 #[test]
-#[should_panic(expected = "upper 4 bytes must be zero")]
+#[should_panic(expected = "JALR source register has nonzero upper 32 bits")]
 fn rs1_upper_bytes_preflight_rejects_test() {
     run_negative_jalr_test(
         JALR,

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -170,7 +170,7 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
 
     let rs1 = limbs_to_u64(rs1) as u32;
 
-    let (next_pc, rd_data) = run_jalr(initial_pc, rs1, imm as u16, imm_sign == 1);
+    let (raw_target_pc, rd_data) = run_jalr(initial_pc, rs1, imm as u16, imm_sign == 1);
     // The register write is suppressed for x0.
     let rd_data = if a == 0 {
         [0u16; BLOCK_FE_WIDTH]
@@ -178,7 +178,7 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
         rd_data
     };
 
-    assert_eq!(next_pc & !1, final_pc);
+    assert_eq!(raw_target_pc & !1, final_pc);
     // Compare against the raw 8-byte register value stored in memory.
     let rd_bytes = u16_block_to_bytes(rd_data);
     assert_eq!(
@@ -277,8 +277,8 @@ fn jalr_max_pc_test() {
 struct JalrPrankValues {
     pub rd_high: Option<[u32; PTR_U16_LIMBS]>,
     pub rs1_data: Option<[u32; PTR_U16_LIMBS]>,
-    pub to_pc_least_sig_bit: Option<u32>,
-    pub to_pc_limbs: Option<[u32; PTR_U16_LIMBS]>,
+    pub raw_target_bit0: Option<u32>,
+    pub to_pc_idx_limbs: Option<[u32; PTR_U16_LIMBS]>,
     pub imm_sign: Option<u32>,
     pub rd_ptr: Option<u32>,
     pub needs_write: Option<bool>,
@@ -326,11 +326,11 @@ fn run_negative_jalr_test_with_rd_ptr(
         if let Some(data) = prank_vals.rs1_data {
             core_cols.rs1_data = data.map(F::from_u32);
         }
-        if let Some(data) = prank_vals.to_pc_least_sig_bit {
-            core_cols.to_pc_least_sig_bit = F::from_u32(data);
+        if let Some(data) = prank_vals.raw_target_bit0 {
+            core_cols.raw_target_bit0 = F::from_u32(data);
         }
-        if let Some(data) = prank_vals.to_pc_limbs {
-            core_cols.to_pc_limbs = data.map(F::from_u32);
+        if let Some(data) = prank_vals.to_pc_idx_limbs {
+            core_cols.to_pc_idx_limbs = data.map(F::from_u32);
         }
         if let Some(data) = prank_vals.imm_sign {
             core_cols.imm_sign = F::from_u32(data);
@@ -415,7 +415,7 @@ fn invalid_cols_negative_tests() {
         Some(0xfe10),
         Some(1),
         JalrPrankValues {
-            to_pc_least_sig_bit: Some(0),
+            raw_target_bit0: Some(0),
             ..Default::default()
         },
         false,
@@ -580,7 +580,7 @@ fn overflow_negative_tests() {
         Some((1 << 11) - 4),
         Some(0),
         JalrPrankValues {
-            to_pc_limbs: Some([
+            to_pc_idx_limbs: Some([
                 (F::NEG_ONE * F::from_u32((1 << 14) + 1)).as_canonical_u32(),
                 1,
             ]),
@@ -602,17 +602,17 @@ fn run_jalr_sanity_test() {
     let imm = -1235_i32 as u32;
     // Chosen so the target (after clearing bit 0) is DEFAULT_PC_STEP-aligned.
     let rs1 = 736482908;
-    let (next_pc, rd_data) = run_jalr(initial_pc, rs1, imm as u16, true);
-    assert_eq!(next_pc & !1, 736481672);
+    let (raw_target_pc, rd_data) = run_jalr(initial_pc, rs1, imm as u16, true);
+    assert_eq!(raw_target_pc & !1, 736481672);
     // u32 pc+4 = 789456124 = 0x2f0e24fc => low u16=0x24fc, high u16=0x2f0e.
     assert_eq!(rd_data, [0x24fc, 0x2f0e, 0, 0]);
 }
 
 #[test]
 fn run_jalr_clears_bit_zero_before_max_pc_check() {
-    let (raw_target, _) = run_jalr(0, MAX_ALLOWED_PC + 1, 0, false);
-    assert_eq!(raw_target, MAX_ALLOWED_PC + 1);
-    assert_eq!(raw_target & !1, MAX_ALLOWED_PC);
+    let (raw_target_pc, _) = run_jalr(0, MAX_ALLOWED_PC + 1, 0, false);
+    assert_eq!(raw_target_pc, MAX_ALLOWED_PC + 1);
+    assert_eq!(raw_target_pc & !1, MAX_ALLOWED_PC);
 
     // Clearing bit 0 of u32::MAX leaves bit 1 set, so the result is still misaligned.
     assert!(try_run_jalr(0, u32::MAX, 0, false).is_none());

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -239,7 +239,7 @@ fn jalr_max_pc_test() {
         JALR,
         Some(0),
         Some(0),
-        Some(MAX_ALLOWED_PC - DEFAULT_PC_STEP),
+        Some(MAX_ALLOWED_PC),
         Some(into_limbs(MAX_ALLOWED_PC)),
         None,
     );
@@ -271,11 +271,11 @@ fn jalr_max_pc_test() {
 // part of the trace and check that the chip throws the expected error.
 //////////////////////////////////////////////////////////////////////////////////////
 
-// Prankable JALR core columns: rs1 low 32 as two u16 cells; rd stores only
-// the high u16 of pc + 4.
+// Prankable JALR core columns: rs1 low 32 as two u16 cells; rd stores its high u16
+// and bit-32 carry.
 #[derive(Clone, Copy, Default, PartialEq)]
 struct JalrPrankValues {
-    pub rd_high: Option<[u32; PTR_U16_LIMBS - 1]>,
+    pub rd_high: Option<[u32; PTR_U16_LIMBS]>,
     pub rs1_data: Option<[u32; PTR_U16_LIMBS]>,
     pub to_pc_least_sig_bit: Option<u32>,
     pub to_pc_limbs: Option<[u32; PTR_U16_LIMBS]>,
@@ -567,7 +567,7 @@ fn overflow_negative_tests() {
         None,
         None,
         JalrPrankValues {
-            rd_high: Some([1]),
+            rd_high: Some([1, 0]),
             ..Default::default()
         },
         true,
@@ -711,6 +711,18 @@ fn test_cuda_rand_jalr_tracegen() {
         Some(0),
         Some(0),
         Some(into_limbs(MAX_ALLOWED_PC + 1)),
+        None,
+    );
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        JALR,
+        Some(0),
+        Some(0),
+        Some(MAX_ALLOWED_PC),
+        Some(into_limbs(MAX_ALLOWED_PC)),
         None,
     );
 

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -46,7 +46,7 @@ use crate::{
         limbs_to_u64, u16_block_to_bytes, JalrAdapterAir, JalrAdapterCols, BYTE_BITS,
         PTR_U16_LIMBS, REGISTER_NUM_LIMBS, WORD_NUM_LIMBS,
     },
-    jalr::{run_jalr, JalrChip, JalrCoreCols, JalrExecutor},
+    jalr::{run_jalr, try_run_jalr, JalrChip, JalrCoreCols, JalrExecutor},
     JalrAir, JalrFiller,
 };
 const IMM_BITS: usize = 16;
@@ -225,8 +225,8 @@ fn rand_jalr_test() {
 
 #[test]
 fn jalr_max_pc_test() {
-    // Jump to the last instruction slot of the 32-bit PC address space, from the
-    // second-to-last slot.
+    // Jump to the last instruction slot of the 32-bit PC address space, including a raw odd
+    // target that becomes the last slot after JALR clears bit 0.
     let mut rng = create_seeded_rng();
     let mut tester = VmChipTestBuilder::default();
     let (mut harness, bitwise) = create_harness(&mut tester);
@@ -241,6 +241,18 @@ fn jalr_max_pc_test() {
         Some(0),
         Some(MAX_ALLOWED_PC - DEFAULT_PC_STEP),
         Some(into_limbs(MAX_ALLOWED_PC)),
+        None,
+    );
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        JALR,
+        Some(0),
+        Some(0),
+        Some(0),
+        Some(into_limbs(MAX_ALLOWED_PC + 1)),
         None,
     );
 
@@ -597,7 +609,17 @@ fn run_jalr_sanity_test() {
 }
 
 #[test]
-#[should_panic(expected = "JALR target exceeds implemented PC address space")]
+fn run_jalr_clears_bit_zero_before_max_pc_check() {
+    let (raw_target, _) = run_jalr(0, MAX_ALLOWED_PC + 1, 0, false);
+    assert_eq!(raw_target, MAX_ALLOWED_PC + 1);
+    assert_eq!(raw_target & !1, MAX_ALLOWED_PC);
+
+    // Clearing bit 0 of u32::MAX leaves bit 1 set, so the result is still misaligned.
+    assert!(try_run_jalr(0, u32::MAX, 0, false).is_none());
+}
+
+#[test]
+#[should_panic(expected = "JALR target is outside implemented PC address space or misaligned")]
 fn run_jalr_rejects_low_32_wraparound_test() {
     run_jalr(0, 0xffff_fff8, 16, false);
 }
@@ -679,6 +701,18 @@ fn test_cuda_rand_jalr_tracegen() {
             None,
         );
     }
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        JALR,
+        Some(0),
+        Some(0),
+        Some(0),
+        Some(into_limbs(MAX_ALLOWED_PC + 1)),
+        None,
+    );
 
     tester
         .build()

--- a/extensions/riscv/circuit/src/jalr/tests.rs
+++ b/extensions/riscv/circuit/src/jalr/tests.rs
@@ -16,7 +16,7 @@ use openvm_circuit_primitives::{
 };
 use openvm_instructions::{
     instruction::Instruction,
-    program::{Program, PC_BITS},
+    program::{Program, DEFAULT_PC_STEP, MAX_ALLOWED_PC},
     LocalOpcode,
 };
 use openvm_riscv_transpiler::JalrOpcode::{self, *};
@@ -134,15 +134,21 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
     let a = rd_ptr.unwrap_or_else(|| rng.random_range(0..32) << 3);
     let b = rng.random_range(1..32) << 3;
     let imm_signed = (imm_ext as i32) as i64;
+    // The target (after clearing bit 0) must be a DEFAULT_PC_STEP-aligned slot in the
+    // implemented PC address space, and rs1 = to_pc - imm must fit in a u32.
     let min_to_pc = imm_signed.max(0) as u32;
-    let to_pc = rng.random_range(min_to_pc..(1 << PC_BITS));
+    let max_to_pc = (u32::MAX as i64 + imm_signed.min(0) - 1).min(MAX_ALLOWED_PC as i64) as u32;
+    let to_pc = rng.random_range(min_to_pc.div_ceil(DEFAULT_PC_STEP)..=max_to_pc / DEFAULT_PC_STEP)
+        * DEFAULT_PC_STEP
+        + rng.random_range(0..2);
 
     let rs1 = rs1.unwrap_or(into_limbs((i64::from(to_pc) - imm_signed) as u32));
     let rs1 = rs1.map(F::from_u32);
 
     tester.write_bytes(1, b, rs1);
 
-    let initial_pc = initial_pc.unwrap_or(rng.random_range(0..(1 << PC_BITS)));
+    let initial_pc = initial_pc
+        .unwrap_or_else(|| (rng.random::<u32>() & !3).min(MAX_ALLOWED_PC - DEFAULT_PC_STEP));
     tester.execute_with_pc(
         executor,
         preflight,
@@ -160,7 +166,7 @@ fn set_and_execute<E: openvm_circuit::arch::Executor<F> + Clone>(
         ),
         initial_pc,
     );
-    let final_pc = tester.last_to_pc().as_canonical_u32();
+    let final_pc = tester.last_to_pc();
 
     let rs1 = limbs_to_u64(rs1) as u32;
 
@@ -208,6 +214,35 @@ fn rand_jalr_test() {
             None,
         );
     }
+
+    let tester = tester
+        .build()
+        .load(harness)
+        .load_periphery(bitwise)
+        .finalize();
+    tester.simple_test().expect("Verification failed");
+}
+
+#[test]
+fn jalr_max_pc_test() {
+    // Jump to the last instruction slot of the 32-bit PC address space, from the
+    // second-to-last slot.
+    let mut rng = create_seeded_rng();
+    let mut tester = VmChipTestBuilder::default();
+    let (mut harness, bitwise) = create_harness(&mut tester);
+
+    set_and_execute(
+        &mut tester,
+        &mut harness.executor,
+        &mut harness.preflight,
+        &mut rng,
+        JALR,
+        Some(0),
+        Some(0),
+        Some(MAX_ALLOWED_PC - DEFAULT_PC_STEP),
+        Some(into_limbs(MAX_ALLOWED_PC)),
+        None,
+    );
 
     let tester = tester
         .build()
@@ -359,10 +394,12 @@ fn invalid_cols_negative_tests() {
         false,
     );
 
+    // rs1 chosen so the raw target is ≡ 1 (mod 4): bit 0 is set (and cleared by JALR), so
+    // pranking the least significant bit to 0 breaks the target arithmetic.
     run_negative_jalr_test(
         JALR,
         None,
-        Some([23, 154, 67, 28, 0, 0, 0, 0]),
+        Some([25, 154, 67, 28, 0, 0, 0, 0]),
         Some(0xfe10),
         Some(1),
         JalrPrankValues {
@@ -513,7 +550,7 @@ fn write_suppression_boundary_negative_tests() {
 fn overflow_negative_tests() {
     run_negative_jalr_test(
         JALR,
-        Some(251),
+        Some(252),
         None,
         None,
         None,
@@ -528,7 +565,7 @@ fn overflow_negative_tests() {
         JALR,
         None,
         Some([0, 0, 0, 0, 0, 0, 0, 0]),
-        Some((1 << 11) - 2),
+        Some((1 << 11) - 4),
         Some(0),
         JalrPrankValues {
             to_pc_limbs: Some([
@@ -551,9 +588,10 @@ fn overflow_negative_tests() {
 fn run_jalr_sanity_test() {
     let initial_pc = 789456120;
     let imm = -1235_i32 as u32;
-    let rs1 = 736482910;
+    // Chosen so the target (after clearing bit 0) is DEFAULT_PC_STEP-aligned.
+    let rs1 = 736482908;
     let (next_pc, rd_data) = run_jalr(initial_pc, rs1, imm as u16, true);
-    assert_eq!(next_pc & !1, 736481674);
+    assert_eq!(next_pc & !1, 736481672);
     // u32 pc+4 = 789456124 = 0x2f0e24fc => low u16=0x24fc, high u16=0x2f0e.
     assert_eq!(rd_data, [0x24fc, 0x2f0e, 0, 0]);
 }

--- a/extensions/riscv/circuit/src/jalr/trace.rs
+++ b/extensions/riscv/circuit/src/jalr/trace.rs
@@ -24,7 +24,7 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
 
     fill_trace_rows(&mut trace, 0, steps, |row, step| {
         let (adapter_row, core_row) = row.split_at_mut(adapter_width);
-        let (rs1, to_pc, rd_data) = JalrAdapterFiller::replay(
+        let (rs1, raw_target_pc, rd_data) = JalrAdapterFiller::replay(
             postflight,
             step,
             &chip.mem_helper.as_borrowed(),
@@ -50,7 +50,7 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
             rs1_value,
             instruction.c.as_u32() as u16,
             instruction.g.is_one(),
-            to_pc,
+            raw_target_pc,
             rd_data,
         );
         Ok(())

--- a/extensions/riscv/circuit/src/jalr/trace.rs
+++ b/extensions/riscv/circuit/src/jalr/trace.rs
@@ -37,7 +37,9 @@ pub fn generate_trace_from_postflight<F: PrimeField32>(
                 }
                 let rs1_value = u32::from(rs1[0]) | (u32::from(rs1[1]) << U16_BITS);
                 try_run_jalr(from_pc, rs1_value, immediate, imm_sign).ok_or_else(|| {
-                    PostflightError::new("JALR target exceeds implemented PC address space")
+                    PostflightError::new(
+                        "JALR target is outside implemented PC address space or misaligned",
+                    )
                 })
             },
         )?;

--- a/extensions/riscv/circuit/src/less_than/core.rs
+++ b/extensions/riscv/circuit/src/less_than/core.rs
@@ -70,7 +70,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LessThanCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [cols.opcode_slt_flag, cols.opcode_sltu_flag];
@@ -139,7 +139,7 @@ where
         a[0] = cols.cmp_result.into();
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [a].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/less_than_imm/core.rs
+++ b/extensions/riscv/circuit/src/less_than_imm/core.rs
@@ -68,7 +68,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LessThanImmCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [cols.opcode_slt_flag, cols.opcode_sltu_flag];
@@ -156,7 +156,7 @@ where
         let imm = cols.imm_low11 + cols.imm_sign * AB::Expr::from_u32(0xFFF800);
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into)].into(),
             writes: [a].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/load/byte/core.rs
+++ b/extensions/riscv/circuit/src/load/byte/core.rs
@@ -67,7 +67,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LoadByteCoreCols<AB::Var> = (*local_core).borrow();
         self.encoder.eval(builder, &cols.selector);
@@ -133,7 +133,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: cols.read_data.map(Into::into).into(),
             writes: write_data.into(),
             instruction: LoadByteInstruction {

--- a/extensions/riscv/circuit/src/load/core.rs
+++ b/extensions/riscv/circuit/src/load/core.rs
@@ -104,7 +104,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LoadCoreCols<AB::Var, NUM_OVERLAP_CELLS> = (*local_core).borrow();
         let width = LOAD_WIDTH / U16_CELL_SIZE;
@@ -181,7 +181,7 @@ where
                 + cols.overlap_lo_bytes[i + 1] * AB::Expr::from_u32(1 << BYTE_BITS)
         });
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: cols.read_data.map(|block| block.map(Into::into)).into(),
             writes: [write_data].into(),
             instruction: LoadInstruction {

--- a/extensions/riscv/circuit/src/load_sign_extend/byte/core.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/byte/core.rs
@@ -77,7 +77,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LoadSignExtendByteCoreCols<AB::Var> = (*local_core).borrow();
         self.encoder.eval(builder, &cols.selector);
@@ -155,7 +155,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: cols.read_data.map(Into::into).into(),
             writes: write_data.into(),
             instruction: LoadByteInstruction {

--- a/extensions/riscv/circuit/src/load_sign_extend/core.rs
+++ b/extensions/riscv/circuit/src/load_sign_extend/core.rs
@@ -111,7 +111,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &LoadSignExtendCoreCols<AB::Var, NUM_OVERLAP_CELLS> = (*local_core).borrow();
         let width = LOAD_WIDTH / U16_CELL_SIZE;
@@ -208,7 +208,7 @@ where
                 + cols.overlap_lo_bytes[i + 1] * AB::Expr::from_u32(1 << BYTE_BITS)
         });
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: cols.read_data.map(|block| block.map(Into::into)).into(),
             writes: [write_data].into(),
             instruction: LoadInstruction {

--- a/extensions/riscv/circuit/src/mul/core.rs
+++ b/extensions/riscv/circuit/src/mul/core.rs
@@ -57,7 +57,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &MultiplicationCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         builder.assert_bool(cols.is_valid);
@@ -97,7 +97,7 @@ where
         let expected_opcode = VmCoreAir::<AB, I>::opcode_to_global_expr(self, MulOpcode::MUL);
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/mulh/core.rs
+++ b/extensions/riscv/circuit/src/mulh/core.rs
@@ -65,7 +65,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &MulHCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let flags = [
@@ -167,7 +167,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/reveal/air.rs
+++ b/extensions/riscv/circuit/src/reveal/air.rs
@@ -13,7 +13,6 @@ use openvm_circuit_primitives::{
 };
 use openvm_circuit_primitives_derive::AlignedBorrow;
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP,
     riscv::{REGISTER_AS, REGISTER_NUM_LIMBS},
     LocalOpcode, PUBLIC_VALUES_AS,
 };
@@ -185,7 +184,7 @@ impl<AB: InteractionBuilder> Air<AB> for RevealAir {
                 ],
                 cols.from_state,
                 ExecutionState {
-                    pc: cols.from_state.pc + AB::F::from_u32(DEFAULT_PC_STEP),
+                    pc: cols.from_state.pc + AB::F::ONE,
                     timestamp: timestamp + AB::F::from_usize(REVEAL_TIMESTAMP_DELTA),
                 },
             )

--- a/extensions/riscv/circuit/src/reveal/trace.rs
+++ b/extensions/riscv/circuit/src/reveal/trace.rs
@@ -5,7 +5,9 @@ use openvm_circuit::{
     utils::next_power_of_two_or_zero,
 };
 use openvm_instructions::{
-    program::DEFAULT_PC_STEP, riscv::REGISTER_AS, LocalOpcode, PUBLIC_VALUES_AS,
+    program::{pc_to_idx, DEFAULT_PC_STEP},
+    riscv::REGISTER_AS,
+    LocalOpcode, PUBLIC_VALUES_AS,
 };
 use openvm_riscv_transpiler::RevealOpcode;
 use openvm_stark_backend::{p3_field::PrimeField32, p3_matrix::dense::RowMajorMatrix};
@@ -133,7 +135,7 @@ pub(crate) fn generate_trace_from_postflight<F: PrimeField32>(
 
         let cols: &mut RevealCols<F> = row.borrow_mut();
         cols.is_valid = F::ONE;
-        cols.from_state.pc = F::from_u32(from_pc);
+        cols.from_state.pc = F::from_u32(pc_to_idx(from_pc));
         cols.from_state.timestamp = F::from_u32(from_timestamp);
         cols.base_ptr = F::from_u32(base_ptr);
         cols.base_ptr_limbs = ptr_to_field_u16_limbs(base_value);

--- a/extensions/riscv/circuit/src/shift_logical/core.rs
+++ b/extensions/riscv/circuit/src/shift_logical/core.rs
@@ -82,7 +82,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &ShiftLogicalCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         builder.assert_bool(cols.opcode_sll_flag);
@@ -222,7 +222,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/shift_logical_imm/core.rs
+++ b/extensions/riscv/circuit/src/shift_logical_imm/core.rs
@@ -69,7 +69,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &ShiftLogicalImmCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         builder.assert_bool(cols.opcode_sll_flag);
@@ -194,7 +194,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/shift_right_arithmetic/core.rs
+++ b/extensions/riscv/circuit/src/shift_right_arithmetic/core.rs
@@ -76,7 +76,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &ShiftRightArithmeticCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let a = &cols.a;
@@ -185,7 +185,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into), cols.c.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: MinimalInstruction {

--- a/extensions/riscv/circuit/src/shift_right_arithmetic_imm/core.rs
+++ b/extensions/riscv/circuit/src/shift_right_arithmetic_imm/core.rs
@@ -66,7 +66,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &ShiftRightArithmeticImmCoreCols<_, NUM_LIMBS, LIMB_BITS> = local_core.borrow();
         let mut bit_marker_sum = AB::Expr::ZERO;
@@ -143,7 +143,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: [cols.b.map(Into::into)].into(),
             writes: [cols.a.map(Into::into)].into(),
             instruction: ImmInstruction {

--- a/extensions/riscv/circuit/src/store/byte/core.rs
+++ b/extensions/riscv/circuit/src/store/byte/core.rs
@@ -81,7 +81,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &StoreByteCoreCols<AB::Var> = (*local_core).borrow();
         self.encoder.eval(builder, &cols.selector);
@@ -127,7 +127,7 @@ where
         );
 
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: (
                 cols.prev_data.map(Into::into),
                 cols.read_data.map(Into::into),

--- a/extensions/riscv/circuit/src/store/core.rs
+++ b/extensions/riscv/circuit/src/store/core.rs
@@ -109,7 +109,7 @@ where
         &self,
         builder: &mut AB,
         local_core: &[AB::Var],
-        _from_pc: AB::Var,
+        _from_pc_idx: AB::Var,
     ) -> AdapterAirContext<AB::Expr, I> {
         let cols: &StoreCoreCols<AB::Var, NUM_VALUE_CELLS> = (*local_core).borrow();
         let width = STORE_WIDTH / U16_CELL_SIZE;
@@ -216,7 +216,7 @@ where
             })
         });
         AdapterAirContext {
-            to_pc: None,
+            to_pc_idx: None,
             reads: (
                 cols.prev_data.map(|block| block.map(Into::into)),
                 cols.read_data.map(Into::into),

--- a/extensions/sha2/circuit/cuda/src/rvr/sha2_main.cu
+++ b/extensions/sha2/circuit/cuda/src/rvr/sha2_main.cu
@@ -52,7 +52,7 @@ static __device__ __forceinline__ void sha2_main_replay_row_body(
 
     SHA2_MAIN_WRITE_INSTR(V, row, is_enabled, Fp::one());
     SHA2_MAIN_WRITE_INSTR(V, row, from_state.timestamp, input.timestamp);
-    SHA2_MAIN_WRITE_INSTR(V, row, from_state.pc, input.from_pc);
+    SHA2_MAIN_WRITE_INSTR(V, row, from_state.pc, ::program::pc_to_idx(input.from_pc));
     SHA2_MAIN_WRITE_INSTR(V, row, dst_reg_ptr, input.dst_reg_ptr);
     SHA2_MAIN_WRITE_INSTR(V, row, state_reg_ptr, input.state_reg_ptr);
     SHA2_MAIN_WRITE_INSTR(V, row, input_reg_ptr, input.input_reg_ptr);

--- a/extensions/sha2/circuit/src/sha2_chips/main_chip/air.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/main_chip/air.rs
@@ -228,7 +228,7 @@ impl<C: Sha2MainChipConfig + Sha2BlockHasherSubairConfig> Sha2MainAir<C> {
         }
 
         self.execution_bridge
-            .execute_and_increment_pc(
+            .execute_and_increment_pc_idx(
                 AB::Expr::from_usize(C::OPCODE as usize + self.offset),
                 [
                     (*local.instruction.dst_reg_ptr).into(),

--- a/extensions/sha2/circuit/src/sha2_chips/main_chip/trace.rs
+++ b/extensions/sha2/circuit/src/sha2_chips/main_chip/trace.rs
@@ -8,7 +8,7 @@ use openvm_circuit::{
     utils::next_power_of_two_or_zero,
 };
 use openvm_circuit_primitives::var_range::VariableRangeCheckerChip;
-use openvm_instructions::LocalOpcode;
+use openvm_instructions::{program::pc_to_idx, LocalOpcode};
 use openvm_riscv_circuit::adapters::{add_block_index_range_checks, ptr_to_u16_limbs};
 use openvm_sha2_air::{set_arrayview_from_u16_le_bytes, set_arrayview_from_u16_slice};
 use openvm_stark_backend::{
@@ -130,7 +130,7 @@ impl<F: PrimeField32, C: Sha2Config> Sha2MainChip<F, C> {
 
         *cols.instruction.is_enabled = F::ONE;
         cols.instruction.from_state.timestamp = F::from_u32(replay.timestamp);
-        cols.instruction.from_state.pc = F::from_u32(replay.from_pc);
+        cols.instruction.from_state.pc = F::from_u32(pc_to_idx(replay.from_pc));
         *cols.instruction.dst_reg_ptr = F::from_u32(replay.dst_reg_ptr);
         *cols.instruction.state_reg_ptr = F::from_u32(replay.state_reg_ptr);
         *cols.instruction.input_reg_ptr = F::from_u32(replay.input_reg_ptr);

--- a/guest-libs/verify-stark/circuit/src/extension.rs
+++ b/guest-libs/verify-stark/circuit/src/extension.rs
@@ -50,7 +50,7 @@ fn output_raw_from_proof(proof: &VmStarkProof) -> OutputRaw {
         &vm_poseidon2_hasher(),
         &vm_pvs.program_commit,
         &vm_pvs.initial_root,
-        vm_pvs.initial_pc,
+        vm_pvs.initial_pc_idx,
     );
     let app_vm_commit =
         poseidon2_hash_slice(&vk_commit_components(verifier_pvs).into_flattened()).0;

--- a/guest-libs/verify-stark/circuit/src/tests.rs
+++ b/guest-libs/verify-stark/circuit/src/tests.rs
@@ -215,7 +215,7 @@ fn test_deferral_verify_prover(child_extra_recursive_layers: usize) -> Result<()
         &vm_poseidon2_hasher::<F>(),
         &vm_pvs.program_commit,
         &vm_pvs.initial_root,
-        vm_pvs.initial_pc,
+        vm_pvs.initial_pc_idx,
     );
     let app_vm_commit =
         poseidon2_hash_slice(&vk_commit_components(verifier_pvs).into_flattened()).0;

--- a/guest-libs/verify-stark/circuit/src/verifier/air.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/air.rs
@@ -58,7 +58,7 @@ pub struct DeferredVerifyPvsCols<F> {
 
     pub program_commit_hash: [F; DIGEST_SIZE],
     pub initial_root_hash: [F; DIGEST_SIZE],
-    pub initial_pc_hash: [F; DIGEST_SIZE],
+    pub initial_pc_idx_hash: [F; DIGEST_SIZE],
 
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
@@ -315,10 +315,10 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             builder,
             Poseidon2CompressMessage {
                 input: pad_slice_to_poseidon2_input(
-                    &[local.child_vm_pvs.initial_pc.into()],
+                    &[local.child_vm_pvs.initial_pc_idx.into()],
                     AB::Expr::ZERO,
                 ),
-                output: local.initial_pc_hash.map(Into::into),
+                output: local.initial_pc_idx_hash.map(Into::into),
             },
             AB::F::ONE,
         );
@@ -340,7 +340,7 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB>
             Poseidon2CompressMessage {
                 input: digests_to_poseidon2_input(
                     local.intermediate_exe_commit,
-                    local.initial_pc_hash,
+                    local.initial_pc_idx_hash,
                 ),
                 output: local.app_exe_commit,
             },

--- a/guest-libs/verify-stark/circuit/src/verifier/trace.rs
+++ b/guest-libs/verify-stark/circuit/src/verifier/trace.rs
@@ -28,7 +28,7 @@ use crate::verifier::{DeferredVerifyPvsCols, RecursiveDeferredVerifyCols};
 pub struct DeferredVerifyPvsRecord<F> {
     pub program_commit_hash: [F; DIGEST_SIZE],
     pub initial_root_hash: [F; DIGEST_SIZE],
-    pub initial_pc_hash: [F; DIGEST_SIZE],
+    pub initial_pc_idx_hash: [F; DIGEST_SIZE],
     pub intermediate_exe_commit: [F; DIGEST_SIZE],
     pub intermediate_vk_states: [[F; POSEIDON2_WIDTH]; NUM_DIGESTS_IN_VM_COMMIT - 1],
     pub app_exe_commit: [F; DIGEST_SIZE],
@@ -54,7 +54,8 @@ pub fn generate_record(
 
     let padded_program_commit = pad_slice_to_poseidon2_input(&child_vm_pvs.program_commit, F::ZERO);
     let padded_initial_root = pad_slice_to_poseidon2_input(&child_vm_pvs.initial_root, F::ZERO);
-    let padded_initial_pc = pad_slice_to_poseidon2_input(&[child_vm_pvs.initial_pc], F::ZERO);
+    let padded_initial_pc_idx =
+        pad_slice_to_poseidon2_input(&[child_vm_pvs.initial_pc_idx], F::ZERO);
 
     let perm = poseidon2_perm();
     let program_commit_hash = perm.permute(padded_program_commit)[..DIGEST_SIZE]
@@ -63,7 +64,7 @@ pub fn generate_record(
     let initial_root_hash = perm.permute(padded_initial_root)[..DIGEST_SIZE]
         .try_into()
         .unwrap();
-    let initial_pc_hash = perm.permute(padded_initial_pc)[..DIGEST_SIZE]
+    let initial_pc_idx_hash = perm.permute(padded_initial_pc_idx)[..DIGEST_SIZE]
         .try_into()
         .unwrap();
 
@@ -72,7 +73,7 @@ pub fn generate_record(
     poseidon2_compress_inputs.extend_from_slice(&[
         padded_program_commit,
         padded_initial_root,
-        padded_initial_pc,
+        padded_initial_pc_idx,
     ]);
 
     let intermediate_exe_commit =
@@ -90,17 +91,17 @@ pub fn generate_record(
     let intermediate_vk_states = intermediate_vk_states_vec.try_into().unwrap();
 
     let app_exe_commit =
-        poseidon2_compress_with_capacity(intermediate_exe_commit, initial_pc_hash).0;
+        poseidon2_compress_with_capacity(intermediate_exe_commit, initial_pc_idx_hash).0;
     poseidon2_compress_inputs.push(digests_to_poseidon2_input(
         intermediate_exe_commit,
-        initial_pc_hash,
+        initial_pc_idx_hash,
     ));
 
     (
         DeferredVerifyPvsRecord {
             program_commit_hash,
             initial_root_hash,
-            initial_pc_hash,
+            initial_pc_idx_hash,
             intermediate_exe_commit,
             intermediate_vk_states,
             app_exe_commit,
@@ -144,7 +145,7 @@ pub fn generate_proving_ctx(
     };
     cols.program_commit_hash = record.program_commit_hash;
     cols.initial_root_hash = record.initial_root_hash;
-    cols.initial_pc_hash = record.initial_pc_hash;
+    cols.initial_pc_idx_hash = record.initial_pc_idx_hash;
     cols.intermediate_exe_commit = record.intermediate_exe_commit;
     cols.intermediate_vk_states = record.intermediate_vk_states;
     cols.app_exe_commit = record.app_exe_commit;


### PR DESCRIPTION
Stacked on #3104 (base `feat/2-pow-32-memory-addresses-v2.1.0`); only the top two commits are new here.

## Summary

Byte program counters now span the full 32-bit address space, matching the 2^32-byte memory port. A 32-bit byte pc does not fit in a BabyBear element, so every circuit-visible pc — trace columns, execution/program bus messages, connector public values, and the exe-commit preimage — instead carries the **pc index** `pc / DEFAULT_PC_STEP < 2^PC_BITS` (`PC_BITS = 30`). Runtime pcs stay byte addresses; conversion happens at the circuit boundary.

## Circuit representation (`crates/vm` + toolchain)

- `openvm-instructions` gains `pc_to_idx` / `idx_to_pc` and `PC_STEP_BITS`; `MAX_ALLOWED_PC` becomes the last aligned 32-bit byte address (`u32::MAX - 3`).
- Program cached trace, connector begin/end pcs, phantom rows, and `compute_exe_commit(pc_start)` all convert to indices. Segment stitching, the root-verifier AIR, and verify-stark pass the public-value felt through unchanged.
- The `ExecutionBridge` default pc increment becomes `+1` index; all `(DEFAULT_PC_STEP, to_pc)` adapter tuples become `(1, to_pc)`.
- AIRs that consume byte immediates (branches, JAL) scale them by `inverse(DEFAULT_PC_STEP)`.
- Also fixes a latent metered pre-compute bug that double-added `pc_base`.

## Chips that materialize the byte pc

The old `[u16, u14]` limb split cannot soundly represent 32-bit values mod p (BabyBear is a 31-bit field), so chips that write the byte pc into a register decompose it differently:

- **JAL/JALR** return address `rd = 4 * (from_idx + 1)`: the low u16 limb is constrained as `4x` with `x < 2^PC_IDX_LOW_BITS` and the high limb as a full u16, which uniquely pins the 32-bit decomposition mod p. JAL `rd` is zero-extended per the bus address convention, while LUI keeps rv64 sign-extension.
- **JALR** `to_pc_limbs` decompose the target *index*; a misaligned target (bit 1 set) is unsatisfiable in the AIR and rejected in `try_run_jalr`.
- **AUIPC** decomposes the byte pc as `[4 * idx_low, u16 high]`; results ≥ 2^32 are rejected at tracegen.
- **Branches** compute `to_pc = from_idx + byte_delta / 4`; fillers use signed integer target math (field addition wraps mod p past 2^30) with bounds validation, shared via `taken_branch_pc` / `checked_branch_target`.

## Misaligned branch/jump offsets

The transpiler deliberately does **not** reject misaligned branch/jump offsets (second commit). It decodes every word of `.text`, so embedded data and never-taken branches can legitimately decode as misaligned control flow. Misalignment is instead enforced where the target is actually used: the interpreter traps on a misaligned pc, and tracegen rejects the row via `checked_branch_target` (branches) and the JAL target bounds check. A misaligned branch that is never taken falls through normally, matching hardware.

## CUDA parity

`constants.h` gains pc helpers; program/phantom/adapter kernels write indices; the `jal_lui` / `jalr` / `auipc` kernels mirror the new limb splits and range-checker counts; rvr replay kernels validate jump targets with integer math (`replay_taken_branch_pc` / `replay_branch_target_in_bounds`); and `checkpoint_replay`'s `branch_target` drops its mod-p reduction.

## Tests

Chip tests sample aligned byte pcs over the full 32-bit range, with new max-pc boundary tests for JAL/JALR/AUIPC. Testers record index-space bus messages while exposing byte pcs as `u32` (roundtripping through F would reduce mod p). The misaligned-offset fix restores `rvr_embedded_text_data`, `rvr_invalid_branch_fallthrough`, and `rvr_invalid_branch_taken`.

Closes INT-8507
