### PR TITLE
fix(toolchain): provide guest critical section

### DIFF
--- a/crates/toolchain/platform/Cargo.toml
+++ b/crates/toolchain/platform/Cargo.toml
@@ -16,7 +16,9 @@ openvm-riscv-guest.workspace = true
 # This crate should have as few dependencies as possible so it can be
 # used as many places as possible to share the platform definitions.
 [target.'cfg(all(target_arch = "riscv64", any(target_os = "none", target_os = "openvm")))'.dependencies]
-critical-section = { workspace = true, optional = true }
+# Provides the single-threaded guest implementation required by no_std crates
+# that use the `critical-section` interface (for example, `once_cell`).
+critical-section.workspace = true
 embedded-alloc = { version = "0.6.0", features = [
     "allocator_api",
 ], optional = true }
@@ -31,7 +33,6 @@ default = []
 entrypoint = []
 export-libm = ["dep:libm"]
 heap-embedded-alloc = [
-    "dep:critical-section",
     "dep:embedded-alloc",
     "rust-runtime",
 ]

--- a/crates/toolchain/platform/src/critical_section.rs
+++ b/crates/toolchain/platform/src/critical_section.rs
@@ -1,0 +1,20 @@
+//! No-op `critical-section` implementation for the OpenVM guest.
+//!
+//! The guest is single-threaded and has no interrupts, so mutual exclusion is
+//! vacuous. Registering the implementation at the platform level lets no_std
+//! dependencies use `critical-section` independently of the selected heap
+//! allocator.
+//!
+//! SAFETY: sound while the guest stays single-threaded; revisit if that changes.
+//! A second `set_impl!` in the linked binary fails at link time due to duplicate
+//! `_critical_section_1_0_{acquire,release}` symbols, so collisions are loud.
+
+use critical_section::RawRestoreState;
+
+struct SingleThreadedCriticalSection;
+critical_section::set_impl!(SingleThreadedCriticalSection);
+
+unsafe impl critical_section::Impl for SingleThreadedCriticalSection {
+    unsafe fn acquire() -> RawRestoreState {}
+    unsafe fn release(_token: RawRestoreState) {}
+}

--- a/crates/toolchain/platform/src/heap/embedded.rs
+++ b/crates/toolchain/platform/src/heap/embedded.rs
@@ -1,18 +1,10 @@
-use critical_section::RawRestoreState;
 use embedded_alloc::LlffHeap as Heap;
+
+// `embedded_alloc::LlffHeap` serializes allocator access via `critical_section`;
+// `crate::critical_section` registers the no-op implementation for the single-threaded guest.
 
 #[global_allocator]
 pub static HEAP: Heap = Heap::empty();
-
-// `embedded_alloc::LlffHeap` serializes allocator access via `critical_section`.
-// The guest is single-threaded, so the impl is a no-op.
-struct CriticalSection;
-critical_section::set_impl!(CriticalSection);
-
-unsafe impl critical_section::Impl for CriticalSection {
-    unsafe fn acquire() -> RawRestoreState {}
-    unsafe fn release(_token: RawRestoreState) {}
-}
 
 pub fn init() {
     extern "C" {

--- a/crates/toolchain/platform/src/lib.rs
+++ b/crates/toolchain/platform/src/lib.rs
@@ -8,6 +8,8 @@
 pub use openvm_custom_insn::{custom_insn_i, custom_insn_r};
 #[cfg(any(openvm_intrinsics, target_os = "openvm"))]
 pub mod alloc;
+#[cfg(any(openvm_intrinsics, target_os = "openvm"))]
+mod critical_section;
 #[cfg(all(feature = "rust-runtime", any(openvm_intrinsics, target_os = "openvm")))]
 pub mod heap;
 #[cfg(all(feature = "export-libm", any(openvm_intrinsics, target_os = "openvm")))]

--- a/extensions/riscv/tests/programs/Cargo.toml
+++ b/extensions/riscv/tests/programs/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", default-features = false, features = [
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 getrandom = { version = "0.3", optional = true }
 getrandom-v02 = { version = "0.2", package = "getrandom", optional = true }
+critical-section = { version = "1.2", default-features = false }
 
 [features]
 default = []

--- a/extensions/riscv/tests/programs/examples/critical-section.rs
+++ b/extensions/riscv/tests/programs/examples/critical-section.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(
+    all(not(feature = "std"), any(openvm_intrinsics, target_os = "openvm")),
+    no_main
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+openvm::entry!(main);
+
+pub fn main() {
+    critical_section::with(|_| {});
+}

--- a/extensions/riscv/tests/src/lib.rs
+++ b/extensions/riscv/tests/src/lib.rs
@@ -1879,6 +1879,21 @@ mod tests {
     }
 
     #[test]
+    fn test_critical_section() -> Result<()> {
+        let config = test_rv64im_config();
+        let elf = build_example_program_at_path(get_programs_dir!(), "critical-section", &config)?;
+        let exe = VmExe::from_elf(
+            elf,
+            Transpiler::<F>::default()
+                .with_extension(Rv64ITranspilerExtension)
+                .with_extension(Rv64MTranspilerExtension)
+                .with_extension(Rv64IoTranspilerExtension),
+        )?;
+        air_test(Rv64ImBuilder, config, exe);
+        Ok(())
+    }
+
+    #[test]
     fn test_tiny_mem_test() -> Result<()> {
         let config = test_rv64im_config();
         let elf = build_example_program_at_path_with_features(


### PR DESCRIPTION
## Summary

- register the no-op `critical-section` implementation at the OpenVM guest platform level
- keep it independent of the selected heap allocator
- add a guest link-and-execute regression

## Why

The guest is single-threaded, but no-std dependencies such as `once_cell` can require the `critical-section` symbols even when `heap-embedded-alloc` is disabled. Thin LTO exposed the missing symbols in the OpenVM-ETH stateless guest build.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo check -p openvm-platform --all-features`
- `cargo nextest run --cargo-profile=fast -p openvm-riscv-integration-tests test_critical_section --test-threads=1`
