### PR TITLE
perf: sparse initial memory snapshot and GPU Merkle build

### DIFF
--- a/crates/vm/cuda/include/system/memory/params.cuh
+++ b/crates/vm/cuda/include/system/memory/params.cuh
@@ -72,5 +72,8 @@ inline constexpr size_t MEMORY_BLOCK_BYTES = BLOCK_FE_WIDTH * U16_CELL_SIZE;
 // Blocks per merkle leaf.
 inline constexpr size_t BLOCKS_PER_LEAF = DIGEST_WIDTH / BLOCK_FE_WIDTH;
 
-// Number of bottom merkle levels omitted from large GPU subtree buffers.
-inline constexpr size_t OMITTED_BOTTOM_LEVELS = 3;
+// Upper bound on a subtree's `base_height`, i.e. on the number of bottom merkle levels that may be
+// omitted from its buffer. Sizes the thread-local scratch of `recompute_omitted_node`, which
+// rebuilds an omitted node from `2^base_height` raw-memory leaves. The host picks the actual
+// number of omitted levels per subtree (`OMITTED_BOTTOM_LEVELS` in `merkle_tree/mod.rs`).
+inline constexpr size_t MAX_OMITTED_LEVELS = 3;

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -420,6 +420,13 @@ __device__ void store_virtual_node(
     size_t const label,
     digest_t const *value
 ) {
+    // Non-existent nodes (labels beyond the stored `actual_height` prefix) have no slot:
+    // the heap region has no entry for them and `stored_node_index` would alias the
+    // vertical-path slot of the label-0 node at path levels. Their updated digests still
+    // propagate through the layer records, so the store can be skipped.
+    if (!virtual_node_exists(node_height, actual_height, label)) {
+        return;
+    }
     if (layout == OMIT_BOTTOM_LEVELS && node_height < OMITTED_BOTTOM_LEVELS) {
         return;
     }

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -15,10 +15,12 @@ struct alignas(32) digest_t {
 
 #define COPY_DIGEST(dst, src) memcpy(dst, src, sizeof(digest_t))
 
-enum MemoryMerkleSubTreeLayout : uint8_t {
-    FULL = 0,
-    OMIT_BOTTOM_LEVELS = 1,
-    SPARSE_PAGES = 2,
+// How a subtree's stored nodes are indexed within its digest buffer. Orthogonal to the subtree's
+// `base_height`, the lowest height it stores at all; nodes below that height are recomputed from
+// raw memory under either indexing.
+enum SubTreeIndexing : uint8_t {
+    DENSE = 0,  // heap-ordered; a node's slot is computed from its (height, label)
+    SPARSE = 1, // sorted per-height label index; a node's slot is found by binary search
 };
 
 // Selects one height's contiguous range in the flat sparse-node arrays.
@@ -91,9 +93,9 @@ __device__ void recompute_omitted_node(
     size_t const label,
     digest_t *out
 ) {
-    // layer is a fixed-size, thread-local scratch buffer of 2^OMITTED_BOTTOM_LEVELS 
+    // layer is a fixed-size, thread-local scratch buffer of 2^MAX_OMITTED_LEVELS
     // digests, used to rebuild an omitted subtree bottom-up.
-    digest_t layer[1 << OMITTED_BOTTOM_LEVELS];
+    digest_t layer[1 << MAX_OMITTED_LEVELS];
     // num_leaves denote the number of leaves of the subtree rooted at this node 
     size_t const num_leaves = 1 << node_height;
     // recall again that node_height is counted starting from the bottom
@@ -120,10 +122,11 @@ __device__ void recompute_omitted_node(
 __global__ void merkle_tree_init_omitted(
     uint8_t *__restrict__ data,
     digest_t *__restrict__ out,
-    uint8_t const cell_type
+    uint8_t const cell_type,
+    uint32_t const base_height
 ) {
     auto gid = blockDim.x * blockIdx.x + threadIdx.x;
-    recompute_omitted_node(data, cell_type, OMITTED_BOTTOM_LEVELS, gid, &out[gid]);
+    recompute_omitted_node(data, cell_type, base_height, gid, &out[gid]);
 }
 
 __global__ void sparse_merkle_init(
@@ -425,9 +428,9 @@ __device__ void fill_merkle_trace_row(
 //   1. Non-existent: `label` lies beyond the touched layer (higher memory
 //      addresses that were never written). It is not stored at all; its value
 //      is the precomputed constant `zero_hash[node_height]`.
-//   2. Omitted bottom level: under the OMIT_BOTTOM_LEVELS layout, nodes with
-//      `node_height < OMITTED_BOTTOM_LEVELS` are not stored either; they are
-//      recomputed on demand from `initial_data`.
+//   2. Omitted bottom level: nodes with `node_height < base_height` are not
+//      stored either, under either indexing; they are recomputed on demand from
+//      `initial_data`.
 //   3. On the vertical path (`node_height > actual_height`): a stored node
 //      above the touched subtree, indexed linearly by height.
 //   4. Inside the actual touched subtree (`node_height <= actual_height`): a
@@ -462,7 +465,8 @@ __device__ __forceinline__ size_t stored_node_index(
 __device__ void load_virtual_node(
     digest_t const *subtree,
     digest_t const *zero_hash,
-    uint8_t const layout,
+    uint8_t const indexing,
+    uint32_t const base_height,
     uint8_t const cell_type,
     uint8_t const *initial_data,
     uint32_t const subtree_height,
@@ -473,8 +477,11 @@ __device__ void load_virtual_node(
     SparseLevel const *sparse_levels,
     digest_t *out
 ) {
-    if (layout == SPARSE_PAGES) {
-        if (node_height < OMITTED_BOTTOM_LEVELS) {
+    // The two indexings differ in how a node's absence is detected -- a sparse index reports it as
+    // a lookup miss, a dense heap as a label past the stored prefix -- so the check stays inside
+    // each branch. Recomputing the levels below `base_height` is common to both.
+    if (indexing == SPARSE) {
+        if (node_height < base_height) {
             recompute_omitted_node(initial_data, cell_type, node_height, label, out);
             return;
         }
@@ -488,12 +495,14 @@ __device__ void load_virtual_node(
         }
         return;
     }
+    // Dense: the bounds check must precede the recompute, since a label past the stored prefix has
+    // no raw memory to rebuild from.
     if (!virtual_node_exists(node_height, actual_height, label)) {
         COPY_DIGEST(out, &zero_hash[node_height]);
         return;
     }
 
-    if (layout == OMIT_BOTTOM_LEVELS && node_height < OMITTED_BOTTOM_LEVELS) {
+    if (node_height < base_height) {
         recompute_omitted_node(initial_data, cell_type, node_height, label, out);
         return;
     }
@@ -504,16 +513,17 @@ __device__ void load_virtual_node(
 
 __device__ void store_virtual_node(
     digest_t *subtree,
-    uint8_t const layout,
+    uint8_t const indexing,
+    uint32_t const base_height,
     uint32_t const subtree_height,
     uint32_t const actual_height,
     uint32_t const node_height,
     size_t const label,
     digest_t const *value
 ) {
-    // Sparse storage is an immutable index of the segment-start tree. Updated values propagate
+    // A sparse index is an immutable index of the segment-start tree. Updated values propagate
     // through `layer`; missing siblings continue to read from this initial index.
-    if (layout == SPARSE_PAGES) {
+    if (indexing == SPARSE) {
         return;
     }
     // Non-existent nodes (labels beyond the stored `actual_height` prefix) have no slot:
@@ -523,7 +533,7 @@ __device__ void store_virtual_node(
     if (!virtual_node_exists(node_height, actual_height, label)) {
         return;
     }
-    if (layout == OMIT_BOTTOM_LEVELS && node_height < OMITTED_BOTTOM_LEVELS) {
+    if (node_height < base_height) {
         return;
     }
     auto const idx = stored_node_index(subtree_height, actual_height, node_height, label);
@@ -564,7 +574,8 @@ __global__ void update_merkle_layer(
     uint32_t layer_height,
     digest_t const *zero_hash,
     size_t const *actual_subtree_heights,
-    uint8_t const *subtree_layouts,
+    uint8_t const *subtree_indexings,
+    uint8_t const *subtree_base_heights,
     uint8_t const *cell_types,
     uintptr_t const *initial_data_ptrs,
     uintptr_t const *sparse_label_ptrs,
@@ -604,7 +615,8 @@ __global__ void update_merkle_layer(
     uint32_t const parent_label = layer[parent_ptr].label >> layer_height;
     auto const subtree = subtrees[address_space_idx];
     uint32_t const actual_height = actual_subtree_heights[address_space_idx];
-    uint8_t const layout = subtree_layouts[address_space_idx];
+    uint8_t const indexing = subtree_indexings[address_space_idx];
+    uint32_t const base_height = subtree_base_heights[address_space_idx];
     uint8_t const cell_type = cell_types[address_space_idx];
     auto const initial_data = reinterpret_cast<uint8_t const *>(initial_data_ptrs[address_space_idx]);
     auto const sparse_labels =
@@ -618,7 +630,8 @@ __global__ void update_merkle_layer(
     load_virtual_node(
         subtree,
         zero_hash,
-        layout,
+        indexing,
+        base_height,
         cell_type,
         initial_data,
         subtree_height,
@@ -633,7 +646,8 @@ __global__ void update_merkle_layer(
     load_virtual_node(
         subtree,
         zero_hash,
-        layout,
+        indexing,
+        base_height,
         cell_type,
         initial_data,
         subtree_height,
@@ -685,7 +699,8 @@ __global__ void update_merkle_layer(
             COPY_DIGEST(cells, layer[child_ptrs[2 * idx]].digest_raw);
             store_virtual_node(
                 subtree,
-                layout,
+                indexing,
+                base_height,
                 subtree_height,
                 actual_height,
                 layer_height - 1,
@@ -699,7 +714,8 @@ __global__ void update_merkle_layer(
             COPY_DIGEST(cells + CELLS_OUT, layer[child_ptrs[2 * idx + 1]].digest_raw);
             store_virtual_node(
                 subtree,
-                layout,
+                indexing,
+                base_height,
                 subtree_height,
                 actual_height,
                 layer_height - 1,
@@ -892,17 +908,22 @@ extern "C" int _build_merkle_subtree(
     digest_t *buffer,
     const size_t tree_offset,
     const uint8_t cell_type,
-    const uint8_t layout,
+    const size_t base_height,
     cudaStream_t stream
 ) {
     if (cell_type < CELL_U8 || cell_type > CELL_FIELD32) return -1;
+    assert(base_height <= MAX_OMITTED_LEVELS);
     digest_t *tree = buffer + tree_offset;
     assert((size & (size - 1)) == 0);
     {
         auto [grid, block] = kernel_launch_params(size);
-        if (layout == OMIT_BOTTOM_LEVELS) {
+        // The stored heap bottoms out at `base_height`, so each of its leaves is a node over
+        // `2^base_height` raw-memory leaves. `merkle_tree_init` is the `base_height == 0`
+        // specialization: it hashes one raw leaf per thread without the recompute scratch, which
+        // matters because it runs over the whole dense image.
+        if (base_height > 0) {
             merkle_tree_init_omitted<<<grid, block, 0, stream>>>(
-                data, tree + (size - 1), cell_type
+                data, tree + (size - 1), cell_type, base_height
             );
         } else {
             merkle_tree_init<<<grid, block, 0, stream>>>(data, tree + (size - 1), cell_type);
@@ -927,7 +948,7 @@ extern "C" int _build_sparse_merkle_subtree(
     cudaStream_t stream
 ) {
     if (cell_type < CELL_U8 || cell_type > CELL_FIELD32) return -1;
-    assert(base_height == OMITTED_BOTTOM_LEVELS);
+    assert(base_height <= MAX_OMITTED_LEVELS);
     auto level = [levels](size_t height) {
         return SparseLevel {
             static_cast<uint32_t>(levels[2 * height]),
@@ -1024,7 +1045,8 @@ extern "C" int _update_merkle_tree(
     digest_t *top_roots,
     digest_t const *zero_hash,
     size_t const *actual_subtree_heights,
-    uint8_t const *subtree_layouts,
+    uint8_t const *subtree_indexings,
+    uint8_t const *subtree_base_heights,
     uint8_t const *cell_types,
     uintptr_t const *initial_data_ptrs,
     uintptr_t const *sparse_label_ptrs,
@@ -1143,7 +1165,8 @@ extern "C" int _update_merkle_tree(
             h,
             zero_hash,
             actual_subtree_heights,
-            subtree_layouts,
+            subtree_indexings,
+            subtree_base_heights,
             cell_types,
             initial_data_ptrs,
             sparse_label_ptrs,

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -18,6 +18,12 @@ struct alignas(32) digest_t {
 enum MemoryMerkleSubTreeLayout : uint8_t {
     FULL = 0,
     OMIT_BOTTOM_LEVELS = 1,
+    SPARSE_PAGES = 2,
+};
+
+struct SparseLevel {
+    uint32_t start;
+    uint32_t count;
 };
 
 __device__ __forceinline__ void hash_raw_memory_leaf(
@@ -114,6 +120,70 @@ __global__ void merkle_tree_init_omitted(
 ) {
     auto gid = blockDim.x * blockIdx.x + threadIdx.x;
     recompute_omitted_node(data, cell_type, OMITTED_BOTTOM_LEVELS, gid, &out[gid]);
+}
+
+__global__ void sparse_merkle_init(
+    uint8_t const *__restrict__ data,
+    digest_t *__restrict__ out,
+    uint32_t const *__restrict__ labels,
+    uint32_t const start,
+    uint32_t const count,
+    uint32_t const base_height,
+    uint8_t const cell_type
+) {
+    auto gid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (gid >= count) {
+        return;
+    }
+    auto const idx = start + gid;
+    recompute_omitted_node(data, cell_type, base_height, labels[idx], &out[idx]);
+}
+
+__device__ __forceinline__ uint32_t sparse_find_label(
+    uint32_t const *__restrict__ labels,
+    SparseLevel const level,
+    uint32_t const needle
+) {
+    uint32_t lo = 0;
+    uint32_t hi = level.count;
+    while (lo < hi) {
+        uint32_t const mid = lo + (hi - lo) / 2;
+        uint32_t const value = labels[level.start + mid];
+        if (value < needle) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo < level.count && labels[level.start + lo] == needle
+        ? level.start + lo
+        : UINT_MAX;
+}
+
+__global__ void sparse_merkle_compress(
+    digest_t *__restrict__ nodes,
+    uint32_t const *__restrict__ labels,
+    SparseLevel const children,
+    SparseLevel const parents,
+    digest_t const *__restrict__ zero_hash,
+    uint32_t const child_height
+) {
+    auto gid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (gid >= parents.count) {
+        return;
+    }
+    auto const parent_idx = parents.start + gid;
+    auto const parent_label = labels[parent_idx];
+    Fp cells[CELLS];
+    auto const left_idx = sparse_find_label(labels, children, 2 * parent_label);
+    auto const right_idx = sparse_find_label(labels, children, 2 * parent_label + 1);
+    COPY_DIGEST(cells, left_idx == UINT_MAX ? &zero_hash[child_height] : &nodes[left_idx]);
+    COPY_DIGEST(
+        cells + CELLS_OUT,
+        right_idx == UINT_MAX ? &zero_hash[child_height] : &nodes[right_idx]
+    );
+    poseidon2_mix(cells);
+    COPY_DIGEST(&nodes[parent_idx], cells);
 }
 
 __global__ void merkle_tree_compress(
@@ -395,8 +465,25 @@ __device__ void load_virtual_node(
     uint32_t const actual_height,
     uint32_t const node_height,
     size_t const label,
+    uint32_t const *sparse_labels,
+    SparseLevel const *sparse_levels,
     digest_t *out
 ) {
+    if (layout == SPARSE_PAGES) {
+        if (node_height < OMITTED_BOTTOM_LEVELS) {
+            recompute_omitted_node(initial_data, cell_type, node_height, label, out);
+            return;
+        }
+        auto const idx = sparse_find_label(
+            sparse_labels, sparse_levels[node_height], static_cast<uint32_t>(label)
+        );
+        if (idx == UINT_MAX) {
+            COPY_DIGEST(out, &zero_hash[node_height]);
+        } else {
+            COPY_DIGEST(out, &subtree[idx]);
+        }
+        return;
+    }
     if (!virtual_node_exists(node_height, actual_height, label)) {
         COPY_DIGEST(out, &zero_hash[node_height]);
         return;
@@ -420,6 +507,11 @@ __device__ void store_virtual_node(
     size_t const label,
     digest_t const *value
 ) {
+    // Sparse storage is an immutable index of the segment-start tree. Updated values propagate
+    // through `layer`; missing siblings continue to read from this initial index.
+    if (layout == SPARSE_PAGES) {
+        return;
+    }
     // Non-existent nodes (labels beyond the stored `actual_height` prefix) have no slot:
     // the heap region has no entry for them and `stored_node_index` would alias the
     // vertical-path slot of the label-0 node at path levels. Their updated digests still
@@ -471,6 +563,8 @@ __global__ void update_merkle_layer(
     uint8_t const *subtree_layouts,
     uint8_t const *cell_types,
     uintptr_t const *initial_data_ptrs,
+    uintptr_t const *sparse_label_ptrs,
+    uintptr_t const *sparse_level_ptrs,
     uint32_t const subtree_height,
     LabeledDigest *layer,
     uint32_t const *child_ptrs,
@@ -509,6 +603,10 @@ __global__ void update_merkle_layer(
     uint8_t const layout = subtree_layouts[address_space_idx];
     uint8_t const cell_type = cell_types[address_space_idx];
     auto const initial_data = reinterpret_cast<uint8_t const *>(initial_data_ptrs[address_space_idx]);
+    auto const sparse_labels =
+        reinterpret_cast<uint32_t const *>(sparse_label_ptrs[address_space_idx]);
+    auto const sparse_levels =
+        reinterpret_cast<SparseLevel const *>(sparse_level_ptrs[address_space_idx]);
     Poseidon2Buffer poseidon2(
         reinterpret_cast<FpArray<16> *>(poseidon2_buffer), poseidon2_buffer_idx, poseidon2_capacity
     );
@@ -523,6 +621,8 @@ __global__ void update_merkle_layer(
         actual_height,
         layer_height - 1,
         2 * parent_label,
+        sparse_labels,
+        sparse_levels,
         &old_left_digest
     );
     digest_t old_right_digest;
@@ -536,6 +636,8 @@ __global__ void update_merkle_layer(
         actual_height,
         layer_height - 1,
         2 * parent_label + 1,
+        sparse_labels,
+        sparse_levels,
         &old_right_digest
     );
     bool const left_present = child_ptrs[2 * idx] != MISSING_CHILD;
@@ -809,6 +911,54 @@ extern "C" int _build_merkle_subtree(
     return CHECK_KERNEL();
 }
 
+extern "C" int _build_sparse_merkle_subtree(
+    uint8_t *data,
+    digest_t *nodes,
+    uint32_t const *labels,
+    size_t const *levels,
+    size_t const base_height,
+    size_t const tree_height,
+    uint8_t const cell_type,
+    digest_t const *zero_hash,
+    cudaStream_t stream
+) {
+    if (cell_type < CELL_U8 || cell_type > CELL_FIELD32) return -1;
+    assert(base_height == OMITTED_BOTTOM_LEVELS);
+    auto level = [levels](size_t height) {
+        return SparseLevel {
+            static_cast<uint32_t>(levels[2 * height]),
+            static_cast<uint32_t>(levels[2 * height + 1]),
+        };
+    };
+    auto const base = level(base_height);
+    {
+        auto [grid, block] = kernel_launch_params(base.count);
+        sparse_merkle_init<<<grid, block, 0, stream>>>(
+            data,
+            nodes,
+            labels,
+            base.start,
+            base.count,
+            base_height,
+            cell_type
+        );
+        if (int err = CHECK_KERNEL(); err) {
+            return err;
+        }
+    }
+    for (size_t height = base_height + 1; height <= tree_height; ++height) {
+        auto const parents = level(height);
+        auto [grid, block] = kernel_launch_params(parents.count);
+        sparse_merkle_compress<<<grid, block, 0, stream>>>(
+            nodes, labels, level(height - 1), parents, zero_hash, height - 1
+        );
+        if (int err = CHECK_KERNEL(); err) {
+            return err;
+        }
+    }
+    return 0;
+}
+
 extern "C" int _restore_merkle_subtree_path(
     digest_t *in_out,
     digest_t *zero_hash,
@@ -873,6 +1023,8 @@ extern "C" int _update_merkle_tree(
     uint8_t const *subtree_layouts,
     uint8_t const *cell_types,
     uintptr_t const *initial_data_ptrs,
+    uintptr_t const *sparse_label_ptrs,
+    uintptr_t const *sparse_level_ptrs,
     Fp *d_poseidon2_raw_buffer,
     uint32_t *d_poseidon2_buffer_idx,
     size_t poseidon2_capacity,
@@ -990,6 +1142,8 @@ extern "C" int _update_merkle_tree(
             subtree_layouts,
             cell_types,
             initial_data_ptrs,
+            sparse_label_ptrs,
+            sparse_level_ptrs,
             subtree_height,
             layer,
             tmp_buf,

--- a/crates/vm/cuda/src/system/memory/merkle_tree.cu
+++ b/crates/vm/cuda/src/system/memory/merkle_tree.cu
@@ -21,6 +21,10 @@ enum MemoryMerkleSubTreeLayout : uint8_t {
     SPARSE_PAGES = 2,
 };
 
+// Selects one height's contiguous range in the flat sparse-node arrays.
+// `labels[start .. start + count]` contains the node labels at this height, and the same range in
+// the digest buffer contains their hashes. Kernels use this range to binary-search a node label
+// without considering labels from other heights.
 struct SparseLevel {
     uint32_t start;
     uint32_t count;

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -28,7 +28,9 @@ use tracing::instrument;
 
 use super::{
     boundary::BoundaryChipGPU,
-    merkle_tree::{MemoryMerkleTree, SpanningNodeCounter, MERKLE_TOUCHED_BLOCK_WIDTH},
+    merkle_tree::{
+        touched_leaf_watermark, MemoryMerkleTree, SpanningNodeCounter, MERKLE_TOUCHED_BLOCK_WIDTH,
+    },
     GpuMemoryCellType, Poseidon2PeripheryChipGPU,
 };
 use crate::{
@@ -203,10 +205,12 @@ impl MemoryInventoryGPU {
             self.clear_initial_memory();
         }
         // Only transfer pages that may contain non-zero data; the rest are zero-filled
-        // on-device. The merkle kernel reads the full address-space region, so the device
-        // buffer is full-size and the skipped pages must read as zero. Replacing this allocation
-        // requires sparse-aware CUDA execution and Merkle kernels; the CPU sparse-snapshot path
-        // cannot safely be reused here.
+        // on-device. Execution and boundary kernels index the full address-space region, so the
+        // device buffer is full-size and the skipped pages must read as zero. Replacing this
+        // allocation requires sparse-aware CUDA execution kernels; the CPU sparse-snapshot path
+        // cannot safely be reused here. The Merkle build, however, is truncated at the
+        // touched-pages watermark: leaves above it are all-zero and are covered by precomputed
+        // zero hashes instead of being hashed (see `touched_leaf_watermark`).
         let per_as: Vec<_> = initial_memory
             .get_memory()
             .iter()
@@ -276,8 +280,11 @@ impl MemoryInventoryGPU {
                 }
                 buf
             }));
-            self.merkle_tree
-                .build_async(self.initial_memory[addr_sp].clone(), addr_sp);
+            self.merkle_tree.build_async(
+                self.initial_memory[addr_sp].clone(),
+                addr_sp,
+                touched_leaf_watermark(initial_memory, addr_sp),
+            );
         }
         self.boundary.initial_leaves = self
             .initial_memory

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -29,7 +29,7 @@ use tracing::instrument;
 use super::{
     boundary::BoundaryChipGPU,
     merkle_tree::{
-        touched_leaf_watermark, MemoryMerkleTree, SpanningNodeCounter, MERKLE_TOUCHED_BLOCK_WIDTH,
+        initial_merkle_build, MemoryMerkleTree, SpanningNodeCounter, MERKLE_TOUCHED_BLOCK_WIDTH,
     },
     GpuMemoryCellType, Poseidon2PeripheryChipGPU,
 };
@@ -208,9 +208,9 @@ impl MemoryInventoryGPU {
         // on-device. Execution and boundary kernels index the full address-space region, so the
         // device buffer is full-size and the skipped pages must read as zero. Replacing this
         // allocation requires sparse-aware CUDA execution kernels; the CPU sparse-snapshot path
-        // cannot safely be reused here. The Merkle build, however, is truncated at the
-        // touched-pages watermark: leaves above it are all-zero and are covered by precomputed
-        // zero hashes instead of being hashed (see `touched_leaf_watermark`).
+        // cannot safely be reused here. The Merkle build uses touched pages to choose either a
+        // dense prefix or page-dense sparse subtrees whose gaps are covered by precomputed zero
+        // hashes (see `initial_merkle_build`).
         let per_as: Vec<_> = initial_memory
             .get_memory()
             .iter()
@@ -227,6 +227,11 @@ impl MemoryInventoryGPU {
             .sum();
         let staging = self.upload_staging.ensure(total);
         let mut offset = 0usize;
+        let address_height = self
+            .merkle_tree
+            .mem_config()
+            .memory_dimensions()
+            .address_height;
         for (addr_sp, (raw_mem, runs)) in per_as.into_iter().enumerate() {
             tracing::debug!(
                 "Setting initial memory for address space {}: {} bytes, {} touched run(s)",
@@ -283,7 +288,7 @@ impl MemoryInventoryGPU {
             self.merkle_tree.build_async(
                 self.initial_memory[addr_sp].clone(),
                 addr_sp,
-                touched_leaf_watermark(initial_memory, addr_sp),
+                initial_merkle_build(initial_memory, addr_sp, address_height),
             );
         }
         self.boundary.initial_leaves = self

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -204,7 +204,9 @@ impl MemoryInventoryGPU {
         }
         // Only transfer pages that may contain non-zero data; the rest are zero-filled
         // on-device. The merkle kernel reads the full address-space region, so the device
-        // buffer is full-size and the skipped pages must read as zero.
+        // buffer is full-size and the skipped pages must read as zero. Replacing this allocation
+        // requires sparse-aware CUDA execution and Merkle kernels; the CPU sparse-snapshot path
+        // cannot safely be reused here.
         let per_as: Vec<_> = initial_memory
             .get_memory()
             .iter()
@@ -832,11 +834,6 @@ mod tests {
         unsafe {
             memory.write_bytes::<MEMORY_BLOCK_BYTES>(REGISTER_AS, 0, [1, 2, 3, 4, 5, 6, 7, 8]);
             memory.write_bytes::<MEMORY_BLOCK_BYTES>(MEMORY_AS, 0, [9, 10, 11, 12, 0, 0, 0, 0]);
-        }
-        // `write_bytes` doesn't mark pages; mark them so `set_initial_memory` transfers them
-        // (see `AddressMap::touched_pages`).
-        for addr_space in [REGISTER_AS, MEMORY_AS] {
-            memory.memory.touched_pages[addr_space as usize].mark_byte_range(0, MEMORY_BLOCK_BYTES);
         }
         (mem_config, memory)
     }

--- a/crates/vm/src/system/cuda/memory.rs
+++ b/crates/vm/src/system/cuda/memory.rs
@@ -1120,9 +1120,10 @@ mod tests {
     fn test_set_initial_memory_rejects_nonzero_unmarked_page() {
         let (mem_config, _) = single_block_setup();
         let mut memory = GuestMemory::new(AddressMap::from_mem_config(&mem_config));
-        unsafe {
-            memory.write_bytes::<MEMORY_BLOCK_BYTES>(MEMORY_AS, 0, [1, 2, 3, 4, 5, 6, 7, 8]);
-        }
+        // Raw mutable access is the documented escape hatch that does NOT mark touched pages
+        // (see `AddressMap::touched_pages`); tracked writers like `write_bytes` mark them.
+        memory.memory.get_memory_mut()[MEMORY_AS as usize].as_mut_slice()[..MEMORY_BLOCK_BYTES]
+            .copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
         assert!(memory.memory.touched_pages[MEMORY_AS as usize]
             .touched_byte_ranges(MEMORY_BLOCK_BYTES)
             .is_empty());

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -22,7 +22,7 @@ pub mod merkle_tree {
             d_tree: *mut std::ffi::c_void,
             tree_offset: usize,
             cell_type: u8,
-            layout: u8,
+            base_height: usize,
             stream: cudaStream_t,
         ) -> i32;
 
@@ -82,7 +82,8 @@ pub mod merkle_tree {
             top_roots: *mut u32,         // are actually `H`s
             zero_hashes_end: *const u32, // are actually `H`s
             actual_subtree_heights: *const usize,
-            subtree_layouts: *const u8,
+            subtree_indexings: *const u8,
+            subtree_base_heights: *const u8,
             cell_types: *const u8,
             initial_data_ptrs: *const usize,
             sparse_label_ptrs: *const usize,
@@ -129,7 +130,7 @@ pub mod merkle_tree {
         d_tree: &DeviceBuffer<T>,
         tree_offset: usize,
         cell_type: u8,
-        layout: u8,
+        base_height: usize,
         stream: cudaStream_t,
     ) -> Result<(), CudaError> {
         CudaError::from_result(_build_merkle_subtree(
@@ -138,7 +139,7 @@ pub mod merkle_tree {
             d_tree.as_mut_raw_ptr(),
             tree_offset,
             cell_type,
-            layout,
+            base_height,
             stream,
         ))
     }
@@ -213,7 +214,8 @@ pub mod merkle_tree {
         touched_blocks: &DeviceBuffer<u32>,
         subtree_height: usize,
         actual_heights: &[usize],
-        subtree_layouts: &[u8],
+        subtree_indexings: &[u8],
+        subtree_base_heights: &[u8],
         cell_types: &[u8],
         initial_data_ptrs: &[usize],
         sparse_label_ptrs: &[usize],
@@ -237,7 +239,8 @@ pub mod merkle_tree {
         )?;
         let tmp_storage = DeviceBuffer::<u8>::with_capacity_on(need_tmp_storage_bytes, device_ctx);
         let actual_heights = actual_heights.to_device_on(device_ctx).unwrap();
-        let subtree_layouts = subtree_layouts.to_device_on(device_ctx).unwrap();
+        let subtree_indexings = subtree_indexings.to_device_on(device_ctx).unwrap();
+        let subtree_base_heights = subtree_base_heights.to_device_on(device_ctx).unwrap();
         let cell_types = cell_types.to_device_on(device_ctx).unwrap();
         let initial_data_ptrs = initial_data_ptrs.to_device_on(device_ctx).unwrap();
         let sparse_label_ptrs = sparse_label_ptrs.to_device_on(device_ctx).unwrap();
@@ -259,7 +262,8 @@ pub mod merkle_tree {
             top_roots.as_mut_ptr() as *mut u32,
             zero_hash.as_ptr() as *mut u32,
             actual_heights.as_ptr(),
-            subtree_layouts.as_ptr(),
+            subtree_indexings.as_ptr(),
+            subtree_base_heights.as_ptr(),
             cell_types.as_ptr(),
             initial_data_ptrs.as_ptr(),
             sparse_label_ptrs.as_ptr(),

--- a/crates/vm/src/system/cuda/merkle_tree/cuda.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/cuda.rs
@@ -26,6 +26,18 @@ pub mod merkle_tree {
             stream: cudaStream_t,
         ) -> i32;
 
+        fn _build_sparse_merkle_subtree(
+            d_data: *mut u8,
+            d_tree: *mut std::ffi::c_void,
+            d_labels: *const u32,
+            h_levels: *const usize,
+            base_height: usize,
+            tree_height: usize,
+            cell_type: u8,
+            d_zero_hash: *const std::ffi::c_void,
+            stream: cudaStream_t,
+        ) -> i32;
+
         fn _restore_merkle_subtree_path(
             d_in_out: *mut std::ffi::c_void,
             d_zero_hash: *mut std::ffi::c_void,
@@ -73,11 +85,42 @@ pub mod merkle_tree {
             subtree_layouts: *const u8,
             cell_types: *const u8,
             initial_data_ptrs: *const usize,
+            sparse_label_ptrs: *const usize,
+            sparse_level_ptrs: *const usize,
             d_poseidon2_raw_buffer: *mut std::ffi::c_void,
             d_poseidon2_buffer_idx: *mut u32,
             poseidon2_capacity: usize,
             stream: cudaStream_t,
         ) -> i32;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn build_sparse_merkle_subtree<T>(
+        d_data: &DeviceBuffer<u8>,
+        d_tree: &DeviceBuffer<T>,
+        d_labels: &DeviceBuffer<u32>,
+        levels: &[[u32; 2]],
+        base_height: usize,
+        tree_height: usize,
+        cell_type: u8,
+        d_zero_hash: &DeviceBuffer<T>,
+        stream: cudaStream_t,
+    ) -> Result<(), CudaError> {
+        let levels = levels
+            .iter()
+            .flat_map(|&[start, count]| [start as usize, count as usize])
+            .collect::<Vec<_>>();
+        CudaError::from_result(_build_sparse_merkle_subtree(
+            d_data.as_mut_ptr(),
+            d_tree.as_mut_raw_ptr(),
+            d_labels.as_ptr(),
+            levels.as_ptr(),
+            base_height,
+            tree_height,
+            cell_type,
+            d_zero_hash.as_raw_ptr(),
+            stream,
+        ))
     }
 
     pub unsafe fn build_merkle_subtree<T>(
@@ -173,6 +216,8 @@ pub mod merkle_tree {
         subtree_layouts: &[u8],
         cell_types: &[u8],
         initial_data_ptrs: &[usize],
+        sparse_label_ptrs: &[usize],
+        sparse_level_ptrs: &[usize],
         unpadded_height: usize,
         hasher_buffer: &SharedBuffer<F>,
         device_ctx: &GpuDeviceCtx,
@@ -195,6 +240,8 @@ pub mod merkle_tree {
         let subtree_layouts = subtree_layouts.to_device_on(device_ctx).unwrap();
         let cell_types = cell_types.to_device_on(device_ctx).unwrap();
         let initial_data_ptrs = initial_data_ptrs.to_device_on(device_ctx).unwrap();
+        let sparse_label_ptrs = sparse_label_ptrs.to_device_on(device_ctx).unwrap();
+        let sparse_level_ptrs = sparse_level_ptrs.to_device_on(device_ctx).unwrap();
         let poseidon2_records = hasher_buffer.records();
         CudaError::from_result(_update_merkle_tree(
             num_leaves,
@@ -215,6 +262,8 @@ pub mod merkle_tree {
             subtree_layouts.as_ptr(),
             cell_types.as_ptr(),
             initial_data_ptrs.as_ptr(),
+            sparse_label_ptrs.as_ptr(),
+            sparse_level_ptrs.as_ptr(),
             poseidon2_records.as_mut_raw_ptr(),
             hasher_buffer.idx.as_mut_ptr(),
             // Length in F elements; the CUDA side converts to record count.

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -138,7 +138,7 @@ pub(crate) fn initial_merkle_build(
     let sparse_nodes = by_height.iter().map(Vec::len).sum::<usize>();
     let dense_height = log2_ceil_usize(dense_size);
     let dense_path_len = full_height - dense_height;
-    let dense_layout = MemoryMerkleSubTree::layout_for_height(dense_height);
+    let dense_layout = MemoryMerkleSubTreeLayout::dense(dense_height);
     let dense_nodes = MemoryMerkleSubTree::buffer_len(dense_size, dense_path_len, dense_layout);
     // Sparse nodes carry a u32 label and use binary-search lookup during updates. Require a
     // meaningful reduction rather than selecting sparse storage for small holes in a dense image.
@@ -191,12 +191,62 @@ impl SpanningNodeCounter {
     }
 }
 
+/// How a subtree's stored nodes are indexed within its digest buffer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
-enum MemoryMerkleSubTreeLayout {
-    Full = 0,
-    OmitBottomLevels = 1,
-    SparsePages = 2,
+enum SubTreeIndexing {
+    /// Heap-ordered: a node's slot is computed from its `(height, label)`.
+    Dense = 0,
+    /// Sorted per-height label index: a node's slot is found by binary search, and an absent label
+    /// means the node is the zero hash for its height.
+    Sparse = 1,
+}
+
+/// The two independent axes of a subtree's node storage: how the stored nodes are indexed, and how
+/// many bottom levels are left out of storage altogether.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MemoryMerkleSubTreeLayout {
+    indexing: SubTreeIndexing,
+    /// Lowest stored node height. Nodes below it are stored under neither indexing; they are
+    /// recomputed from `initial_data` on demand (`recompute_omitted_node` in `merkle_tree.cu`).
+    base_height: usize,
+}
+
+impl MemoryMerkleSubTreeLayout {
+    /// Layout of a dense subtree of conceptual height `height`. Bottom levels are omitted only
+    /// when the subtree is taller than the omitted region; a shorter one keeps every level, since
+    /// omitting them all would leave nothing but the root.
+    fn dense(height: usize) -> Self {
+        Self {
+            indexing: SubTreeIndexing::Dense,
+            base_height: if height > OMITTED_BOTTOM_LEVELS {
+                OMITTED_BOTTOM_LEVELS
+            } else {
+                0
+            },
+        }
+    }
+
+    fn sparse(base_height: usize) -> Self {
+        Self {
+            indexing: SubTreeIndexing::Sparse,
+            base_height,
+        }
+    }
+
+    /// Height of the stored heap of a dense subtree of conceptual height `height`.
+    fn stored_heap_height(&self, height: usize) -> usize {
+        debug_assert_eq!(
+            self.indexing,
+            SubTreeIndexing::Dense,
+            "sparse subtrees store no heap"
+        );
+        height - self.base_height
+    }
+
+    fn heap_len(&self, height: usize) -> usize {
+        2 * (1 << self.stored_heap_height(height)) - 1
+    }
 }
 
 /// A Merkle subtree stored in a single flat buffer, combining a vertical path and a heap-ordered
@@ -205,11 +255,11 @@ enum MemoryMerkleSubTreeLayout {
 /// Memory layout:
 /// - The first `path_len` elements form a vertical path (one node per level), used when the actual
 ///   size is smaller than the max size.
-/// - `Full` subtrees store the remaining nodes as the complete subtree heap.
-/// - `OmitBottomLevels` subtrees omit the bottom `OMITTED_BOTTOM_LEVELS` levels and store only the
-///   retained heap whose leaves are the first stored hashes above the omitted levels.
-/// - `SparsePages` subtrees store sorted `(height, label) -> digest` levels for touched pages and
-///   their ancestors; absent labels resolve to the precomputed zero hash for that height.
+/// - `Dense` subtrees store the remaining nodes as a heap whose leaves are the nodes at
+///   `layout.base_height`; the levels below that height are not stored.
+/// - `Sparse` subtrees store sorted `(height, label) -> digest` levels for touched pages and their
+///   ancestors, down to `layout.base_height`; absent labels resolve to the precomputed zero hash
+///   for that height.
 ///
 /// All GPU work is issued on the subtree's `GpuDeviceCtx` stream.
 /// `build_completion_event` records when the build kernels finish so that downstream consumers can
@@ -232,10 +282,10 @@ pub struct MemoryMerkleSubTree {
     /// the same range indexes the matching sparse-node digests in `buf`.
     sparse_levels: DeviceBuffer<[u32; 2]>,
     /// Shared handle to the initial-memory buffer (`d_data`) from [`Self::build_async`], or
-    /// `None` for empty/dummy subtrees. Co-owning the buffer keeps the host from freeing it: under
-    /// `OmitBottomLevels` and `SparsePages`, the omitted levels aren't in `buf` and are recomputed
-    /// from this buffer during [`MemoryMerkleTree::update_with_touched_blocks`]
-    /// (`recompute_omitted_node` in `merkle_tree.cu`).
+    /// `None` for empty/dummy subtrees. Co-owning the buffer keeps the host from freeing it: when
+    /// `layout.base_height > 0`, the levels below it aren't in `buf` and are recomputed from this
+    /// buffer during [`MemoryMerkleTree::update_with_touched_blocks`] (`recompute_omitted_node` in
+    /// `merkle_tree.cu`).
     ///
     /// This only covers host-side ownership; the buffer also feeds GPU kernels on the stream, so
     /// drop the subtrees (releasing these handles) only after the `stream.synchronize()` in
@@ -244,32 +294,12 @@ pub struct MemoryMerkleSubTree {
 }
 
 impl MemoryMerkleSubTree {
-    fn layout_for_height(height: usize) -> MemoryMerkleSubTreeLayout {
-        if height > OMITTED_BOTTOM_LEVELS {
-            MemoryMerkleSubTreeLayout::OmitBottomLevels
-        } else {
-            MemoryMerkleSubTreeLayout::Full
-        }
-    }
-
-    fn heap_len(height: usize, layout: MemoryMerkleSubTreeLayout) -> usize {
-        let retained_height = match layout {
-            MemoryMerkleSubTreeLayout::Full => height,
-            MemoryMerkleSubTreeLayout::OmitBottomLevels => height - OMITTED_BOTTOM_LEVELS,
-            MemoryMerkleSubTreeLayout::SparsePages => {
-                unreachable!("sparse buffers are sized by SparseMerklePlan")
-            }
-        };
-        2 * (1 << retained_height) - 1
-    }
-
     fn buffer_len(
         addr_space_size: usize,
         path_len: usize,
         layout: MemoryMerkleSubTreeLayout,
     ) -> usize {
-        let height = log2_ceil_usize(addr_space_size);
-        path_len + Self::heap_len(height, layout)
+        path_len + layout.heap_len(log2_ceil_usize(addr_space_size))
     }
 
     /// Constructs a new Merkle subtree with a vertical path and heap-ordered tree.
@@ -312,7 +342,7 @@ impl MemoryMerkleSubTree {
         }
         let height = log2_ceil_usize(addr_space_size);
         let path_len = log2_ceil_usize(max_size).checked_sub(height).unwrap();
-        let layout = Self::layout_for_height(height);
+        let layout = MemoryMerkleSubTreeLayout::dense(height);
         let buffer_len = Self::buffer_len(addr_space_size, path_len, layout);
         tracing::debug!(
             "Creating a subtree buffer, size is {} (addr space size is {})",
@@ -340,7 +370,7 @@ impl MemoryMerkleSubTree {
             height: 0,
             buf: DeviceBuffer::new(),
             path_len: 0,
-            layout: MemoryMerkleSubTreeLayout::Full,
+            layout: MemoryMerkleSubTreeLayout::dense(0),
             cell_type: GpuMemoryCellType::Unsupported,
             sparse_labels: DeviceBuffer::new(),
             sparse_levels: DeviceBuffer::new(),
@@ -369,25 +399,11 @@ impl MemoryMerkleSubTree {
             buf: DeviceBuffer::<H>::with_capacity_on(plan.labels.len(), device_ctx),
             height: full_height,
             path_len: 0,
-            layout: MemoryMerkleSubTreeLayout::SparsePages,
+            layout: MemoryMerkleSubTreeLayout::sparse(plan.base_height),
             cell_type,
             sparse_labels: plan.labels.to_device_on(device_ctx).unwrap(),
             sparse_levels: plan.levels.to_device_on(device_ctx).unwrap(),
             initial_data: None,
-        }
-    }
-
-    fn layout_tag(&self) -> u8 {
-        self.layout as u8
-    }
-
-    fn stored_heap_height(&self) -> usize {
-        match self.layout {
-            MemoryMerkleSubTreeLayout::Full => self.height,
-            MemoryMerkleSubTreeLayout::OmitBottomLevels => self.height - OMITTED_BOTTOM_LEVELS,
-            MemoryMerkleSubTreeLayout::SparsePages => {
-                unreachable!("sparse subtrees do not use heap height")
-            }
         }
     }
 
@@ -400,8 +416,8 @@ impl MemoryMerkleSubTree {
         device_ctx: &GpuDeviceCtx,
     ) {
         let event = CudaEvent::new().unwrap();
-        // Co-own the buffer; it must outlive `update_with_touched_blocks`, which re-reads it under
-        // the `OmitBottomLevels` layout (see the `initial_data` field).
+        // Co-own the buffer; it must outlive `update_with_touched_blocks`, which re-reads it when
+        // the layout omits bottom levels (see the `initial_data` field).
         self.initial_data = Some(d_data.clone());
         if self.buf.is_empty() {
             self.buf = DeviceBuffer::with_capacity_on(1, device_ctx);
@@ -419,11 +435,11 @@ impl MemoryMerkleSubTree {
             unsafe {
                 build_merkle_subtree(
                     &d_data,
-                    1 << self.stored_heap_height(),
+                    1 << self.layout.stored_heap_height(self.height),
                     &self.buf,
                     self.path_len,
                     self.cell_type as u8,
-                    self.layout_tag(),
+                    self.layout.base_height,
                     device_ctx.stream.as_raw(),
                 )
                 .unwrap();
@@ -459,7 +475,7 @@ impl MemoryMerkleSubTree {
                 &self.buf,
                 &self.sparse_labels,
                 &plan.levels,
-                plan.base_height,
+                self.layout.base_height,
                 self.height,
                 self.cell_type as u8,
                 zero_hash,
@@ -563,11 +579,10 @@ impl MemoryMerkleTree {
     /// unrepresented leaf to be all-zero, as guaranteed by the touched-page metadata.
     ///
     /// **Note:** the caller MUST ENSURE that `d_data` lives long enough to be there
-    /// when the enqueued task actually starts. Moreover, when the subtree uses the
-    /// `OmitBottomLevels` or `SparsePages` layout, `d_data` is also re-read during
-    /// [`Self::update_with_touched_blocks`] to recompute the omitted bottom levels, so it must
-    /// remain valid until that update completes — not just until the build kernel runs. See
-    /// [`MemoryMerkleSubTree`]'s `initial_data` field for details.
+    /// when the enqueued task actually starts. Moreover, when the subtree's layout omits bottom
+    /// levels, `d_data` is also re-read during [`Self::update_with_touched_blocks`] to recompute
+    /// them, so it must remain valid until that update completes — not just until the build kernel
+    /// runs. See [`MemoryMerkleSubTree`]'s `initial_data` field for details.
     pub(crate) fn build_async(
         &mut self,
         d_data: Arc<DeviceBuffer<u8>>,
@@ -667,10 +682,15 @@ impl MemoryMerkleTree {
             output.buffer().fill_zero_on(&self.device_ctx).unwrap();
 
             let actual_heights = self.subtrees.iter().map(|s| s.height).collect::<Vec<_>>();
-            let subtree_layouts = self
+            let subtree_indexings = self
                 .subtrees
                 .iter()
-                .map(|s| s.layout_tag())
+                .map(|s| s.layout.indexing as u8)
+                .collect::<Vec<_>>();
+            let subtree_base_heights = self
+                .subtrees
+                .iter()
+                .map(|s| s.layout.base_height as u8)
                 .collect::<Vec<_>>();
             let cell_types = self
                 .subtrees
@@ -708,7 +728,8 @@ impl MemoryMerkleTree {
                     d_touched_blocks,
                     self.height - log2_ceil_usize(self.subtrees.len()),
                     &actual_heights,
-                    &subtree_layouts,
+                    &subtree_indexings,
+                    &subtree_base_heights,
                     &cell_types,
                     &initial_data_ptrs,
                     &sparse_label_ptrs,
@@ -789,7 +810,7 @@ mod tests {
 
     use super::{
         initial_merkle_build, GpuMemoryCellType, InitialMerkleBuild, MemoryMerkleSubTree,
-        MemoryMerkleSubTreeLayout, MemoryMerkleTree, SpanningNodeCounter, OMITTED_BOTTOM_LEVELS,
+        MemoryMerkleTree, SpanningNodeCounter, SubTreeIndexing, OMITTED_BOTTOM_LEVELS,
     };
     use crate::{
         arch::testing::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
@@ -854,7 +875,8 @@ mod tests {
             GpuMemoryCellType::U16,
             &device_ctx,
         );
-        assert_eq!(below.layout, MemoryMerkleSubTreeLayout::Full);
+        assert_eq!(below.layout.indexing, SubTreeIndexing::Dense);
+        assert_eq!(below.layout.base_height, 0);
         assert_eq!(
             below.buf.len(),
             below.path_len + (2 * (1 << (OMITTED_BOTTOM_LEVELS - 1)) - 1)
@@ -866,7 +888,8 @@ mod tests {
             GpuMemoryCellType::U16,
             &device_ctx,
         );
-        assert_eq!(equal.layout, MemoryMerkleSubTreeLayout::Full);
+        assert_eq!(equal.layout.indexing, SubTreeIndexing::Dense);
+        assert_eq!(equal.layout.base_height, 0);
         assert_eq!(
             equal.buf.len(),
             equal.path_len + (2 * (1 << OMITTED_BOTTOM_LEVELS) - 1)
@@ -880,7 +903,8 @@ mod tests {
         );
         let full_len = above.path_len + (2 * (1 << (OMITTED_BOTTOM_LEVELS + 1)) - 1);
         let optimized_len = above.path_len + (2 * (1 << 1) - 1);
-        assert_eq!(above.layout, MemoryMerkleSubTreeLayout::OmitBottomLevels);
+        assert_eq!(above.layout.indexing, SubTreeIndexing::Dense);
+        assert_eq!(above.layout.base_height, OMITTED_BOTTOM_LEVELS);
         assert_eq!(above.buf.len(), optimized_len);
         assert!(above.buf.len() < full_len);
     }
@@ -983,18 +1007,11 @@ mod tests {
                 ),
             );
         }
-        assert_eq!(
-            gpu_merkle_tree.subtrees[REGISTER_AS as usize - 1].layout,
-            MemoryMerkleSubTreeLayout::OmitBottomLevels
-        );
-        assert_eq!(
-            gpu_merkle_tree.subtrees[MEMORY_AS as usize - 1].layout,
-            MemoryMerkleSubTreeLayout::OmitBottomLevels
-        );
-        assert_eq!(
-            gpu_merkle_tree.subtrees[DEFERRAL_AS as usize - 1].layout,
-            MemoryMerkleSubTreeLayout::OmitBottomLevels
-        );
+        for addr_space in [REGISTER_AS, MEMORY_AS, DEFERRAL_AS] {
+            let layout = gpu_merkle_tree.subtrees[addr_space as usize - 1].layout;
+            assert_eq!(layout.indexing, SubTreeIndexing::Dense);
+            assert_eq!(layout.base_height, OMITTED_BOTTOM_LEVELS);
+        }
         gpu_merkle_tree.finalize();
 
         let cpu_hasher_chip = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
@@ -1110,7 +1127,7 @@ mod tests {
     /// produced by the CPU `MemoryMerkleChip`. The CPU trace is known to satisfy the
     /// `MemoryMerkleAir` constraints (covered by the CPU-side merkle tests), so matching every
     /// row content-for-content implies the GPU emits the correct merkle trace. This exercises the
-    /// `OmitBottomLevels` trace-generation path, whose row contents (the reconstructed omitted
+    /// omitted-bottom-levels trace-generation path, whose row contents (the reconstructed omitted
     /// levels) are not checked by the root-equivalence test.
     ///
     /// The comparison is order-independent: the `MemoryMerkleAir` permits more than one valid row
@@ -1438,7 +1455,8 @@ mod tests {
         // into the dense equivalence tests.
         for addr_space in LARGE_AS {
             let subtree = &gpu_merkle_tree.subtrees[addr_space - 1];
-            assert_eq!(subtree.layout, MemoryMerkleSubTreeLayout::SparsePages);
+            assert_eq!(subtree.layout.indexing, SubTreeIndexing::Sparse);
+            assert_eq!(subtree.layout.base_height, OMITTED_BOTTOM_LEVELS);
         }
         gpu_merkle_tree.finalize();
 

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -76,6 +76,26 @@ pub(crate) fn touched_leaf_watermark(memory: &AddressMap, addr_sp: usize) -> usi
 /// root of eight raw-memory leaves. Touched 4 KiB pages therefore remain dense and coalesced while
 /// gaps between pages are represented by precomputed zero hashes. Dense-prefix construction stays
 /// preferable for the ordinary contiguous guest image because it avoids sparse labels and lookups.
+///
+/// An update path through a sparse subtree looks like this (illustrated for
+/// `OMITTED_BOTTOM_LEVELS = 3`):
+///
+/// stored root
+///       |
+/// sparse stored ancestors
+///       |
+/// stored height-4 ancestor
+/// /                       \
+/// stored height-3 node       zero_hash[3]
+/// |
+/// omitted heights 0, 1, and 2
+/// reconstructed from raw memory
+/// |
+/// touched 4 KiB page
+///
+/// `labels` stores only the left-hand nodes shown on this path (and analogous nodes for other
+/// touched pages). When a sibling label is absent, the CUDA update kernel substitutes the zero
+/// hash for that sibling's height.
 pub(crate) fn initial_merkle_build(
     memory: &AddressMap,
     addr_sp: usize,
@@ -201,7 +221,15 @@ pub struct MemoryMerkleSubTree {
     pub path_len: usize,
     layout: MemoryMerkleSubTreeLayout,
     cell_type: GpuMemoryCellType,
+    /// Flattened labels of every stored sparse node, grouped by descending height.
+    ///
+    /// For a given height, [`Self::sparse_levels`] selects the corresponding contiguous range.
+    /// The digest for each label is stored at the same index in `buf`.
     sparse_labels: DeviceBuffer<u32>,
+    /// Per-height index into [`Self::sparse_labels`], stored as `[start, count]`.
+    ///
+    /// This lets CUDA restrict its binary search for a `(height, label)` to that height's labels;
+    /// the same range indexes the matching sparse-node digests in `buf`.
     sparse_levels: DeviceBuffer<[u32; 2]>,
     /// Shared handle to the initial-memory buffer (`d_data`) from [`Self::build_async`], or
     /// `None` for empty/dummy subtrees. Co-owning the buffer keeps the host from freeing it: under

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -1326,6 +1326,14 @@ mod tests {
     /// initial root, final root, and full trace against the CPU reference.
     #[test]
     fn test_cuda_merkle_tree_sparse_pages_cpu_gpu_equivalence() {
+        // The address spaces filled to `max_cells`, spanning all three cell types: u16
+        // (MEMORY_AS), Field32 (DEFERRAL_AS), and u8 (PUBLIC_VALUES_AS).
+        const LARGE_AS: [usize; 3] = [
+            MEMORY_AS as usize,
+            DEFERRAL_AS as usize,
+            PUBLIC_VALUES_AS as usize,
+        ];
+
         let mut rng = create_seeded_rng();
         let mem_config = {
             let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
@@ -1333,8 +1341,9 @@ mod tests {
             let max_cells = 1 << max_ptr_bits;
             // REGISTER_AS uses u16 storage cells.
             addr_spaces[REGISTER_AS as usize].num_cells = 32 * size_of::<u64>() / U16_CELL_SIZE;
-            addr_spaces[MEMORY_AS as usize].num_cells = max_cells;
-            addr_spaces[DEFERRAL_AS as usize].num_cells = max_cells;
+            for addr_space in LARGE_AS {
+                addr_spaces[addr_space].num_cells = max_cells;
+            }
             MemoryConfig::new(2, addr_spaces, max_ptr_bits, 29, 17)
         };
 
@@ -1376,9 +1385,7 @@ mod tests {
                         }
                     }
                 }
-                if (idx == MEMORY_AS as usize || idx == DEFERRAL_AS as usize)
-                    && space.num_cells != 0
-                {
+                if LARGE_AS.contains(&idx) && space.num_cells != 0 {
                     let ptr = (space.num_cells - 1) as u32;
                     match space.layout {
                         MemoryCellType::U8 => initial_memory.write::<u8, 1>(idx as u32, ptr, [1]),
@@ -1429,7 +1436,7 @@ mod tests {
         }
         // The large address spaces must actually select page sparsity, or this test degenerates
         // into the dense equivalence tests.
-        for addr_space in [MEMORY_AS as usize, DEFERRAL_AS as usize] {
+        for addr_space in LARGE_AS {
             let subtree = &gpu_merkle_tree.subtrees[addr_space - 1];
             assert_eq!(subtree.layout, MemoryMerkleSubTreeLayout::SparsePages);
         }
@@ -1460,8 +1467,7 @@ mod tests {
                 let mut ptrs = Vec::new();
                 let num_leaves = cnf.num_cells / VM_DIGEST_WIDTH;
                 for j in 0..num_leaves {
-                    let is_last_large = j + 1 == num_leaves
-                        && (i == MEMORY_AS as usize || i == DEFERRAL_AS as usize);
+                    let is_last_large = j + 1 == num_leaves && LARGE_AS.contains(&i);
                     if is_last_large || rng.random_bool(0.333) {
                         ptrs.push((i as u32, (j * VM_DIGEST_WIDTH) as u32));
                     }

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -43,18 +43,19 @@ pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
 /// An update path through a sparse subtree looks like this (illustrated for
 /// `OMITTED_BOTTOM_LEVELS = 3`):
 ///
-/// stored root
-///       |
-/// sparse stored ancestors
-///       |
-/// stored height-4 ancestor
-/// /                       \
-/// stored height-3 node       zero_hash[3]
-/// |
-/// omitted heights 0, 1, and 2
-/// reconstructed from raw memory
-/// |
-/// touched 4 KiB page
+/// ```text
+///               stored root                   height = full_height
+///                    |
+///                    ⋮                        sparse stored ancestors
+///                    |
+///               stored node                   height 4
+///                /        \
+///       stored node      zero_hash[3]         height 3 = OMITTED_BOTTOM_LEVELS
+///            /\                               heights 2, 1, and 0 are never stored;
+///           /  \                              the update kernel rehashes them from
+///          /____\                             the raw memory of the touched page
+///    8 raw-memory leaves
+/// ```
 ///
 /// `labels` stores only the left-hand nodes shown on this path (and analogous nodes for other
 /// touched pages). When a sibling label is absent, the CUDA update kernel substitutes the zero

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -385,7 +385,15 @@ impl MemoryMerkleSubTree {
         cell_type: GpuMemoryCellType,
         device_ctx: &GpuDeviceCtx,
     ) -> Self {
-        debug_assert_eq!(plan.levels[full_height], [0, 1]);
+        // The subtree root is read from index 0, so the plan must terminate in exactly one node
+        // at `full_height`. This holds for every configured address space
+        // (`MemoryMerkleTree::new` bounds each leaf count by `1 << address_height`); check it
+        // unconditionally anyway, since the cost is one comparison per subtree build.
+        assert_eq!(
+            plan.levels[full_height],
+            [0, 1],
+            "sparse plan must have a single root at the full height"
+        );
         assert!(
             cell_type != GpuMemoryCellType::Unsupported,
             "nonempty CUDA memory address spaces require U8, U16, or Field32 cells"
@@ -521,6 +529,8 @@ impl MemoryMerkleTree {
         hasher_chip: Arc<Poseidon2PeripheryChipGPU>,
         device_ctx: GpuDeviceCtx,
     ) -> Self {
+        let label_max_bits = mem_config.memory_dimensions().address_height;
+
         let addr_space_sizes = mem_config
             .addr_spaces
             .iter()
@@ -529,7 +539,27 @@ impl MemoryMerkleTree {
                     ashc.num_cells % VM_DIGEST_WIDTH == 0,
                     "the number of cells must be divisible by `VM_DIGEST_WIDTH`"
                 );
-                ashc.num_cells / VM_DIGEST_WIDTH
+                let leaves = ashc.num_cells / VM_DIGEST_WIDTH;
+                // Both builders address raw memory in whole base nodes of
+                // `1 << OMITTED_BOTTOM_LEVELS` leaves, and the sparse planner rounds its last
+                // touched range up to one, so a leaf count that is not a power of two would let a
+                // base node read past the device buffer. Leaf counts below one base node are safe
+                // because such an address space fits in a single page, which
+                // `initial_merkle_build` always resolves to a dense prefix whose layout stores
+                // every level (see `MemoryMerkleSubTreeLayout::dense`).
+                assert!(
+                    leaves == 0 || leaves.is_power_of_two(),
+                    "address space needs {leaves} leaf digests, which must be a power of two; \
+                     check that every address space's `num_cells` is `VM_DIGEST_WIDTH` times a \
+                     power of two"
+                );
+                assert!(
+                    leaves <= 1 << label_max_bits,
+                    "address space needs {leaves} leaf digests but the tree supports at most {}; \
+                     check that every address space's `num_cells` fits within `pointer_max_bits`",
+                    1usize << label_max_bits
+                );
+                leaves
             })
             .collect::<Vec<_>>();
         assert!(!(addr_space_sizes.is_empty()), "Invalid config");
@@ -545,8 +575,6 @@ impl MemoryMerkleTree {
                 "The first `ADDR_SPACE_OFFSET` address spaces are assumed to be empty"
             );
         }
-
-        let label_max_bits = mem_config.memory_dimensions().address_height;
 
         let zero_hash = DeviceBuffer::<H>::with_capacity_on(label_max_bits + 1, &device_ctx);
         let top_roots = DeviceBuffer::<H>::with_capacity_on(2 * num_addr_spaces - 1, &device_ctx);
@@ -923,6 +951,39 @@ mod tests {
             GpuMemoryCellType::Unsupported,
             &device_ctx,
         );
+    }
+
+    /// Builds a tree over `mem_config`, which is only reached if every leaf count passes the
+    /// shape checks in [`MemoryMerkleTree::new`].
+    fn build_merkle_tree_for(mem_config: MemoryConfig) {
+        let device_ctx = GpuDeviceCtx {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        };
+        let hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(1, device_ctx.clone()));
+        let _ = MemoryMerkleTree::new(mem_config, hasher_chip, device_ctx);
+    }
+
+    /// A leaf count that is not a power of two would let the sparse planner round its last touched
+    /// range up to a base node that reads past the address space's device buffer.
+    #[test]
+    #[should_panic(expected = "leaf digests, which must be a power of two")]
+    fn test_non_power_of_two_leaf_count_is_rejected() {
+        let max_ptr_bits = 16;
+        let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
+        addr_spaces[MEMORY_AS as usize].num_cells = VM_DIGEST_WIDTH * ((1 << 10) + 1);
+        build_merkle_tree_for(MemoryConfig::new(2, addr_spaces, max_ptr_bits, 29, 17));
+    }
+
+    /// An address space larger than the configured tree would plan more than one node at the full
+    /// height, leaving the subtree root ambiguous.
+    #[test]
+    #[should_panic(expected = "but the tree supports at most")]
+    fn test_leaf_count_above_address_height_is_rejected() {
+        let max_ptr_bits = 16;
+        let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
+        addr_spaces[MEMORY_AS as usize].num_cells = VM_DIGEST_WIDTH << (max_ptr_bits + 1);
+        build_merkle_tree_for(MemoryConfig::new(2, addr_spaces, max_ptr_bits, 29, 17));
     }
 
     #[test]

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -33,6 +33,32 @@ pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + BLOCK_FE_WIDTH;
 pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + VM_DIGEST_WIDTH;
 pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
 
+/// Chooses between the fast dense-prefix builder and a page-dense, upper-level-sparse builder.
+///
+/// The sparse representation starts at height [`OMITTED_BOTTOM_LEVELS`], so each base node is the
+/// root of eight raw-memory leaves. Touched 4 KiB pages therefore remain dense and coalesced while
+/// gaps between pages are represented by precomputed zero hashes. Dense-prefix construction stays
+/// preferable for the ordinary contiguous guest image because it avoids sparse labels and lookups.
+///
+/// An update path through a sparse subtree looks like this (illustrated for
+/// `OMITTED_BOTTOM_LEVELS = 3`):
+///
+/// stored root
+///       |
+/// sparse stored ancestors
+///       |
+/// stored height-4 ancestor
+/// /                       \
+/// stored height-3 node       zero_hash[3]
+/// |
+/// omitted heights 0, 1, and 2
+/// reconstructed from raw memory
+/// |
+/// touched 4 KiB page
+///
+/// `labels` stores only the left-hand nodes shown on this path (and analogous nodes for other
+/// touched pages). When a sibling label is absent, the CUDA update kernel substitutes the zero
+/// hash for that sibling's height.
 #[derive(Debug)]
 pub(crate) enum InitialMerkleBuild {
     DensePrefix(usize),
@@ -70,32 +96,6 @@ pub(crate) fn touched_leaf_watermark(memory: &AddressMap, addr_sp: usize) -> usi
         .next_power_of_two()
 }
 
-/// Chooses between the fast dense-prefix builder and a page-dense, upper-level-sparse builder.
-///
-/// The sparse representation starts at height [`OMITTED_BOTTOM_LEVELS`], so each base node is the
-/// root of eight raw-memory leaves. Touched 4 KiB pages therefore remain dense and coalesced while
-/// gaps between pages are represented by precomputed zero hashes. Dense-prefix construction stays
-/// preferable for the ordinary contiguous guest image because it avoids sparse labels and lookups.
-///
-/// An update path through a sparse subtree looks like this (illustrated for
-/// `OMITTED_BOTTOM_LEVELS = 3`):
-///
-/// stored root
-///       |
-/// sparse stored ancestors
-///       |
-/// stored height-4 ancestor
-/// /                       \
-/// stored height-3 node       zero_hash[3]
-/// |
-/// omitted heights 0, 1, and 2
-/// reconstructed from raw memory
-/// |
-/// touched 4 KiB page
-///
-/// `labels` stores only the left-hand nodes shown on this path (and analogous nodes for other
-/// touched pages). When a sibling label is absent, the CUDA update kernel substitutes the zero
-/// hash for that sibling's height.
 pub(crate) fn initial_merkle_build(
     memory: &AddressMap,
     addr_sp: usize,

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -2,7 +2,11 @@ use std::{ffi::c_void, sync::Arc};
 
 use openvm_circuit::{
     arch::{AddressSpaceHostLayout, MemoryConfig, ADDR_SPACE_OFFSET, BLOCK_FE_WIDTH},
-    system::memory::{merkle::MemoryMerkleCols, online::LinearMemory, AddressMap},
+    system::memory::{
+        merkle::MemoryMerkleCols,
+        online::{LinearMemory, PAGE_SIZE},
+        AddressMap,
+    },
     utils::next_power_of_two_or_zero,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
@@ -29,6 +33,21 @@ pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + BLOCK_FE_WIDTH;
 pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + VM_DIGEST_WIDTH;
 pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
 
+#[derive(Debug)]
+pub(crate) enum InitialMerkleBuild {
+    DensePrefix(usize),
+    SparsePages(SparseMerklePlan),
+}
+
+#[derive(Debug)]
+pub(crate) struct SparseMerklePlan {
+    /// Node labels grouped by height, with the root first. Digests use the same ordering.
+    labels: Vec<u32>,
+    /// For each conceptual node height, `[start, count]` in `labels`.
+    levels: Vec<[u32; 2]>,
+    base_height: usize,
+}
+
 /// Number of leaf digests a subtree must store densely so that every page of `addr_sp` that may
 /// contain non-zero data lies inside it, rounded up to a power of two. Returns 0 for an empty
 /// address space and at least 1 otherwise, so that stored-node reads during
@@ -49,6 +68,77 @@ pub(crate) fn touched_leaf_watermark(memory: &AddressMap, addr_sp: usize) -> usi
     watermark_bytes
         .div_ceil(cell_size * VM_DIGEST_WIDTH)
         .next_power_of_two()
+}
+
+/// Chooses between the fast dense-prefix builder and a page-dense, upper-level-sparse builder.
+///
+/// The sparse representation starts at height [`OMITTED_BOTTOM_LEVELS`], so each base node is the
+/// root of eight raw-memory leaves. Touched 4 KiB pages therefore remain dense and coalesced while
+/// gaps between pages are represented by precomputed zero hashes. Dense-prefix construction stays
+/// preferable for the ordinary contiguous guest image because it avoids sparse labels and lookups.
+pub(crate) fn initial_merkle_build(
+    memory: &AddressMap,
+    addr_sp: usize,
+    full_height: usize,
+) -> InitialMerkleBuild {
+    let raw_len = memory.mem[addr_sp].as_slice().len();
+    let dense_size = touched_leaf_watermark(memory, addr_sp);
+    if raw_len == 0 || dense_size == 0 {
+        return InitialMerkleBuild::DensePrefix(dense_size);
+    }
+
+    let ranges = memory.touched_pages[addr_sp].touched_byte_ranges(raw_len);
+    if ranges.is_empty() || (ranges.len() == 1 && ranges[0].0 == 0) {
+        return InitialMerkleBuild::DensePrefix(dense_size);
+    }
+
+    let cell_size = memory.config[addr_sp].layout.size();
+    let leaf_bytes = cell_size * VM_DIGEST_WIDTH;
+    let base_leaf_count = 1usize << OMITTED_BOTTOM_LEVELS;
+    let base_node_bytes = leaf_bytes * base_leaf_count;
+    debug_assert_eq!(PAGE_SIZE % base_node_bytes, 0);
+
+    let mut by_height = vec![Vec::<u32>::new(); full_height + 1];
+    for (start, end) in ranges {
+        let first = start / base_node_bytes;
+        let last = end.div_ceil(base_node_bytes);
+        by_height[OMITTED_BOTTOM_LEVELS].extend((first..last).map(|label| label as u32));
+    }
+    by_height[OMITTED_BOTTOM_LEVELS].sort_unstable();
+    by_height[OMITTED_BOTTOM_LEVELS].dedup();
+    for height in OMITTED_BOTTOM_LEVELS + 1..=full_height {
+        let mut parents = by_height[height - 1]
+            .iter()
+            .map(|label| label >> 1)
+            .collect::<Vec<_>>();
+        parents.dedup();
+        by_height[height] = parents;
+    }
+
+    let sparse_nodes = by_height.iter().map(Vec::len).sum::<usize>();
+    let dense_height = log2_ceil_usize(dense_size);
+    let dense_path_len = full_height - dense_height;
+    let dense_layout = MemoryMerkleSubTree::layout_for_height(dense_height);
+    let dense_nodes = MemoryMerkleSubTree::buffer_len(dense_size, dense_path_len, dense_layout);
+    // Sparse nodes carry a u32 label and use binary-search lookup during updates. Require a
+    // meaningful reduction rather than selecting sparse storage for small holes in a dense image.
+    if sparse_nodes.saturating_mul(2) >= dense_nodes {
+        return InitialMerkleBuild::DensePrefix(dense_size);
+    }
+
+    let mut labels = Vec::with_capacity(sparse_nodes);
+    let mut levels = vec![[0u32; 2]; full_height + 1];
+    for height in (OMITTED_BOTTOM_LEVELS..=full_height).rev() {
+        let start = labels.len();
+        labels.extend_from_slice(&by_height[height]);
+        levels[height] = [start as u32, by_height[height].len() as u32];
+    }
+    debug_assert_eq!(levels[full_height], [0, 1]);
+    InitialMerkleBuild::SparsePages(SparseMerklePlan {
+        labels,
+        levels,
+        base_height: OMITTED_BOTTOM_LEVELS,
+    })
 }
 
 /// Exact number of distinct internal merkle nodes (heights `1..=tree_height`) on the
@@ -86,6 +176,7 @@ impl SpanningNodeCounter {
 enum MemoryMerkleSubTreeLayout {
     Full = 0,
     OmitBottomLevels = 1,
+    SparsePages = 2,
 }
 
 /// A Merkle subtree stored in a single flat buffer, combining a vertical path and a heap-ordered
@@ -97,6 +188,8 @@ enum MemoryMerkleSubTreeLayout {
 /// - `Full` subtrees store the remaining nodes as the complete subtree heap.
 /// - `OmitBottomLevels` subtrees omit the bottom `OMITTED_BOTTOM_LEVELS` levels and store only the
 ///   retained heap whose leaves are the first stored hashes above the omitted levels.
+/// - `SparsePages` subtrees store sorted `(height, label) -> digest` levels for touched pages and
+///   their ancestors; absent labels resolve to the precomputed zero hash for that height.
 ///
 /// All GPU work is issued on the subtree's `GpuDeviceCtx` stream.
 /// `build_completion_event` records when the build kernels finish so that downstream consumers can
@@ -108,11 +201,13 @@ pub struct MemoryMerkleSubTree {
     pub path_len: usize,
     layout: MemoryMerkleSubTreeLayout,
     cell_type: GpuMemoryCellType,
+    sparse_labels: DeviceBuffer<u32>,
+    sparse_levels: DeviceBuffer<[u32; 2]>,
     /// Shared handle to the initial-memory buffer (`d_data`) from [`Self::build_async`], or
     /// `None` for empty/dummy subtrees. Co-owning the buffer keeps the host from freeing it: under
-    /// `OmitBottomLevels` the omitted levels aren't in `buf` and are recomputed from this buffer
-    /// during [`MemoryMerkleTree::update_with_touched_blocks`] (`recompute_omitted_node` in
-    /// `merkle_tree.cu`).
+    /// `OmitBottomLevels` and `SparsePages`, the omitted levels aren't in `buf` and are recomputed
+    /// from this buffer during [`MemoryMerkleTree::update_with_touched_blocks`]
+    /// (`recompute_omitted_node` in `merkle_tree.cu`).
     ///
     /// This only covers host-side ownership; the buffer also feeds GPU kernels on the stream, so
     /// drop the subtrees (releasing these handles) only after the `stream.synchronize()` in
@@ -133,6 +228,9 @@ impl MemoryMerkleSubTree {
         let retained_height = match layout {
             MemoryMerkleSubTreeLayout::Full => height,
             MemoryMerkleSubTreeLayout::OmitBottomLevels => height - OMITTED_BOTTOM_LEVELS,
+            MemoryMerkleSubTreeLayout::SparsePages => {
+                unreachable!("sparse buffers are sized by SparseMerklePlan")
+            }
         };
         2 * (1 << retained_height) - 1
     }
@@ -202,6 +300,8 @@ impl MemoryMerkleSubTree {
             path_len,
             layout,
             cell_type,
+            sparse_labels: DeviceBuffer::new(),
+            sparse_levels: DeviceBuffer::new(),
             initial_data: None,
         }
     }
@@ -214,6 +314,37 @@ impl MemoryMerkleSubTree {
             path_len: 0,
             layout: MemoryMerkleSubTreeLayout::Full,
             cell_type: GpuMemoryCellType::Unsupported,
+            sparse_labels: DeviceBuffer::new(),
+            sparse_levels: DeviceBuffer::new(),
+            initial_data: None,
+        }
+    }
+
+    fn new_sparse(
+        full_height: usize,
+        plan: &SparseMerklePlan,
+        cell_type: GpuMemoryCellType,
+        device_ctx: &GpuDeviceCtx,
+    ) -> Self {
+        debug_assert_eq!(plan.levels[full_height], [0, 1]);
+        assert!(
+            cell_type != GpuMemoryCellType::Unsupported,
+            "nonempty CUDA memory address spaces require U8, U16, or Field32 cells"
+        );
+        tracing::debug!(
+            nodes = plan.labels.len(),
+            full_height,
+            "Creating a page-sparse subtree buffer"
+        );
+        Self {
+            build_completion_event: None,
+            buf: DeviceBuffer::<H>::with_capacity_on(plan.labels.len(), device_ctx),
+            height: full_height,
+            path_len: 0,
+            layout: MemoryMerkleSubTreeLayout::SparsePages,
+            cell_type,
+            sparse_labels: plan.labels.to_device_on(device_ctx).unwrap(),
+            sparse_levels: plan.levels.to_device_on(device_ctx).unwrap(),
             initial_data: None,
         }
     }
@@ -226,6 +357,9 @@ impl MemoryMerkleSubTree {
         match self.layout {
             MemoryMerkleSubTreeLayout::Full => self.height,
             MemoryMerkleSubTreeLayout::OmitBottomLevels => self.height - OMITTED_BOTTOM_LEVELS,
+            MemoryMerkleSubTreeLayout::SparsePages => {
+                unreachable!("sparse subtrees do not use heap height")
+            }
         }
     }
 
@@ -278,6 +412,33 @@ impl MemoryMerkleSubTree {
                 }
                 event.record(device_ctx.stream.as_raw()).unwrap();
             }
+        }
+        self.build_completion_event = Some(event);
+    }
+
+    fn build_sparse_async(
+        &mut self,
+        d_data: Arc<DeviceBuffer<u8>>,
+        plan: &SparseMerklePlan,
+        zero_hash: &DeviceBuffer<H>,
+        device_ctx: &GpuDeviceCtx,
+    ) {
+        let event = CudaEvent::new().unwrap();
+        self.initial_data = Some(d_data.clone());
+        unsafe {
+            build_sparse_merkle_subtree(
+                &d_data,
+                &self.buf,
+                &self.sparse_labels,
+                &plan.levels,
+                plan.base_height,
+                self.height,
+                self.cell_type as u8,
+                zero_hash,
+                device_ctx.stream.as_raw(),
+            )
+            .unwrap();
+            event.record(device_ctx.stream.as_raw()).unwrap();
         }
         self.build_completion_event = Some(event);
     }
@@ -370,43 +531,54 @@ impl MemoryMerkleTree {
     /// Here `addr_space` is the _unshifted_ address space, so `addr_space = 0` is the immediate
     /// address space, which should be ignored.
     ///
-    /// `addr_space_size` is the number of leaf digests to build and store densely — a power of
-    /// two (or zero for an empty address space) no larger than the address space's configured
-    /// leaf count. Every leaf of `d_data` at or beyond this watermark must be all-zero: the
-    /// stored subtree covers only the watermark prefix, the vertical path above it is folded
-    /// with zero hashes, and reads outside the prefix resolve to precomputed zero hashes
-    /// (`virtual_node_exists` in `merkle_tree.cu`). Passing [`touched_leaf_watermark`] makes the
-    /// build cost proportional to touched memory instead of the configured capacity.
+    /// `build` selects either a dense prefix or page-dense sparse construction. Both require every
+    /// unrepresented leaf to be all-zero, as guaranteed by the touched-page metadata.
     ///
     /// **Note:** the caller MUST ENSURE that `d_data` lives long enough to be there
     /// when the enqueued task actually starts. Moreover, when the subtree uses the
-    /// `OmitBottomLevels` layout, `d_data` is also re-read during
+    /// `OmitBottomLevels` or `SparsePages` layout, `d_data` is also re-read during
     /// [`Self::update_with_touched_blocks`] to recompute the omitted bottom levels, so it must
     /// remain valid until that update completes — not just until the build kernel runs. See
     /// [`MemoryMerkleSubTree`]'s `initial_data` field for details.
-    pub fn build_async(
+    pub(crate) fn build_async(
         &mut self,
         d_data: Arc<DeviceBuffer<u8>>,
         addr_space: usize,
-        addr_space_size: usize,
+        build: InitialMerkleBuild,
     ) {
         if addr_space < ADDR_SPACE_OFFSET as usize {
             return;
         }
         let addr_space_idx = addr_space - ADDR_SPACE_OFFSET as usize;
         if addr_space < self.mem_config.addr_spaces.len() && addr_space_idx == self.subtrees.len() {
-            assert!(
-                addr_space_size
-                    <= self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH,
-                "subtree size exceeds the address space's configured leaf count"
-            );
-            let mut subtree = MemoryMerkleSubTree::new(
-                addr_space_size,
-                1 << (self.zero_hash.len() - 1), /* label_max_bits */
-                self.mem_config.addr_spaces[addr_space].layout.into(),
-                &self.device_ctx,
-            );
-            subtree.build_async(d_data, &self.zero_hash, &self.device_ctx);
+            let full_height = self.zero_hash.len() - 1;
+            let cell_type = self.mem_config.addr_spaces[addr_space].layout.into();
+            let mut subtree = match &build {
+                InitialMerkleBuild::DensePrefix(addr_space_size) => {
+                    assert!(
+                        *addr_space_size
+                            <= self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH,
+                        "subtree size exceeds the address space's configured leaf count"
+                    );
+                    MemoryMerkleSubTree::new(
+                        *addr_space_size,
+                        1 << full_height, /* label_max_bits */
+                        cell_type,
+                        &self.device_ctx,
+                    )
+                }
+                InitialMerkleBuild::SparsePages(plan) => {
+                    MemoryMerkleSubTree::new_sparse(full_height, plan, cell_type, &self.device_ctx)
+                }
+            };
+            match &build {
+                InitialMerkleBuild::DensePrefix(_) => {
+                    subtree.build_async(d_data, &self.zero_hash, &self.device_ctx)
+                }
+                InitialMerkleBuild::SparsePages(plan) => {
+                    subtree.build_sparse_async(d_data, plan, &self.zero_hash, &self.device_ctx)
+                }
+            }
             self.subtrees.push(subtree);
         } else {
             panic!("Invalid address space ID");
@@ -482,6 +654,16 @@ impl MemoryMerkleTree {
                 .iter()
                 .map(|s| s.initial_data.as_ref().map_or(0, |b| b.as_ptr() as usize))
                 .collect::<Vec<_>>();
+            let sparse_label_ptrs = self
+                .subtrees
+                .iter()
+                .map(|s| s.sparse_labels.as_ptr() as usize)
+                .collect::<Vec<_>>();
+            let sparse_level_ptrs = self
+                .subtrees
+                .iter()
+                .map(|s| s.sparse_levels.as_ptr() as usize)
+                .collect::<Vec<_>>();
             let subtrees_pointers = self
                 .subtrees
                 .iter()
@@ -501,6 +683,8 @@ impl MemoryMerkleTree {
                     &subtree_layouts,
                     &cell_types,
                     &initial_data_ptrs,
+                    &sparse_label_ptrs,
+                    &sparse_level_ptrs,
                     unpadded_height,
                     &self.hasher_buffer,
                     &self.device_ctx,
@@ -576,9 +760,8 @@ mod tests {
     use rand::Rng;
 
     use super::{
-        touched_leaf_watermark, GpuMemoryCellType, MemoryMerkleSubTree, MemoryMerkleSubTreeLayout,
-        MemoryMerkleTree,
-        SpanningNodeCounter, OMITTED_BOTTOM_LEVELS,
+        initial_merkle_build, GpuMemoryCellType, InitialMerkleBuild, MemoryMerkleSubTree,
+        MemoryMerkleSubTreeLayout, MemoryMerkleTree, SpanningNodeCounter, OMITTED_BOTTOM_LEVELS,
     };
     use crate::{
         arch::testing::{MEMORY_MERKLE_BUS, POSEIDON2_DIRECT_BUS},
@@ -767,7 +950,9 @@ mod tests {
             gpu_merkle_tree.build_async(
                 mem_slice.clone(),
                 i,
-                mem_config.addr_spaces[i].num_cells / VM_DIGEST_WIDTH,
+                InitialMerkleBuild::DensePrefix(
+                    mem_config.addr_spaces[i].num_cells / VM_DIGEST_WIDTH,
+                ),
             );
         }
         assert_eq!(
@@ -977,7 +1162,9 @@ mod tests {
             gpu_merkle_tree.build_async(
                 mem_slice.clone(),
                 i,
-                mem_config.addr_spaces[i].num_cells / VM_DIGEST_WIDTH,
+                InitialMerkleBuild::DensePrefix(
+                    mem_config.addr_spaces[i].num_cells / VM_DIGEST_WIDTH,
+                ),
             );
         }
         gpu_merkle_tree.finalize();
@@ -1104,15 +1291,13 @@ mod tests {
         );
     }
 
-    /// Sparse-prefix variant of the equivalence tests: only a low prefix of each large address
-    /// space contains data, so the GPU subtrees are built only up to the touched-pages watermark
-    /// (`touched_leaf_watermark`) with a zero-hash vertical path above. The update then touches
-    /// blocks across the whole pointer range — including dirty and clean blocks *above* the
-    /// watermark, whose initial values resolve to precomputed zero hashes and whose path stores
-    /// land outside the stored prefix (skipped by `store_virtual_node`). Checks the initial root,
-    /// the final root, and the full trace against the CPU reference.
+    /// Page-sparse variant of the equivalence tests: the large address spaces contain a low prefix
+    /// and data in their final page. A prefix-only builder would therefore hash the entire address
+    /// space, while the page builder stores only those page subtrees and their ancestors. The
+    /// update then touches dirty and clean blocks across the whole pointer range. Checks the
+    /// initial root, final root, and full trace against the CPU reference.
     #[test]
-    fn test_cuda_merkle_tree_sparse_prefix_cpu_gpu_equivalence() {
+    fn test_cuda_merkle_tree_sparse_pages_cpu_gpu_equivalence() {
         let mut rng = create_seeded_rng();
         let mem_config = {
             let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
@@ -1125,8 +1310,8 @@ mod tests {
             MemoryConfig::new(2, addr_spaces, max_ptr_bits, 29, 17)
         };
 
-        // Fill REGISTER_AS fully and only a low prefix of the two large address spaces, so
-        // that the watermark truncates their subtrees (asserted below).
+        // Fill REGISTER_AS fully, plus a low prefix and the final cell of each large address
+        // space. The distant page forces selection of SparsePages (asserted below).
         let prefix_cells = 1 << 10;
         let mut initial_memory = GuestMemory::new(AddressMap::from_mem_config(&mem_config));
         for (idx, space) in mem_config.addr_spaces.iter().enumerate() {
@@ -1163,6 +1348,20 @@ mod tests {
                         }
                     }
                 }
+                if (idx == MEMORY_AS as usize || idx == DEFERRAL_AS as usize)
+                    && space.num_cells != 0
+                {
+                    let ptr = (space.num_cells - 1) as u32;
+                    match space.layout {
+                        MemoryCellType::U8 => initial_memory.write::<u8, 1>(idx as u32, ptr, [1]),
+                        MemoryCellType::U16 => initial_memory.write::<u16, 1>(idx as u32, ptr, [1]),
+                        MemoryCellType::U32 => initial_memory.write::<u32, 1>(idx as u32, ptr, [1]),
+                        MemoryCellType::F { .. } => {
+                            initial_memory.write::<F, 1>(idx as u32, ptr, [F::ONE])
+                        }
+                        MemoryCellType::Null => {}
+                    }
+                }
             }
         }
 
@@ -1193,17 +1392,18 @@ mod tests {
             gpu_merkle_tree.build_async(
                 mem_slice.clone(),
                 i,
-                touched_leaf_watermark(&initial_memory.memory, i),
+                initial_merkle_build(
+                    &initial_memory.memory,
+                    i,
+                    mem_config.memory_dimensions().address_height,
+                ),
             );
         }
-        // The large address spaces must actually be truncated, or this test degenerates into
-        // the dense equivalence tests.
+        // The large address spaces must actually select page sparsity, or this test degenerates
+        // into the dense equivalence tests.
         for addr_space in [MEMORY_AS as usize, DEFERRAL_AS as usize] {
             let subtree = &gpu_merkle_tree.subtrees[addr_space - 1];
-            assert!(
-                subtree.path_len > 0,
-                "watermark did not truncate AS {addr_space}"
-            );
+            assert_eq!(subtree.layout, MemoryMerkleSubTreeLayout::SparsePages);
         }
         gpu_merkle_tree.finalize();
 
@@ -1222,8 +1422,8 @@ mod tests {
             "initial roots diverge"
         );
 
-        // Touch ~1/3 of digest-aligned pointers across the WHOLE pointer range (most lie above
-        // the watermark), always including the very last leaf of the large address spaces.
+        // Touch ~1/3 of digest-aligned pointers across the whole pointer range, always including
+        // the very last leaf of the large address spaces.
         let touched_ptrs = mem_config
             .addr_spaces
             .iter()

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -1,8 +1,8 @@
 use std::{ffi::c_void, sync::Arc};
 
 use openvm_circuit::{
-    arch::{MemoryConfig, ADDR_SPACE_OFFSET, BLOCK_FE_WIDTH},
-    system::memory::merkle::MemoryMerkleCols,
+    arch::{AddressSpaceHostLayout, MemoryConfig, ADDR_SPACE_OFFSET, BLOCK_FE_WIDTH},
+    system::memory::{merkle::MemoryMerkleCols, online::LinearMemory, AddressMap},
     utils::next_power_of_two_or_zero,
 };
 use openvm_cuda_backend::{base::DeviceMatrix, prelude::F, GpuBackend};
@@ -28,6 +28,28 @@ pub const TIMESTAMPED_BLOCK_WIDTH: usize = 3 + BLOCK_FE_WIDTH;
 /// = 2 (key) + 1 (is_dirty) + VM_DIGEST_WIDTH (values); see `MemoryMerkleRecord`.
 pub const MERKLE_TOUCHED_BLOCK_WIDTH: usize = 3 + VM_DIGEST_WIDTH;
 pub(crate) const OMITTED_BOTTOM_LEVELS: usize = 3;
+
+/// Number of leaf digests a subtree must store densely so that every page of `addr_sp` that may
+/// contain non-zero data lies inside it, rounded up to a power of two. Returns 0 for an empty
+/// address space and at least 1 otherwise, so that stored-node reads during
+/// [`MemoryMerkleTree::update_with_touched_blocks`] stay in bounds. All leaves at or beyond the
+/// watermark are guaranteed zero (see
+/// [`TouchedPages`](openvm_circuit::system::memory::online::TouchedPages)), which is exactly the
+/// invariant [`MemoryMerkleTree::build_async`] requires of its `addr_space_size` argument.
+pub(crate) fn touched_leaf_watermark(memory: &AddressMap, addr_sp: usize) -> usize {
+    let raw_len = memory.mem[addr_sp].as_slice().len();
+    if raw_len == 0 {
+        return 0;
+    }
+    let cell_size = memory.config[addr_sp].layout.size();
+    let watermark_bytes = memory.touched_pages[addr_sp]
+        .touched_byte_ranges(raw_len)
+        .last()
+        .map_or(0, |&(_, end)| end);
+    watermark_bytes
+        .div_ceil(cell_size * VM_DIGEST_WIDTH)
+        .next_power_of_two()
+}
 
 /// Exact number of distinct internal merkle nodes (heights `1..=tree_height`) on the
 /// paths from a sorted stream of global leaf indices to the root: the first leaf's path
@@ -348,20 +370,38 @@ impl MemoryMerkleTree {
     /// Here `addr_space` is the _unshifted_ address space, so `addr_space = 0` is the immediate
     /// address space, which should be ignored.
     ///
+    /// `addr_space_size` is the number of leaf digests to build and store densely — a power of
+    /// two (or zero for an empty address space) no larger than the address space's configured
+    /// leaf count. Every leaf of `d_data` at or beyond this watermark must be all-zero: the
+    /// stored subtree covers only the watermark prefix, the vertical path above it is folded
+    /// with zero hashes, and reads outside the prefix resolve to precomputed zero hashes
+    /// (`virtual_node_exists` in `merkle_tree.cu`). Passing [`touched_leaf_watermark`] makes the
+    /// build cost proportional to touched memory instead of the configured capacity.
+    ///
     /// **Note:** the caller MUST ENSURE that `d_data` lives long enough to be there
     /// when the enqueued task actually starts. Moreover, when the subtree uses the
     /// `OmitBottomLevels` layout, `d_data` is also re-read during
     /// [`Self::update_with_touched_blocks`] to recompute the omitted bottom levels, so it must
     /// remain valid until that update completes — not just until the build kernel runs. See
     /// [`MemoryMerkleSubTree`]'s `initial_data` field for details.
-    pub fn build_async(&mut self, d_data: Arc<DeviceBuffer<u8>>, addr_space: usize) {
+    pub fn build_async(
+        &mut self,
+        d_data: Arc<DeviceBuffer<u8>>,
+        addr_space: usize,
+        addr_space_size: usize,
+    ) {
         if addr_space < ADDR_SPACE_OFFSET as usize {
             return;
         }
         let addr_space_idx = addr_space - ADDR_SPACE_OFFSET as usize;
         if addr_space < self.mem_config.addr_spaces.len() && addr_space_idx == self.subtrees.len() {
+            assert!(
+                addr_space_size
+                    <= self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH,
+                "subtree size exceeds the address space's configured leaf count"
+            );
             let mut subtree = MemoryMerkleSubTree::new(
-                self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH,
+                addr_space_size,
                 1 << (self.zero_hash.len() - 1), /* label_max_bits */
                 self.mem_config.addr_spaces[addr_space].layout.into(),
                 &self.device_ctx,
@@ -536,7 +576,8 @@ mod tests {
     use rand::Rng;
 
     use super::{
-        GpuMemoryCellType, MemoryMerkleSubTree, MemoryMerkleSubTreeLayout, MemoryMerkleTree,
+        touched_leaf_watermark, GpuMemoryCellType, MemoryMerkleSubTree, MemoryMerkleSubTreeLayout,
+        MemoryMerkleTree,
         SpanningNodeCounter, OMITTED_BOTTOM_LEVELS,
     };
     use crate::{
@@ -723,7 +764,11 @@ mod tests {
             })
             .collect::<Vec<_>>();
         for (i, mem_slice) in mem_slices.iter().enumerate() {
-            gpu_merkle_tree.build_async(mem_slice.clone(), i);
+            gpu_merkle_tree.build_async(
+                mem_slice.clone(),
+                i,
+                mem_config.addr_spaces[i].num_cells / VM_DIGEST_WIDTH,
+            );
         }
         assert_eq!(
             gpu_merkle_tree.subtrees[REGISTER_AS as usize - 1].layout,
@@ -929,7 +974,11 @@ mod tests {
             })
             .collect::<Vec<_>>();
         for (i, mem_slice) in mem_slices.iter().enumerate() {
-            gpu_merkle_tree.build_async(mem_slice.clone(), i);
+            gpu_merkle_tree.build_async(
+                mem_slice.clone(),
+                i,
+                mem_config.addr_spaces[i].num_cells / VM_DIGEST_WIDTH,
+            );
         }
         gpu_merkle_tree.finalize();
 
@@ -1053,5 +1102,261 @@ mod tests {
             gpu_rows, cpu_rows,
             "GPU merkle trace rows do not match the CPU reference trace"
         );
+    }
+
+    /// Sparse-prefix variant of the equivalence tests: only a low prefix of each large address
+    /// space contains data, so the GPU subtrees are built only up to the touched-pages watermark
+    /// (`touched_leaf_watermark`) with a zero-hash vertical path above. The update then touches
+    /// blocks across the whole pointer range — including dirty and clean blocks *above* the
+    /// watermark, whose initial values resolve to precomputed zero hashes and whose path stores
+    /// land outside the stored prefix (skipped by `store_virtual_node`). Checks the initial root,
+    /// the final root, and the full trace against the CPU reference.
+    #[test]
+    fn test_cuda_merkle_tree_sparse_prefix_cpu_gpu_equivalence() {
+        let mut rng = create_seeded_rng();
+        let mem_config = {
+            let mut addr_spaces = MemoryConfig::empty_address_space_configs(5);
+            let max_ptr_bits = 16;
+            let max_cells = 1 << max_ptr_bits;
+            // REGISTER_AS uses u16 storage cells.
+            addr_spaces[REGISTER_AS as usize].num_cells = 32 * size_of::<u64>() / U16_CELL_SIZE;
+            addr_spaces[MEMORY_AS as usize].num_cells = max_cells;
+            addr_spaces[DEFERRAL_AS as usize].num_cells = max_cells;
+            MemoryConfig::new(2, addr_spaces, max_ptr_bits, 29, 17)
+        };
+
+        // Fill REGISTER_AS fully and only a low prefix of the two large address spaces, so
+        // that the watermark truncates their subtrees (asserted below).
+        let prefix_cells = 1 << 10;
+        let mut initial_memory = GuestMemory::new(AddressMap::from_mem_config(&mem_config));
+        for (idx, space) in mem_config.addr_spaces.iter().enumerate() {
+            let num_filled = if idx == REGISTER_AS as usize {
+                space.num_cells
+            } else {
+                space.num_cells.min(prefix_cells)
+            };
+            unsafe {
+                match space.layout {
+                    MemoryCellType::Null => {}
+                    MemoryCellType::U8 => {
+                        for i in 0..num_filled {
+                            initial_memory.write::<u8, 1>(idx as u32, i as u32, [rng.random()]);
+                        }
+                    }
+                    MemoryCellType::U16 => {
+                        for i in 0..num_filled {
+                            initial_memory.write::<u16, 1>(idx as u32, i as u32, [rng.random()]);
+                        }
+                    }
+                    MemoryCellType::U32 => {
+                        for i in 0..num_filled {
+                            initial_memory.write::<u32, 1>(idx as u32, i as u32, [rng.random()]);
+                        }
+                    }
+                    MemoryCellType::F { .. } => {
+                        for i in 0..num_filled {
+                            initial_memory.write::<F, 1>(
+                                idx as u32,
+                                i as u32,
+                                [F::from_u32(rng.random_range(0..F::ORDER_U32))],
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let device_ctx = GpuDeviceCtx {
+            device_id: get_device().unwrap() as u32,
+            stream: StreamGuard::new(CudaStream::new_non_blocking().unwrap()),
+        };
+        let gpu_hasher_chip = Arc::new(Poseidon2PeripheryChipGPU::new(1, device_ctx.clone()));
+        let mut gpu_merkle_tree = MemoryMerkleTree::new(
+            mem_config.clone(),
+            gpu_hasher_chip.clone(),
+            device_ctx.clone(),
+        );
+        let mem_slices = initial_memory
+            .memory
+            .get_memory()
+            .iter()
+            .map(|mem| {
+                let mem_slice = mem.as_slice();
+                Arc::new(if !mem_slice.is_empty() {
+                    mem_slice.to_device_on(&gpu_merkle_tree.device_ctx).unwrap()
+                } else {
+                    DeviceBuffer::new()
+                })
+            })
+            .collect::<Vec<_>>();
+        for (i, mem_slice) in mem_slices.iter().enumerate() {
+            gpu_merkle_tree.build_async(
+                mem_slice.clone(),
+                i,
+                touched_leaf_watermark(&initial_memory.memory, i),
+            );
+        }
+        // The large address spaces must actually be truncated, or this test degenerates into
+        // the dense equivalence tests.
+        for addr_space in [MEMORY_AS as usize, DEFERRAL_AS as usize] {
+            let subtree = &gpu_merkle_tree.subtrees[addr_space - 1];
+            assert!(
+                subtree.path_len > 0,
+                "watermark did not truncate AS {addr_space}"
+            );
+        }
+        gpu_merkle_tree.finalize();
+
+        let cpu_hasher_chip = Poseidon2PeripheryChip::new(vm_poseidon2_config(), 3);
+        let cpu_merkle_tree = MerkleTree::<F, VM_DIGEST_WIDTH>::from_memory(
+            &initial_memory.memory,
+            &mem_config.memory_dimensions(),
+            &cpu_hasher_chip,
+        );
+        assert_eq!(
+            cpu_merkle_tree.root(),
+            gpu_merkle_tree
+                .top_roots
+                .to_host_on(&gpu_merkle_tree.device_ctx)
+                .unwrap()[0],
+            "initial roots diverge"
+        );
+
+        // Touch ~1/3 of digest-aligned pointers across the WHOLE pointer range (most lie above
+        // the watermark), always including the very last leaf of the large address spaces.
+        let touched_ptrs = mem_config
+            .addr_spaces
+            .iter()
+            .enumerate()
+            .flat_map(|(i, cnf)| {
+                let mut ptrs = Vec::new();
+                let num_leaves = cnf.num_cells / VM_DIGEST_WIDTH;
+                for j in 0..num_leaves {
+                    let is_last_large = j + 1 == num_leaves
+                        && (i == MEMORY_AS as usize || i == DEFERRAL_AS as usize);
+                    if is_last_large || rng.random_bool(0.333) {
+                        ptrs.push((i as u32, (j * VM_DIGEST_WIDTH) as u32));
+                    }
+                }
+                ptrs
+            })
+            .collect::<Vec<_>>();
+        let mut new_data = touched_ptrs
+            .iter()
+            .map(|_| std::array::from_fn(|_| F::from_u32(rng.random_range(0..F::ORDER_U32))))
+            .collect::<Vec<[F; VM_DIGEST_WIDTH]>>();
+        // Make every third touched leaf *clean* (final values equal to initial ones). Above the
+        // watermark the initial values are all zero, so this exercises clean zero-hash leaves.
+        for (i, (&(address_space, ptr), values)) in
+            touched_ptrs.iter().zip(new_data.iter_mut()).enumerate()
+        {
+            if i % 3 == 0 {
+                *values = std::array::from_fn(|j| unsafe {
+                    initial_memory
+                        .memory
+                        .get_f::<F>(address_space, ptr + j as u32)
+                });
+            }
+        }
+        let new_data = new_data;
+        assert!(!touched_ptrs.is_empty());
+
+        let mut cpu_merkle_chip = MemoryMerkleChip::<VM_DIGEST_WIDTH, F>::new(
+            mem_config.memory_dimensions(),
+            PermutationCheckBus::new(MEMORY_MERKLE_BUS),
+            PermutationCheckBus::new(POSEIDON2_DIRECT_BUS),
+        );
+        let final_partition: BTreeMap<(u32, u32), [F; VM_DIGEST_WIDTH]> = touched_ptrs
+            .iter()
+            .copied()
+            .zip(new_data.iter().copied())
+            .collect();
+        // Dirtiness is per *write*; the test scenario treats exactly the leaves whose
+        // values changed as written (the minimal valid dirty set).
+        let dirty_leaves: DirtyLeaves = final_partition
+            .iter()
+            .filter(|((address_space, ptr), values)| {
+                let init_values: [F; VM_DIGEST_WIDTH] = std::array::from_fn(|i| unsafe {
+                    initial_memory
+                        .memory
+                        .get_f::<F>(*address_space, *ptr + i as u32)
+                });
+                init_values != **values
+            })
+            .map(|(&key, _)| key)
+            .collect();
+        cpu_merkle_chip.finalize(
+            &initial_memory.memory,
+            &final_partition,
+            &dirty_leaves,
+            &cpu_hasher_chip,
+        );
+        let cpu_ctx = cpu_merkle_chip.generate_proving_ctx::<SC>();
+
+        let touched_blocks = touched_ptrs
+            .into_iter()
+            .zip(new_data)
+            .map(|(address, data)| {
+                (
+                    address,
+                    TimestampedValues {
+                        timestamp: rng.random_range(0..(1u32 << mem_config.timestamp_max_bits)),
+                        values: data,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let (merkle_records, unpadded_height) =
+            build_records_and_height(&initial_memory, &touched_blocks, &mem_config);
+        let d_touched_blocks = merkle_records
+            .to_device_on(&gpu_merkle_tree.device_ctx)
+            .unwrap();
+        gpu_hasher_chip.prepare_records(unpadded_height);
+        let merkle_ctx =
+            gpu_merkle_tree.update_with_touched_blocks(unpadded_height, &d_touched_blocks, false);
+
+        // Final roots and the full trace must match the CPU reference.
+        let gpu_final_root = gpu_merkle_tree
+            .top_roots
+            .to_host_on(&gpu_merkle_tree.device_ctx)
+            .unwrap()[0];
+        let width = cpu_ctx.common_main.width;
+        let height = cpu_ctx.common_main.values.len() / width;
+        let cpu_vals = &cpu_ctx.common_main.values;
+        // The CPU chip's final root is the parent hash of the height-section final root row
+        // (row 1 by the AIR's pinning of the first two rows).
+        let gpu_trace = &merkle_ctx.common_main;
+        assert_eq!(gpu_trace.width(), width, "trace width mismatch");
+        assert_eq!(gpu_trace.height(), height, "trace (padded) height mismatch");
+        let gpu_vals = gpu_trace
+            .buffer()
+            .to_host_on(&gpu_merkle_tree.device_ctx)
+            .unwrap();
+        let row_to_u32 = |get: &dyn Fn(usize, usize) -> F, r: usize| -> Vec<u32> {
+            (0..width).map(|c| get(r, c).as_canonical_u32()).collect()
+        };
+        let cpu_get = |r: usize, c: usize| cpu_vals[r * width + c];
+        let gpu_get = |r: usize, c: usize| gpu_vals[c * height + r];
+        let mut cpu_rows: Vec<Vec<u32>> = (0..height).map(|r| row_to_u32(&cpu_get, r)).collect();
+        let mut gpu_rows: Vec<Vec<u32>> = (0..height).map(|r| row_to_u32(&gpu_get, r)).collect();
+        cpu_rows.sort_unstable();
+        gpu_rows.sort_unstable();
+        assert_eq!(
+            gpu_rows, cpu_rows,
+            "GPU merkle trace rows do not match the CPU reference trace"
+        );
+        // Cross-check the final root through an independently finalized CPU tree.
+        let mut cpu_final_tree = MerkleTree::<F, VM_DIGEST_WIDTH>::from_memory(
+            &initial_memory.memory,
+            &mem_config.memory_dimensions(),
+            &cpu_hasher_chip,
+        );
+        cpu_final_tree.finalize(
+            &cpu_hasher_chip,
+            &final_partition,
+            &dirty_leaves,
+            &mem_config.memory_dimensions(),
+        );
+        assert_eq!(cpu_final_tree.root(), gpu_final_root, "final roots diverge");
     }
 }

--- a/crates/vm/src/system/memory/merkle/mod.rs
+++ b/crates/vm/src/system/memory/merkle/mod.rs
@@ -73,46 +73,53 @@ pub(crate) fn memory_to_vec_partition<F: PrimeField32, const N: usize>(
     memory: &AddressMap,
     md: &MemoryDimensions,
 ) -> Vec<(u64, [F; N])> {
-    (0..memory.mem.len())
+    let mut partition = (0..memory.mem.len())
         .into_par_iter()
         .map(move |as_idx| {
             let space_mem = memory.mem[as_idx].as_slice();
             let addr_space_layout = memory.config[as_idx].layout;
             let cell_size = addr_space_layout.size();
-            debug_assert_eq!(PAGE_SIZE % (cell_size * N), 0);
+            let leaf_bytes = cell_size * N;
+            debug_assert_eq!(PAGE_SIZE % leaf_bytes, 0);
 
-            let num_nonzero_pages = space_mem
-                .par_chunks(PAGE_SIZE)
-                .enumerate()
-                .filter_map(|(idx, page)| has_nonzero_byte(page).then_some(idx + 1))
-                .max()
-                .unwrap_or(0);
-
-            let space_mem = &space_mem[..(num_nonzero_pages * PAGE_SIZE).min(space_mem.len())];
-            let mut num_elements = space_mem.len() / (cell_size * N);
-            // virtual memory may be larger than dimensions due to rounding up to page size
-            num_elements = num_elements.min(1 << md.address_height);
-
-            (0..num_elements)
+            memory.touched_pages[as_idx]
+                .touched_byte_ranges(space_mem.len())
                 .into_par_iter()
-                .map(move |idx| {
-                    (
-                        md.label_to_index((as_idx as u32, idx as u32)),
-                        array::from_fn(|i| unsafe {
-                            // SAFETY: idx < num_elements = space_mem.len() / (cell_size * N) so ptr
-                            // is within bounds. We are reading one cell at a time, so alignment is
-                            // guaranteed.
-                            let ptr: *const u8 =
-                                space_mem.as_ptr().add(idx * cell_size * N + i * cell_size);
-                            addr_space_layout
-                                .to_field(&*core::ptr::slice_from_raw_parts(ptr, cell_size))
-                        }),
-                    )
+                .flat_map(|(start, end)| {
+                    debug_assert_eq!(start % leaf_bytes, 0);
+                    space_mem[start..end]
+                        .par_chunks(leaf_bytes)
+                        .enumerate()
+                        .filter_map(move |(local_idx, leaf)| {
+                            if leaf.len() != leaf_bytes || !has_nonzero_byte(leaf) {
+                                return None;
+                            }
+                            let byte_offset = start + local_idx * leaf_bytes;
+                            let leaf_idx = byte_offset / leaf_bytes;
+                            (leaf_idx < 1 << md.address_height).then(|| {
+                                (
+                                    md.label_to_index((as_idx as u32, leaf_idx as u32)),
+                                    array::from_fn(|i| unsafe {
+                                        // SAFETY: `byte_offset` identifies a complete leaf in
+                                        // `space_mem`, and `i < N`, so this cell-sized slice is
+                                        // entirely within that leaf.
+                                        addr_space_layout.to_field(
+                                            &*core::ptr::slice_from_raw_parts(
+                                                space_mem.as_ptr().add(byte_offset + i * cell_size),
+                                                cell_size,
+                                            ),
+                                        )
+                                    }),
+                                )
+                            })
+                        })
                 })
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>()
         .into_iter()
         .flatten()
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+    partition.sort_unstable_by_key(|(index, _)| *index);
+    partition
 }

--- a/crates/vm/src/system/memory/online.rs
+++ b/crates/vm/src/system/memory/online.rs
@@ -60,6 +60,11 @@ pub type Address = (u32, u32);
 pub trait LinearMemory {
     /// Create instance of `Self` with `size` bytes.
     fn new(size: usize) -> Self;
+    /// Clone into a zero-initialized mapping, copying only the supplied byte ranges.
+    ///
+    /// Callers must guarantee that bytes outside `ranges` are zero. This permits very large
+    /// logical address spaces to stay virtually reserved without faulting every page into RAM.
+    fn sparse_clone(&self, ranges: &[(usize, usize)]) -> Self;
     /// Allocated size of the memory in bytes.
     fn size(&self) -> usize;
     /// Returns the entire memory as a raw byte slice.
@@ -154,17 +159,41 @@ pub struct AddressMap<M: LinearMemory = MemoryBackend> {
     pub mem: Vec<M>,
     /// Host configuration for each address space.
     pub config: Vec<AddressSpaceHostConfig>,
-    /// Per-address-space record of which pages may contain non-zero data, used to skip all-zero
-    /// pages during the GPU host-to-device transfer. See [`TouchedPages`].
+    /// Per-address-space record of which pages may contain non-zero data, used by sparse
+    /// snapshots, CPU Merkle initialization, and the GPU host-to-device transfer. See
+    /// [`TouchedPages`].
     ///
     /// Invariant: any path that writes non-zero data into memory that may later be transferred via
     /// `set_initial_memory` must mark the written pages (`set_from_sparse`,
     /// `extend_touched_pages_from_touched`) or rebuild the metadata with
-    /// [`AddressMap::recompute_touched_pages`]. Unmarked pages are transferred as zero. The
-    /// untracked write paths (`get_memory_mut`, `GuestMemory::write`/`write_bytes`) do not mark,
-    /// so callers must recompute before transferring a memory image produced through those
-    /// paths.
+    /// [`AddressMap::recompute_touched_pages`]. Unmarked pages are treated as zero. Raw mutable
+    /// access through `get_memory_mut` does not mark pages, so callers must recompute after using
+    /// that escape hatch.
     pub touched_pages: Vec<TouchedPages>,
+}
+
+impl<M: LinearMemory> AddressMap<M> {
+    /// Clone only pages that may contain non-zero bytes into fresh zero-backed mappings.
+    ///
+    /// This is intended for immutable segment-start snapshots after all untracked writers have
+    /// updated or rebuilt `touched_pages`. Ordinary [`Clone`] remains an exact dense clone for
+    /// callers that cannot provide that invariant.
+    pub fn sparse_clone(&self) -> Self {
+        let mem = self
+            .mem
+            .iter()
+            .zip(&self.touched_pages)
+            .map(|(mem, touched)| {
+                let ranges = touched.touched_byte_ranges(mem.size());
+                mem.sparse_clone(&ranges)
+            })
+            .collect();
+        Self {
+            mem,
+            config: self.config.clone(),
+            touched_pages: self.touched_pages.clone(),
+        }
+    }
 }
 
 impl Default for AddressMap {
@@ -427,12 +456,17 @@ impl GuestMemory {
         T: Copy + Debug,
     {
         self.debug_assert_cell_type::<T>(addr_space);
+        let byte_start = (ptr as usize) * size_of::<T>();
         // SAFETY:
         // - alignment for `[T; BLOCK_SIZE]` is automatic since we multiply by `size_of::<T>()`
         self.memory
             .get_memory_mut()
             .get_unchecked_mut(addr_space as usize)
-            .write((ptr as usize) * size_of::<T>(), values);
+            .write(byte_start, values);
+        self.memory
+            .touched_pages
+            .get_unchecked_mut(addr_space as usize)
+            .mark_byte_range(byte_start, size_of::<T>() * BLOCK_SIZE);
     }
 
     /// Swaps `BLOCK_SIZE` AS-native cells starting at `ptr`.
@@ -449,12 +483,17 @@ impl GuestMemory {
         T: Copy + Debug,
     {
         self.debug_assert_cell_type::<T>(addr_space);
+        let byte_start = (ptr as usize) * size_of::<T>();
         // SAFETY:
         // - alignment for `[T; BLOCK_SIZE]` is automatic since we multiply by `size_of::<T>()`
         self.memory
             .get_memory_mut()
             .get_unchecked_mut(addr_space as usize)
-            .swap((ptr as usize) * size_of::<T>(), values);
+            .swap(byte_start, values);
+        self.memory
+            .touched_pages
+            .get_unchecked_mut(addr_space as usize)
+            .mark_byte_range(byte_start, size_of::<T>() * BLOCK_SIZE);
     }
 
     #[inline(always)]
@@ -534,6 +573,10 @@ impl GuestMemory {
             .get_memory_mut()
             .get_unchecked_mut(addr_space as usize)
             .write(byte_ptr as usize, values);
+        self.memory
+            .touched_pages
+            .get_unchecked_mut(addr_space as usize)
+            .mark_byte_range(byte_ptr as usize, N);
     }
 }
 
@@ -964,6 +1007,12 @@ impl TracingMemory {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(
+        target_os = "linux",
+        target_pointer_width = "64",
+        not(feature = "basic-memory")
+    ))]
+    use openvm_instructions::riscv::MEMORY_AS;
     use openvm_instructions::{riscv::REGISTER_AS, PUBLIC_VALUES_AS, VM_DIGEST_WIDTH};
     use openvm_stark_backend::p3_field::PrimeCharacteristicRing;
     use openvm_stark_sdk::p3_baby_bear::BabyBear;
@@ -975,6 +1024,84 @@ mod tests {
     };
 
     type F = BabyBear;
+
+    #[test]
+    fn sparse_clone_preserves_marked_pages_and_snapshot_independence() {
+        let config = vec![
+            AddressSpaceHostConfig::new(0, MemoryCellType::Null),
+            AddressSpaceHostConfig::new(4 * PAGE_SIZE, MemoryCellType::U8),
+        ];
+        let mut memory: AddressMap = AddressMap::new(config);
+        let mut sparse = SparseMemoryImage::new();
+        sparse.insert((1, 7), 11);
+        sparse.insert((1, (3 * PAGE_SIZE + 9) as u32), 22);
+        memory.set_from_sparse(&sparse);
+
+        let snapshot = memory.sparse_clone();
+        assert_eq!(snapshot.mem[1].as_slice()[7], 11);
+        assert_eq!(snapshot.mem[1].as_slice()[3 * PAGE_SIZE + 9], 22);
+        assert_eq!(snapshot.mem[1].as_slice()[2 * PAGE_SIZE], 0);
+
+        memory.mem[1].as_mut_slice()[7] = 99;
+        assert_eq!(snapshot.mem[1].as_slice()[7], 11);
+    }
+
+    #[cfg(all(
+        target_os = "linux",
+        target_pointer_width = "64",
+        not(feature = "basic-memory")
+    ))]
+    #[test]
+    fn sparse_clone_keeps_default_memory_backing_sparse_at_high_addresses() {
+        fn resident_pages(memory: &impl LinearMemory) -> usize {
+            let bytes = memory.size();
+            let mut residency = vec![0u8; bytes.div_ceil(PAGE_SIZE)];
+            let result = unsafe {
+                libc::mincore(
+                    memory.as_slice().as_ptr().cast_mut().cast(),
+                    bytes,
+                    residency.as_mut_ptr(),
+                )
+            };
+            assert_eq!(
+                result,
+                0,
+                "mincore failed: {}",
+                std::io::Error::last_os_error()
+            );
+            residency.into_iter().filter(|byte| byte & 1 != 0).count()
+        }
+
+        let mem_config = MemoryConfig::default();
+        let mut memory: AddressMap = AddressMap::from_mem_config(&mem_config);
+        // Highest addressable byte of the memory AS, derived from the configured size rather
+        // than hardcoded: the point is that touching the very top of the range must not
+        // materialize everything below it, whatever that range happens to be.
+        let high_addr = u32::try_from(memory.mem[MEMORY_AS as usize].size() - 1)
+            .expect("memory AS byte size must fit a u32 address");
+        let mut sparse = SparseMemoryImage::new();
+        sparse.insert((MEMORY_AS, 0), 11);
+        sparse.insert((MEMORY_AS, high_addr), 22);
+        memory.set_from_sparse(&sparse);
+
+        let snapshot = memory.sparse_clone();
+        let memory_backing = &snapshot.mem[MEMORY_AS as usize];
+        assert_eq!(memory_backing.as_slice()[0], 11);
+        assert_eq!(memory_backing.as_slice()[high_addr as usize], 22);
+        let partition = crate::system::memory::merkle::memory_to_vec_partition::<
+            BabyBear,
+            VM_DIGEST_WIDTH,
+        >(&snapshot, &mem_config.memory_dimensions());
+        assert_eq!(
+            partition.len(),
+            2,
+            "only two nonzero Merkle leaves should be built"
+        );
+        assert!(
+            resident_pages(memory_backing) < 1024,
+            "a sparse two-page snapshot should not materialize the full mapping"
+        );
+    }
 
     #[test]
     fn timed_accesses_append_minimal_u16_history() {

--- a/crates/vm/src/system/memory/online/basic.rs
+++ b/crates/vm/src/system/memory/online/basic.rs
@@ -120,6 +120,26 @@ impl LinearMemory for BasicMemory {
         Self { ptr, size, layout }
     }
 
+    fn sparse_clone(&self, ranges: &[(usize, usize)]) -> Self {
+        let cloned = Self::new(self.size);
+        for &(start, end) in ranges {
+            assert!(
+                start <= end && end <= self.size,
+                "sparse clone range out of bounds"
+            );
+            // SAFETY: both allocations are valid for `self.size` bytes and the checked range is
+            // within them. The allocations are distinct.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    self.ptr.as_ptr().add(start),
+                    cloned.ptr.as_ptr().add(start),
+                    end - start,
+                );
+            }
+        }
+        cloned
+    }
+
     fn size(&self) -> usize {
         self.size
     }

--- a/crates/vm/src/system/memory/online/guarded.rs
+++ b/crates/vm/src/system/memory/online/guarded.rs
@@ -203,6 +203,26 @@ impl LinearMemory for GuardedMemory {
         }
     }
 
+    fn sparse_clone(&self, ranges: &[(usize, usize)]) -> Self {
+        let mut cloned = Self::new(self.memory_size);
+        for &(start, end) in ranges {
+            assert!(
+                start <= end && end <= self.memory_size,
+                "sparse clone range out of bounds"
+            );
+            // SAFETY: both mappings are valid for `memory_size` bytes and the checked range is
+            // within them. The mappings are distinct.
+            unsafe {
+                core::ptr::copy_nonoverlapping(
+                    self.as_ptr().add(start),
+                    cloned.as_mut_ptr().add(start),
+                    end - start,
+                );
+            }
+        }
+        cloned
+    }
+
     fn size(&self) -> usize {
         self.memory_size
     }

--- a/crates/vm/src/system/memory/online/memmap.rs
+++ b/crates/vm/src/system/memory/online/memmap.rs
@@ -75,6 +75,18 @@ impl LinearMemory for MmapMemory {
         }
     }
 
+    fn sparse_clone(&self, ranges: &[(usize, usize)]) -> Self {
+        let mut cloned = Self::new(self.size);
+        for &(start, end) in ranges {
+            assert!(
+                start <= end && end <= self.size,
+                "sparse clone range out of bounds"
+            );
+            cloned.mmap[start..end].copy_from_slice(&self.mmap[start..end]);
+        }
+        cloned
+    }
+
     fn size(&self) -> usize {
         self.size
     }

--- a/crates/vm/src/system/memory/online/touched_pages.rs
+++ b/crates/vm/src/system/memory/online/touched_pages.rs
@@ -1,13 +1,13 @@
 use super::PAGE_SIZE;
 
-/// Tracks which fixed-size pages of an address space's linear memory may contain non-zero data,
-/// for the GPU host-to-device transfer. Pages that are *not* marked are guaranteed zero and are
-/// skipped by the transport (which zero-fills the device buffer first).
+/// Tracks which fixed-size pages of an address space's linear memory may contain non-zero data.
+/// Pages that are *not* marked are guaranteed zero and are skipped by sparse CPU snapshots,
+/// initial Merkle construction, and the GPU host-to-device transfer.
 /// Pages are [`PAGE_SIZE`] bytes, matching the mmap page size.
 ///
 /// A freshly constructed set is empty: callers must [`mark_byte_range`](Self::mark_byte_range)
-/// every page they write before the memory is transferred. Unmarked pages are transferred as
-/// zero. `bits` is a little-endian bitset over pages: bit `i` set means page `i` may be non-zero.
+/// every page they write before the memory is consumed. Unmarked pages are treated as zero.
+/// `bits` is a little-endian bitset over pages: bit `i` set means page `i` may be non-zero.
 #[derive(Debug, Clone)]
 pub struct TouchedPages {
     bits: Box<[u64]>,

--- a/crates/vm/src/system/mod.rs
+++ b/crates/vm/src/system/mod.rs
@@ -367,7 +367,7 @@ where
 
     fn transport_init_memory_to_device(&mut self, memory: &GuestMemory) {
         self.memory_controller
-            .set_initial_memory(memory.memory.clone());
+            .set_initial_memory(memory.memory.sparse_clone());
     }
 
     fn memory_top_tree(&self) -> Option<&[[Val<SC>; VM_DIGEST_WIDTH]]> {


### PR DESCRIPTION
Builds the initial memory image and the initial Merkle tree sparsely, so per-segment postflight cost scales with the pages a guest actually touches rather than with the configured address-space size.Observed per-segment initial-Merkle postflight time drops from ~221ms to ~2-22ms depending on how many pages a segment touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Perf bench: https://github.com/axiom-crypto/openvm-eth/actions/runs/31213205639

Closes INT-9124 and INT-8149 as well.
