### PR TITLE
fix: keep the dummy root-keygen app config self-consistent

### DIFF
--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -71,6 +71,11 @@ pub(crate) fn compute_root_proof_heights(
         MAX_APP_LOG_STACKED_HEIGHT,
     ));
     app_config.app_vm_config.system.config = system_config;
+    // The caller's system config may size `DEFERRAL_AS`, but this dummy config carries no deferral
+    // extension. Re-run the optimizations so the outer config matches the one the AIRs and chips
+    // are built from (`SdkVmConfig::to_inner`); otherwise the executor allocates a memory image
+    // for an address space the circuit treats as empty.
+    app_config.app_vm_config.apply_optimizations();
 
     let def_hook_cached_commit = deferral_setup.hook_cached_commit();
     let def_hook_commit = deferral_setup.hook_commit().map(Into::into);

--- a/crates/sdk/src/keygen/dummy.rs
+++ b/crates/sdk/src/keygen/dummy.rs
@@ -71,10 +71,6 @@ pub(crate) fn compute_root_proof_heights(
         MAX_APP_LOG_STACKED_HEIGHT,
     ));
     app_config.app_vm_config.system.config = system_config;
-    // The caller's system config may size `DEFERRAL_AS`, but this dummy config carries no deferral
-    // extension. Re-run the optimizations so the outer config matches the one the AIRs and chips
-    // are built from (`SdkVmConfig::to_inner`); otherwise the executor allocates a memory image
-    // for an address space the circuit treats as empty.
     app_config.app_vm_config.apply_optimizations();
 
     let def_hook_cached_commit = deferral_setup.hook_cached_commit();

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -189,10 +189,6 @@ pub fn compute_root_proof_heights(
         MAX_APP_LOG_STACKED_HEIGHT,
     ));
     app_config.app_vm_config.system.config = system_config;
-    // The caller's system config may size `DEFERRAL_AS`, but this dummy config carries no deferral
-    // extension. Re-run the optimizations so the outer config matches the one the AIRs and chips
-    // are built from (`SdkVmConfig::to_inner`); otherwise the executor allocates a memory image
-    // for an address space the circuit treats as empty.
     app_config.app_vm_config.apply_optimizations();
 
     let deferral_setup = match def_prover {

--- a/crates/sdk/src/prover/root.rs
+++ b/crates/sdk/src/prover/root.rs
@@ -189,6 +189,11 @@ pub fn compute_root_proof_heights(
         MAX_APP_LOG_STACKED_HEIGHT,
     ));
     app_config.app_vm_config.system.config = system_config;
+    // The caller's system config may size `DEFERRAL_AS`, but this dummy config carries no deferral
+    // extension. Re-run the optimizations so the outer config matches the one the AIRs and chips
+    // are built from (`SdkVmConfig::to_inner`); otherwise the executor allocates a memory image
+    // for an address space the circuit treats as empty.
+    app_config.app_vm_config.apply_optimizations();
 
     let deferral_setup = match def_prover {
         Some(def_prover) => DeferralSetup::Active(def_prover),

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -629,9 +629,6 @@ impl MemoryMerkleTree {
                 InitialMerkleBuild::DensePrefix(addr_space_size) => {
                     let configured_leaves =
                         self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH;
-                    // The size comes from the initial memory image, so a violation means the image
-                    // was built from a different `MemoryConfig` than this tree: check that the
-                    // executor and the circuit see the same address space sizes.
                     assert!(
                         *addr_space_size <= configured_leaves,
                         "address space {addr_space}: initial memory needs {addr_space_size} leaf \

--- a/crates/vm/src/system/cuda/merkle_tree/mod.rs
+++ b/crates/vm/src/system/cuda/merkle_tree/mod.rs
@@ -627,10 +627,15 @@ impl MemoryMerkleTree {
             let cell_type = self.mem_config.addr_spaces[addr_space].layout.into();
             let mut subtree = match &build {
                 InitialMerkleBuild::DensePrefix(addr_space_size) => {
+                    let configured_leaves =
+                        self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH;
+                    // The size comes from the initial memory image, so a violation means the image
+                    // was built from a different `MemoryConfig` than this tree: check that the
+                    // executor and the circuit see the same address space sizes.
                     assert!(
-                        *addr_space_size
-                            <= self.mem_config.addr_spaces[addr_space].num_cells / VM_DIGEST_WIDTH,
-                        "subtree size exceeds the address space's configured leaf count"
+                        *addr_space_size <= configured_leaves,
+                        "address space {addr_space}: initial memory needs {addr_space_size} leaf \
+                         digests but the address space is configured for {configured_leaves}"
                     );
                     MemoryMerkleSubTree::new(
                         *addr_space_size,


### PR DESCRIPTION
## Problem

`test_deferrals_enabled_without_usage` fails in the SDK CUDA job (`--features cuda,root-prover,...`) with:
```
panicked at crates/vm/src/system/cuda/merkle_tree/mod.rs:630:
subtree size exceeds the address space's configured leaf count
```

The panic is in the dummy app proof that root keygen runs (`compute_root_proof_heights` → `StarkProver::prove` → `transport_init_memory_to_device`), so it only reproduces with `root-prover` enabled. It was first seen on the stacked 2^32 branches, but it reproduces on `develop-v2.1.0` as well.

## Cause

`compute_root_proof_heights` builds its dummy app config from `AppConfig::riscv64`, which carries **no** deferral extension, and then overwrites `app_vm_config.system.config` with the caller's system config. When the real app VM enables deferrals, that config sizes `DEFERRAL_AS` (`1 << 14` cells).

From there the two halves of the VM disagree:

- **AIRs and chips** come from `SdkVmConfig::to_inner()`, which re-runs `apply_optimizations()`. With no deferral extension present that zeroes `DEFERRAL_AS`, so the Merkle tree is configured for **0** leaves in that address space.
- **The executor's memory image** comes from the outer config (`VirtualMachine::create_initial_state` → `config().as_ref()`), so it still allocates the full 64 KiB buffer.

Before #3112 the GPU subtree size was taken from the circuit's config, so the oversized (all-zero) image was silently ignored.

#3112 derives the dense-prefix size from the image's touched-page watermark instead, which is `≥ 1` for any non-empty buffer so the mismatch now trips the bound. 

## Fix

Re-run `apply_optimizations()` after the assignment at both copies of `compute_root_proof_heights` (`keygen/dummy.rs`, `prover/root.rs`) so the outer config matches the one the circuit is built from.

This does not move the app VK or any trace heights: `create_airs()` already went through `to_inner()`, so only the executor-side allocation changes, and the address space it drops was all-zero.

Also included: the assertion now names the address space and both leaf counts, since the old message did not say which address space diverged.

## Testing

- `cargo nextest run --cargo-profile=fast --features cuda,root-prover` in `crates/sdk` — 13/13 pass (was: `test_deferrals_enabled_without_usage` panicking).
- `cargo nextest run --cargo-profile=fast -p openvm-circuit --features cuda -E 'test(merkle)'` — 20/20 pass.

## Follow-up (not in this PR)

`SdkVmConfig` has an unwritten invariant that `config.as_ref()` must equal `config.to_inner().system`; mutating `system.config` after construction silently breaks it and the failure surfaces far away, in the GPU Merkle build. Worth considering a constructor or a debug assertion that enforces it.
