### PR TITLE
chore: document full u32 PC and memory addresses

### DIFF
--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -11,10 +11,11 @@ As in v1, OpenVM v2 starts with a list of app segment proofs, which are generate
 
 ## Public Values
 
-The final internal-recursive proof will expose the following public values:
+The final internal-recursive proof will expose the following public values. Circuit program counters
+use the index `pc_idx = pc / DEFAULT_PC_STEP`.
 
 - `program_commit`: Program code commitment
-- `initial_pc_idx`: Initial circuit program counter index (`byte_pc / DEFAULT_PC_STEP`) at the start of app execution
+- `initial_pc_idx`: Initial circuit program counter index at the start of app execution
 - `final_pc_idx`: Final circuit program counter index after app execution
 - `exit_code`: Exit code after app execution
 - `is_terminate`: Flag to indicate whether the program terminated or not

--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -36,7 +36,7 @@ The user public values proof length is also checked against the baseline `num_us
 
 Given a fixed VM and executable, we must check certain exposed public values against a set of baseline artifacts (which can be generated ahead of time given the exe and VM, app, and aggregation configs).
 
-- `program_commit`, `initial_root`, and `initial_pc_idx` are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`. The executable's byte `pc_start` is divided by `DEFAULT_PC_STEP` before the resulting PC index is included in this commitment.
+- `program_commit`, `initial_root`, and `initial_pc_idx` (`pc_start / DEFAULT_PC_STEP`) are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`.
 - `app_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit` (each containing both `cached_commit` and `vk_pre_hash`) are compared against pre-computed baselines
 - `internal_recursive_vk_commit` is checked conditionally:
   - if `recursion_depth > 1`, it is compared against the pre-computed baseline
@@ -50,7 +50,7 @@ The other public values are checked for completeness.
 - `internal_flag` is checked to be 2, i.e. the final layer must be internal-recursive
 - `recursion_depth` is checked to be in `[1, 256]`
 
-Note there is no expected value for `final_pc_idx`, and thus it is left unchecked.
+`final_pc_idx` is not separately compared against a baseline expected value.
 
 **Deferral Validation:**
 

--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -14,8 +14,8 @@ As in v1, OpenVM v2 starts with a list of app segment proofs, which are generate
 The final internal-recursive proof will expose the following public values:
 
 - `program_commit`: Program code commitment
-- `initial_pc_idx`: Initial circuit PC index (`byte_pc / DEFAULT_PC_STEP`) at the start of app execution
-- `final_pc_idx`: Final circuit PC index after app execution
+- `initial_pc_idx`: Initial circuit program counter index (`byte_pc / DEFAULT_PC_STEP`) at the start of app execution
+- `final_pc_idx`: Final circuit program counter index after app execution
 - `exit_code`: Exit code after app execution
 - `is_terminate`: Flag to indicate whether the program terminated or not
 - `initial_root`: Merkle root of VM memory at the start of app execution
@@ -36,7 +36,7 @@ The user public values proof length is also checked against the baseline `num_us
 
 Given a fixed VM and executable, we must check certain exposed public values against a set of baseline artifacts (which can be generated ahead of time given the exe and VM, app, and aggregation configs).
 
-- `program_commit`, `initial_root`, and `initial_pc_idx` (`pc_start / DEFAULT_PC_STEP`) are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`.
+- `program_commit`, `initial_root`, and `initial_pc_idx` are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`.
 - `app_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit` (each containing both `cached_commit` and `vk_pre_hash`) are compared against pre-computed baselines
 - `internal_recursive_vk_commit` is checked conditionally:
   - if `recursion_depth > 1`, it is compared against the pre-computed baseline

--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -51,7 +51,7 @@ The other public values are checked for completeness.
 - `internal_flag` is checked to be 2, i.e. the final layer must be internal-recursive
 - `recursion_depth` is checked to be in `[1, 256]`
 
-`final_pc_idx` is not separately compared against a baseline expected value.
+Note there is no expected value for `final_pc_idx`, and thus it is left unchecked.
 
 **Deferral Validation:**
 

--- a/crates/verify/README.md
+++ b/crates/verify/README.md
@@ -14,8 +14,8 @@ As in v1, OpenVM v2 starts with a list of app segment proofs, which are generate
 The final internal-recursive proof will expose the following public values:
 
 - `program_commit`: Program code commitment
-- `initial_pc`: Initial program counter at the start of app execution
-- `final_pc`: Final program counter after app execution
+- `initial_pc_idx`: Initial circuit PC index (`byte_pc / DEFAULT_PC_STEP`) at the start of app execution
+- `final_pc_idx`: Final circuit PC index after app execution
 - `exit_code`: Exit code after app execution
 - `is_terminate`: Flag to indicate whether the program terminated or not
 - `initial_root`: Merkle root of VM memory at the start of app execution
@@ -36,7 +36,7 @@ The user public values proof length is also checked against the baseline `num_us
 
 Given a fixed VM and executable, we must check certain exposed public values against a set of baseline artifacts (which can be generated ahead of time given the exe and VM, app, and aggregation configs).
 
-- `program_commit`, `initial_root`, and `initial_pc` are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`.
+- `program_commit`, `initial_root`, and `initial_pc_idx` are hash-compressed and compared against a baseline `app_exe_commit`, which is derived from the `VmConfig`, `VmExe`, `MemoryConfig`, and application `SystemParams`. The executable's byte `pc_start` is divided by `DEFAULT_PC_STEP` before the resulting PC index is included in this commitment.
 - `app_vk_commit`, `leaf_vk_commit`, and `internal_for_leaf_vk_commit` (each containing both `cached_commit` and `vk_pre_hash`) are compared against pre-computed baselines
 - `internal_recursive_vk_commit` is checked conditionally:
   - if `recursion_depth > 1`, it is compared against the pre-computed baseline
@@ -50,7 +50,7 @@ The other public values are checked for completeness.
 - `internal_flag` is checked to be 2, i.e. the final layer must be internal-recursive
 - `recursion_depth` is checked to be in `[1, 256]`
 
-Note there is no expected value for `final_pc`, and thus it is left unchecked.
+Note there is no expected value for `final_pc_idx`, and thus it is left unchecked.
 
 **Deferral Validation:**
 

--- a/docs/crates/vm.md
+++ b/docs/crates/vm.md
@@ -73,7 +73,7 @@ Preflight uses the same opcode executors as pure and metered execution. Its
 execution context maintains read/write guest memory while appending two generic,
 chip-independent logs:
 
-- a program log containing `(timestamp, pc)` with a byte PC for every retired instruction and a
+- a program log containing `(timestamp, pc)` with the program counter for every retired instruction and a
   final sentinel;
 - a memory log containing each timed block access and its value, plus the
   first-write values required to reconstruct memory chronology.
@@ -125,7 +125,7 @@ execution bus. The memory bus is used to access memory, the program bus is used 
 and the execution bus is used to constrain the execution flow. These buses are derivable from the `SystemPort` struct,
 which is provided by `AirInventory`/`SystemAirInventory`.
 
-The program and execution buses use `pc_idx = byte_pc / DEFAULT_PC_STEP`. A sequential AIR
+The program and execution buses use the program counter index `pc_idx = pc / DEFAULT_PC_STEP`. A sequential AIR
 transition advances `pc_idx` by one.
 
 Memory-bus addresses contain an address space and a block index. Each block contains

--- a/docs/crates/vm.md
+++ b/docs/crates/vm.md
@@ -17,10 +17,6 @@ There is a `struct VmOpcode(usize)` to protect the global opcode `usize`, which 
 
 Pure execution runs the program without any overhead and is used to obtain the final VM state at termination, or after executing a fixed number of instructions.
 
-Interpreter execution states and executor APIs use aligned 32-bit byte program counters. Circuit
-execution states, trace columns, and bus messages use the 30-bit PC index
-`pc_idx = byte_pc / DEFAULT_PC_STEP`, which fits in one BabyBear field element.
-
 The `InterpreterExecutor<F>` trait defines the interface for pure execution (aliased as `Executor<F>` via a supertrait):
 
 ```rust
@@ -129,9 +125,13 @@ execution bus. The memory bus is used to access memory, the program bus is used 
 and the execution bus is used to constrain the execution flow. These buses are derivable from the `SystemPort` struct,
 which is provided by `AirInventory`/`SystemAirInventory`.
 
-The `pc_idx` carried by the program and execution buses is the circuit PC index. A sequential AIR
-transition advances it by one, corresponding to advancing the runtime byte PC by
-`DEFAULT_PC_STEP` bytes.
+The program and execution buses use `pc_idx = byte_pc / DEFAULT_PC_STEP`. A sequential AIR
+transition advances `pc_idx` by one.
+
+Memory-bus addresses contain an address space and a block index. Each block contains
+`BLOCK_FE_WIDTH` cells. In the RV64 register and memory address spaces, this is four u16 cells, or
+eight guest bytes. The default RV64 configuration supports 32-bit guest addresses; adapters reject
+accesses outside the configured pointer bound.
 
 The buses have very low-level APIs and are not intended to be used directly. "Bridges" are provided to provide a cleaner interface for
 sending interactions over the buses and enforcing additional constraints for soundness. The two system bridges are
@@ -139,9 +139,7 @@ sending interactions over the buses and enforcing additional constraints for sou
 
 ### Phantom Sub-Instructions
 
-Phantom sub-instructions are instructions that affect the runtime and trace matrix values but have
-no AIR constraints besides advancing `pc_idx` by one. They should not mutate memory, but they can
-mutate the input & hint streams.
+Phantom sub-instructions are instructions that affect the runtime and trace matrix values but have no AIR constraints besides advancing `pc_idx` by one. They should not mutate memory, but they can mutate the input & hint streams.
 
 You can specify phantom sub-instruction executors by implementing the trait:
 

--- a/docs/crates/vm.md
+++ b/docs/crates/vm.md
@@ -73,7 +73,7 @@ Preflight uses the same opcode executors as pure and metered execution. Its
 execution context maintains read/write guest memory while appending two generic,
 chip-independent logs:
 
-- a program log containing `(timestamp, pc)` with the program counter for every retired instruction and a
+- a program log containing `(timestamp, pc)` for every retired instruction and a
   final sentinel;
 - a memory log containing each timed block access and its value, plus the
   first-write values required to reconstruct memory chronology.

--- a/docs/crates/vm.md
+++ b/docs/crates/vm.md
@@ -17,6 +17,10 @@ There is a `struct VmOpcode(usize)` to protect the global opcode `usize`, which 
 
 Pure execution runs the program without any overhead and is used to obtain the final VM state at termination, or after executing a fixed number of instructions.
 
+Interpreter execution states and executor APIs use aligned 32-bit byte program counters. Circuit
+execution states, trace columns, and bus messages use the 30-bit PC index
+`pc_idx = byte_pc / DEFAULT_PC_STEP`, which fits in one BabyBear field element.
+
 The `InterpreterExecutor<F>` trait defines the interface for pure execution (aliased as `Executor<F>` via a supertrait):
 
 ```rust
@@ -73,7 +77,7 @@ Preflight uses the same opcode executors as pure and metered execution. Its
 execution context maintains read/write guest memory while appending two generic,
 chip-independent logs:
 
-- a program log containing `(timestamp, pc)` for every retired instruction and a
+- a program log containing `(timestamp, pc)` with a byte PC for every retired instruction and a
   final sentinel;
 - a memory log containing each timed block access and its value, plus the
   first-write values required to reconstruct memory chronology.
@@ -125,13 +129,19 @@ execution bus. The memory bus is used to access memory, the program bus is used 
 and the execution bus is used to constrain the execution flow. These buses are derivable from the `SystemPort` struct,
 which is provided by `AirInventory`/`SystemAirInventory`.
 
+The `pc_idx` carried by the program and execution buses is the circuit PC index. A sequential AIR
+transition advances it by one, corresponding to advancing the runtime byte PC by
+`DEFAULT_PC_STEP` bytes.
+
 The buses have very low-level APIs and are not intended to be used directly. "Bridges" are provided to provide a cleaner interface for
 sending interactions over the buses and enforcing additional constraints for soundness. The two system bridges are
 `MemoryBridge` and `ExecutionBridge`, which should respectively be used to constrain memory accesses and execution flow.
 
 ### Phantom Sub-Instructions
 
-Phantom sub-instructions are instructions that affect the runtime and trace matrix values but have no AIR constraints besides advancing the PC by `DEFAULT_PC_STEP`. They should not mutate memory, but they can mutate the input & hint streams.
+Phantom sub-instructions are instructions that affect the runtime and trace matrix values but have
+no AIR constraints besides advancing `pc_idx` by one. They should not mutate memory, but they can
+mutate the input & hint streams.
 
 You can specify phantom sub-instruction executors by implementing the trait:
 

--- a/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
+++ b/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
@@ -86,7 +86,7 @@ use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_ST
 </details>
 
 :::info
-When using Rust to write the guest program, keep the default `pointer_max_bits = 31`. This value counts u16 cells, so 31 bits covers the full 32-bit guest byte address space. Smaller values may reject valid guest memory addresses.
+When using Rust to write the guest program, the VM system configuration should keep the default value `pointer_max_bits = 31`. This value counts u16 cells, so 31 bits covers the full 32-bit guest byte address space. Otherwise, the guest program may fail due to out of bounds memory access in the VM.
 :::
 
 ## Building and Transpiling a Program

--- a/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
+++ b/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
@@ -86,7 +86,7 @@ use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_ST
 </details>
 
 :::info
-When using Rust to write the guest program, the VM system configuration should keep the default value `pointer_max_bits = 29` to match the hardcoded memory limit of the memory allocator. Otherwise, the guest program may fail due to out of bounds memory access in the VM.
+For Rust guest programs, keep the default `pointer_max_bits = 31`. Smaller values may reject valid 32-bit guest memory addresses.
 :::
 
 ## Building and Transpiling a Program

--- a/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
+++ b/docs/vocs/docs/pages/book/advanced-usage/sdk.mdx
@@ -86,7 +86,7 @@ use openvm_stark_sdk::config::{app_params_with_100_bits_security, MAX_APP_LOG_ST
 </details>
 
 :::info
-For Rust guest programs, keep the default `pointer_max_bits = 31`. Smaller values may reject valid 32-bit guest memory addresses.
+When using Rust to write the guest program, keep the default `pointer_max_bits = 31`. This value counts u16 cells, so 31 bits covers the full 32-bit guest byte address space. Smaller values may reject valid guest memory addresses.
 :::
 
 ## Building and Transpiling a Program

--- a/docs/vocs/docs/pages/book/writing-apps/writing-a-program.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/writing-a-program.mdx
@@ -25,7 +25,7 @@ let n: u64 = read();
 
 For debugging purposes, `openvm::io::print` and `openvm::io::println` can be used normally, but `println!` will only work if `std` is enabled.
 
-:::info
+:::warning
 With the default VM configuration, guest programs can address bytes in `[0, 2^32)`. Loads, stores, memory intrinsics, and heap allocations fail if they extend past this range.
 :::
 

--- a/docs/vocs/docs/pages/book/writing-apps/writing-a-program.mdx
+++ b/docs/vocs/docs/pages/book/writing-apps/writing-a-program.mdx
@@ -25,8 +25,8 @@ let n: u64 = read();
 
 For debugging purposes, `openvm::io::print` and `openvm::io::println` can be used normally, but `println!` will only work if `std` is enabled.
 
-:::warning
-The maximum memory address for an OpenVM program is `2^29`. The majority of that (approximately 480-500 MB depending on transpilation) is available to the guest program, but large reads may exceed the maximum memory and thus fail.
+:::info
+With the default VM configuration, guest programs can address bytes in `[0, 2^32)`. Loads, stores, memory intrinsics, and heap allocations fail if they extend past this range.
 :::
 
 ## Configuring OpenVM

--- a/docs/vocs/docs/pages/specs/architecture/circuit-architecture.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/circuit-architecture.mdx
@@ -35,7 +35,8 @@ AIRs, and global coherence comes from the buses plus the local AIR constraints.
 
 ## Execution flow
 
-A circuit _execution state_ consists of `pc_idx = byte_pc / DEFAULT_PC_STEP` and `timestamp`.
+A circuit _execution state_ consists of the program counter index
+`pc_idx = pc / DEFAULT_PC_STEP` and `timestamp`.
 
 Although we use sequential language below, a witness (a set of traces) is a static object. The AIR
 constraints and bus balancing conditions are designed so that from any valid witness one can extract

--- a/docs/vocs/docs/pages/specs/architecture/circuit-architecture.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/circuit-architecture.mdx
@@ -35,10 +35,7 @@ AIRs, and global coherence comes from the buses plus the local AIR constraints.
 
 ## Execution flow
 
-A circuit _execution state_ consists of `pc_idx` and `timestamp`. Runtime execution uses an aligned
-32-bit byte PC, while circuits use the 30-bit index
-`pc_idx = byte_pc / DEFAULT_PC_STEP`. Program- and execution-bus messages carry this index in one
-field element, and an ordinary four-byte instruction advances it by one.
+A circuit _execution state_ consists of `pc_idx = byte_pc / DEFAULT_PC_STEP` and `timestamp`.
 
 Although we use sequential language below, a witness (a set of traces) is a static object. The AIR
 constraints and bus balancing conditions are designed so that from any valid witness one can extract
@@ -46,11 +43,10 @@ a valid execution of the committed program whose boundary states match the publi
 standard cryptographic assumptions, the proof system ensures the verifier only accepts proofs for
 which such a witness exists.
 
-The connector AIR exposes the initial and final execution states of the segment as public values.
-The exposed `initial_pc_idx` and `final_pc_idx` values are single field elements. On the execution
-bus, the connector sends the initial execution state and receives the final execution state. If the
-segment terminates the whole program, the connector also constrains that `final_pc_idx` points to a
-`TERMINATE` instruction with the declared exit code.
+The connector AIR exposes the initial and final execution states of the segment as public values. On
+the execution bus, the connector sends the initial execution state and receives the final execution
+state. If the segment terminates the whole program, the connector also constrains that `final_pc_idx`
+points to a `TERMINATE` instruction with the declared exit code.
 
 For each instruction it handles, an instruction executor AIR receives an execution state from the
 bus and sends the next execution state back. It also looks up the instruction at that `pc_idx` on the
@@ -138,5 +134,5 @@ At the constraint level, a new instruction executor must:
 - [Ensure memory consistency](/specs/architecture/memory#what-to-take-into-account-when-adding-a-new-chip)
 - Constrain the semantics of every opcode family that your AIR handles.
 - Balance the relevant system buses for each logical instruction execution.
-- Update the execution state correctly, including the `pc` and `timestamp`.
+- Update the execution state correctly, including `pc_idx` and `timestamp`.
 - Preserve the timestamp-growth bound above, even if one logical instruction execution spans multiple trace rows.

--- a/docs/vocs/docs/pages/specs/architecture/circuit-architecture.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/circuit-architecture.mdx
@@ -35,7 +35,10 @@ AIRs, and global coherence comes from the buses plus the local AIR constraints.
 
 ## Execution flow
 
-An _execution state_ consists of `pc` and `timestamp`.
+A circuit _execution state_ consists of `pc_idx` and `timestamp`. Runtime execution uses an aligned
+32-bit byte PC, while circuits use the 30-bit index
+`pc_idx = byte_pc / DEFAULT_PC_STEP`. Program- and execution-bus messages carry this index in one
+field element, and an ordinary four-byte instruction advances it by one.
 
 Although we use sequential language below, a witness (a set of traces) is a static object. The AIR
 constraints and bus balancing conditions are designed so that from any valid witness one can extract
@@ -43,23 +46,24 @@ a valid execution of the committed program whose boundary states match the publi
 standard cryptographic assumptions, the proof system ensures the verifier only accepts proofs for
 which such a witness exists.
 
-The connector AIR exposes the initial and final execution states of the segment as public values. On
-the execution bus, the connector sends the initial execution state and receives the final execution
-state. If the segment terminates the whole program, the connector also constrains that `final_pc`
-points to a `TERMINATE` instruction with the declared exit code.
+The connector AIR exposes the initial and final execution states of the segment as public values.
+The exposed `initial_pc_idx` and `final_pc_idx` values are single field elements. On the execution
+bus, the connector sends the initial execution state and receives the final execution state. If the
+segment terminates the whole program, the connector also constrains that `final_pc_idx` points to a
+`TERMINATE` instruction with the declared exit code.
 
 For each instruction it handles, an instruction executor AIR receives an execution state from the
-bus and sends the next execution state back. It also looks up the instruction at that `pc` on the
+bus and sends the next execution state back. It also looks up the instruction at that `pc_idx` on the
 program bus, and the local AIR constraints check the semantics of the opcode family.
 
 Bus balancing forces these interactions to form a chain: the initial state sent by the connector
 is received by some instruction executor trace row, whose post-state is received by another
 instruction executor trace row, and so on, until the final state is received by the connector. The
-program bus pins each step to the instruction committed at that `pc`.
+program bus pins each step to the instruction committed at that `pc_idx`.
 
-The net effect is that a valid witness encodes a chain of instruction executions from `initial_pc`
-to `final_pc`. Large executions may be split into segments; continuations then relate the boundary
-states of adjacent segments. See
+The net effect is that a valid witness encodes a chain of instruction executions from
+`initial_pc_idx` to `final_pc_idx`. Large executions may be split into segments; continuations then
+relate the boundary states of adjacent segments. See
 [Continuations](/specs/architecture/continuations) for full details.
 
 ## Memory flow

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -170,8 +170,8 @@ There are 2 aggregation subcircuit types: **inner** and **root**. Each type has 
 
 App public values are the public values exposed by the app layer. They are propagated through all aggregation layers.
 
-- `initial_pc: F` — starting PC value of the program/segment
-- `final_pc: F` — final PC value of the program/segment
+- `initial_pc_idx: F` — circuit PC index at the start of the program/segment
+- `final_pc_idx: F` — circuit PC index at the end of the program/segment
 - `exit_code: F` — exit code of the program/segment
 - `is_terminate: F` — boolean flag indicating whether this segment terminated the program
 - `initial_root: Digest` — Merkle root of the initial memory state
@@ -179,7 +179,7 @@ App public values are the public values exposed by the app layer. They are propa
 
 All aggregation subcircuits enforce **segment adjacency** constraints on the app public values. Given several adjacent segments, the aggregation subcircuit constrains that:
 
-1. The `final_pc` and `final_root` of each non-terminal segment equal the `initial_pc` and `initial_root` of the segment immediately following it
+1. The `final_pc_idx` and `final_root` of each non-terminal segment equal the `initial_pc_idx` and `initial_root` of the segment immediately following it
 2. Non-terminal segments have `is_terminate == 0` and `exit_code == DEFAULT_SUSPEND_EXIT_CODE`
 3. The terminal segment has `is_terminate == 1` and `exit_code == ExitCode::Success`
 
@@ -247,7 +247,7 @@ The root subcircuit exposes a new set of public values for the static verifier. 
 - `app_exe_commit: Digest` — hashed combination of:
   - The app-level `ProgramAir` cached trace commit
   - The Merkle root of the starting app memory state (`initial_root`)
-  - The initial app program counter (`initial_pc`)
+  - The initial app PC index (`initial_pc_idx`)
 - `app_vm_commit: Digest` — commitment to the app VM verifier key, computed by hashing the 6 components of the child proof's app, leaf, and internal-for-leaf VK commits (`cached_commit` and `vk_pre_hash` for each) via `hash_slice`
 
 #### Constraints

--- a/docs/vocs/docs/pages/specs/architecture/continuations.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/continuations.mdx
@@ -170,8 +170,8 @@ There are 2 aggregation subcircuit types: **inner** and **root**. Each type has 
 
 App public values are the public values exposed by the app layer. They are propagated through all aggregation layers.
 
-- `initial_pc_idx: F` — circuit PC index at the start of the program/segment
-- `final_pc_idx: F` — circuit PC index at the end of the program/segment
+- `initial_pc_idx: F` — circuit program counter index at the start of the program/segment
+- `final_pc_idx: F` — circuit program counter index at the end of the program/segment
 - `exit_code: F` — exit code of the program/segment
 - `is_terminate: F` — boolean flag indicating whether this segment terminated the program
 - `initial_root: Digest` — Merkle root of the initial memory state

--- a/docs/vocs/docs/pages/specs/architecture/memory.mdx
+++ b/docs/vocs/docs/pages/specs/architecture/memory.mdx
@@ -13,7 +13,7 @@
 
 ---
 
-Chips in the VM need to perform memory read and write operations. The goal of memory checking is to ensure memory consistency across all chips. Every memory operation consists of an operation type (Read or Write), address (`address_space` and `pointer`), data, and timestamp. All memory operations across all chips should happen at distinct timestamps between $1$ and $2^{\text{timestamp\_max\_bits}}$ (in the current implementation, `timestamp_max_bits <= 29`). The memory boundary chip represents the initial memory state on the memory bus at timestamp $0$.
+Chips in the VM need to perform memory read and write operations. The goal of memory checking is to ensure memory consistency across all chips. Every memory operation consists of an operation type (Read or Write), address (`address_space` and `block_index`), data, and timestamp. Each block contains `BLOCK_FE_WIDTH` cells, and `block_index` is the aligned cell pointer divided by `BLOCK_FE_WIDTH`. All memory operations across all chips should happen at distinct timestamps between $1$ and $2^{\text{timestamp\_max\_bits}}$ (in the current implementation, `timestamp_max_bits <= 29`). The memory boundary chip represents the initial memory state on the memory bus at timestamp $0$.
 
 There is no single global memory trace. Instead, chips that access memory post interactions on the
 memory bus, and the boundary chips account for the initial and final memory states. The soundness
@@ -86,7 +86,9 @@ The memory boundary chip performs, for every touched memory chunk, a send intera
 The following invariants **must** be maintained by the memory architecture:
 1. In the MEMORY_BUS, the `timestamp` is always in range `[0, 2^timestamp_max_bits)` where `timestamp_max_bits <= F::bits() - 2` is a configuration constant.
 2. In the MEMORY_BUS, the `address_space` is always in range `[1, 1 + 2^addr_space_height)` where `addr_space_height` is a configuration constant satisfying `addr_space_height < F::bits() - 2`. (Our current implementation only supports `addr_space_height` less than the max bits supported by the VariableRangeCheckerBus).
-3. In the MEMORY_BUS, the `pointer` is always in range `[0, 2^pointer_max_bits)` where `pointer_max_bits <= F::bits() - 2` is a configuration constant.
+3. In the MEMORY_BUS, `block_index` lies in `[0, 2^(pointer_max_bits - log2(BLOCK_FE_WIDTH)))`. The current implementation supports `16 <= pointer_max_bits <= 32`; the default is 31.
+
+`pointer_max_bits` counts cells, not guest bytes. The default RV64 user-memory address space contains `2^31` u16 cells, covering `2^32` guest bytes.
 
 Invariant 1 is guaranteed by [time goes forward](#time-goes-forward) under the [assumption](/specs/architecture/circuit-architecture#instruction-executors) that the timestamp increase during a single logical instruction execution is bounded by `num_interactions * num_rows_per_execution`, where `num_interactions` is the number of interactions contributed by one trace row.
 

--- a/docs/vocs/docs/pages/specs/openvm/isa.mdx
+++ b/docs/vocs/docs/pages/specs/openvm/isa.mdx
@@ -28,8 +28,9 @@ OpenVM depends on the following parameters, some of which are fixed and some of 
 | Name                         | Description                                                        | Constraints                                                          |
 | ---------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
 | `F`                          | The field over which the VM operates.                              | Currently fixed to Baby Bear, but may change to another 31-bit field. |
-| `PC_BITS`                    | The number of bits in the program counter.                         | Fixed to 30.                                                         |
-| `DEFAULT_PC_STEP`            | The default program counter step size.                             | Fixed to 4.                                                          |
+| `PC_IDX_BITS`                | The number of bits in the circuit PC index.                        | Fixed to 30.                                                         |
+| `DEFAULT_PC_STEP`            | The byte distance between sequential instructions.                | Fixed to 4.                                                          |
+| `MAX_ALLOWED_PC`             | The greatest supported byte program counter.                       | Fixed to `2^32 - DEFAULT_PC_STEP = 0xffff_fffc`.                     |
 | `LIMB_BITS`                  | The number of bits in a limb for RISC-V memory emulation.          | Fixed to 8.                                                          |
 | `ADDR_SPACE_OFFSET`          | The index of the first writable address space.                     | Fixed to 1.                                                          |
 | `addr_space_height`          | The base 2 log of the number of writable address spaces supported. | Configurable, must satisfy `addr_space_height <= F::bits() - 2`      |
@@ -66,7 +67,7 @@ The state of the virtual machine consists of the following components:
 The **initial state** of the virtual machine consists of:
 
 - Program ROM - immutable throughout VM execution
-- `pc_0` - starting program counter
+- `pc_0` - starting byte program counter
 - Initial data memory
 - No user public outputs
 - Input stream
@@ -81,12 +82,14 @@ OpenVM operates under the Harvard architecture, where program code is stored sep
 memory. The program code is loaded as read-only memory (ROM) in the VM state prior to execution, and it remains
 immutable throughout the execution.
 
-Program code is a map from `[0, 2^PC_BITS)` to the space of instructions `F^{NUM_OPERANDS + 1}`, where
+Program code is a map from PC indices in `[0, 2^PC_IDX_BITS)` to the space of instructions
+`F^{NUM_OPERANDS + 1}`, where
 
-- `PC_BITS = 30`
+- `PC_IDX_BITS = 30`
 - `NUM_OPERANDS = 7`.
 
-Instructions will typically only exist at a subset of the indices in `[0, 2^PC_BITS)`.
+Index `pc_idx` corresponds to the aligned byte address `pc_idx * DEFAULT_PC_STEP`. Instructions
+will typically only exist at a subset of the indices in `[0, 2^PC_IDX_BITS)`.
 
 #### Instruction format
 
@@ -104,9 +107,21 @@ case, `d` is suggested to be set to `1`. This also may not be constrained, thoug
 
 ### Program Counter
 
-There is a single special purpose register `pc` for the program counter of type `F` which stores the location of the
-instruction being executed. During execution, the program counter must always be a valid program address, meaning that it
-is an element in the range `[0, 2^PC_BITS)` where the program code is defined.
+There is a single special purpose register `pc` for the program counter. It is a 32-bit byte address
+that must be a multiple of `DEFAULT_PC_STEP` and at most `MAX_ALLOWED_PC`, so the full aligned
+32-bit byte address space is supported.
+
+Because an arbitrary 32-bit value does not fit uniquely in one BabyBear element, circuits represent
+the byte PC by dividing out its two fixed alignment bits:
+
+```
+pc_idx = pc / DEFAULT_PC_STEP
+```
+
+The resulting 30-bit `pc_idx` fits in one field element. Program trace columns, program- and
+execution-bus messages, connector public values, and the executable commitment all carry the PC
+index. Runtime execution and preflight records continue to use byte PCs and convert at circuit
+boundaries.
 
 ### Data Memory
 
@@ -210,8 +225,10 @@ which must satisfy the following conditions:
 - The program counter is set to a new `to_pc` at the end of the instruction execution.
   Instructions are only considered valid if `to_pc` is the address of a valid instruction in the program ROM.
 
-ℹ️ Notes for extension developers: The specification of new instructions should carefully consider `to_pc` overflows, especially when you want to move `pc` with
-a positive offset.
+ℹ️ Notes for extension developers: Runtime execution and preflight records use byte PCs, while AIR
+trace columns and buses use `pc_idx = byte_pc / DEFAULT_PC_STEP`. Sequential AIR transitions advance
+`pc_idx` by one. New instructions must reject byte-PC overflow and any destination that is not
+`DEFAULT_PC_STEP`-aligned before converting it to an index.
 
 ### Guest Instruction Execution
 
@@ -243,8 +260,9 @@ new extension to be compatible with some extensions, you need select some compat
 
 ## OpenVM Instruction Set
 
-We now specify instructions supported by the default VM extensions shipping with OpenVM. Unless otherwise specified,
-instructions will set `to_pc = from_pc + DEFAULT_PC_STEP`. We will use the following notation:
+We now specify instructions supported by the default VM extensions shipping with OpenVM. Unless
+otherwise specified, instructions set `to_pc = from_pc + DEFAULT_PC_STEP`. We will use the
+following notation:
 
 - `u64(x)` where `x: [F; 8]` consists of 8 bytes will mean the casting from little-endian bytes in 2's complement to
   unsigned 64-bit integer.
@@ -380,27 +398,28 @@ For branch instructions, we fix `d = e = 1`. For jump instructions, we fix `d = 
 | BGE_RV64   | `a,b,c,1,1`      | `if(i64([a:8]_1) >= i64([b:8]_1)) pc += c`                                                                                                                                                                                                                                                                                                                                  |
 | BLTU_RV64  | `a,b,c,1,1`      | `if(u64([a:8]_1) < u64([b:8]_1)) pc += c`                                                                                                                                                                                                                                                                                                                                   |
 | BGEU_RV64  | `a,b,c,1,1`      | `if(u64([a:8]_1) >= u64([b:8]_1)) pc += c`                                                                                                                                                                                                                                                                                                                                  |
-| JAL_RV64   | `a,_,c,1,_,f`    | `if(f!=0) [a:8]_1 = sign_extend(decompose(pc+4)); pc += c`. The operand `f` is assumed to be boolean. The `pc` increment is always done regardless of `f`'s value. Here `i32(c)`must be in`[-2^24, 2^24)`.                                                                                                                                                                    |
-| JALR_RV64  | `a,b,c,1,_,f,g` | `if(f!=0) [a:8]_1 = zero_extend(decompose(pc+4)); pc = F::from_u32(u32([b:8]_1) + sign_extend(decompose(c)[0:2], g) as u32)`. Constrains that `u32([b:8]_1) + sign_extend(decompose(c)[0:2], g) is in [0, 2^PC_BITS)`. Here `u32(c)` must be in `[0, 2^16)`. The operands `f` and `g` are assumed to be boolean. The `pc` assignment is always done regardless of `f`'s value. |
-| LUI_RV64   | `a,_,c,1,_,1`    | `[a:8]_1 = sign_extend(u32(c) << 12)`. Here `i32(c)` must be in `[0, 2^20)`.                                                                                                                                                                                                                                                                                                |
-| AUIPC_RV64 | `a,_,c,1,_,_`    | `[a:8]_1 = sign_extend(decompose(pc) + (decompose(c) << 8))`. Here `i32(c)` must be in `[0, 2^24)`.                                                                                                                                                                                                                                                                        |
+| JAL_RV64   | `a,_,c,1,_,f`    | If `f!=0`, write the 64-bit link value `u64(pc) + 4` to `[a:8]_1`; then set `pc += c`. The operand `f` is assumed to be boolean. The PC update is always done regardless of `f`'s value. Here `i32(c)` must be in `[-2^24, 2^24)`. The target must remain in the 32-bit PC address space and be 4-byte aligned. |
+| JALR_RV64  | `a,b,c,1,_,f,g` | Let `raw_target = u32([b:8]_1) + sign_extend(decompose(c)[0:2], g)`. If `f!=0`, write the 64-bit link value `u64(pc) + 4` to `[a:8]_1`; then set `pc = raw_target & !1`. The operands `f` and `g` are assumed to be boolean. The PC update is always done regardless of `f`'s value. The masked target must be in the 32-bit PC address space and be 4-byte aligned. Here `u32(c)` must be in `[0, 2^16)`. |
+| LUI_RV64   | `a,_,c,1,_,1`    | `[a:8]_1 = sign_extend(u32(c) << 12)`. Here `i32(c)` must be in `[0, 2^20)`. |
+| AUIPC_RV64 | `a,_,c,1,_,_`    | `[a:8]_1 = u64(pc) + sign_extend(u32(c) << 8)`, computed as a 64-bit value. Here `i32(c)` must be in `[0, 2^24)`. |
 
-For branch and JAL_RV64 instructions, the instructions assume that the operand `i32(c)` is in `[-2^24,2^24)`. The
-assignment `pc += c` is done as field elements.
-In valid programs, the `from_pc` is always in `[0, 2^PC_BITS)`. We will only use base field `F` satisfying
-`2^PC_BITS + 2*2^24 < F::modulus()` so `to_pc = from_pc + c` is only valid if `i32(from_pc) + i32(c)` is in
-`[0, 2^PC_BITS)`.
+For branch and JAL_RV64 instructions, `i32(c)` is a signed byte offset in `[-2^24, 2^24)`.
+A taken target is valid only if integer addition places it in `[0, MAX_ALLOWED_PC]` on a
+`DEFAULT_PC_STEP`-aligned address. The circuit constrains
+`to_pc_idx = from_pc_idx + i32(c) / DEFAULT_PC_STEP`. A misaligned encoding is not rejected merely
+because it occurs in the executable's text, which may contain embedded data; it is rejected if
+execution actually uses it as a control-flow target.
 
 For JALR_RV64, we treat `c` in `[0, 2^16)` as a raw encoding of 16-bits.
 The operand `g` must be a boolean. We let `sign_extend(decompose(c)[0:2], g)` denote the `i32` defined by first taking
-the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering the 32 bits as the 2's complement of an `i32`. Then it is added to the register value `u32([b:8]_1)` (the upper 4 bytes of the 64-bit register must be zero), where 32-bit overflow is ignored. The instruction is only valid if the resulting `i32` is in range `[0, 2^PC_BITS)`. The
-result is then cast to `u32` and then to `F` and assigned to `pc`.
+the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering the 32 bits as the 2's complement of an `i32`. It is then added to the register value `u32([b:8]_1)` (the upper 4 bytes of the 64-bit register must be zero) without wrapping the implemented address space. JALR clears bit 0 before validation; bit 1 must be zero so that the resulting PC is 4-byte aligned. The circuit decomposes the resulting 30-bit PC index into a low 14-bit limb and a high 16-bit limb for this arithmetic.
 
 For LUI_RV64, we are treating `c` in `[0, 2^20)` as a raw encoding of 20-bits.
 For AUIPC_RV64, we are treating `c` in `[0, 2^24)` as a raw encoding of 24-bits.
 The instruction does not need to interpret whether the register is signed or unsigned.
-For AUIPC_RV64, the addition is treated as unchecked `u32` addition since that is the same as `i32` addition at the bit
-level. The result is sign-extended to 64 bits before writing to the register.
+For AUIPC_RV64, the circuit reconstructs the byte PC from `pc_idx` before adding the immediate.
+Negative results are sign-extended to 64 bits, while a positive carry becomes bit 32 of the
+64-bit result. For example, `0xfffffff8 + 0x1000 = 0x1_00000ff8` is valid.
 
 Note that AUIPC_RV64 does not have any condition for the register write.
 

--- a/docs/vocs/docs/pages/specs/openvm/isa.mdx
+++ b/docs/vocs/docs/pages/specs/openvm/isa.mdx
@@ -30,7 +30,7 @@ OpenVM depends on the following parameters, some of which are fixed and some of 
 | `F`                          | The field over which the VM operates.                              | Currently fixed to Baby Bear, but may change to another 31-bit field. |
 | `PC_IDX_BITS`                | The number of bits in the circuit PC index.                        | Fixed to 30.                                                         |
 | `DEFAULT_PC_STEP`            | The byte distance between sequential instructions.                 | Fixed to 4.                                                          |
-| `MAX_ALLOWED_PC`             | The greatest supported byte program counter.                       | Fixed to `2^32 - DEFAULT_PC_STEP = 0xffff_fffc`.                     |
+| `MAX_ALLOWED_PC`             | The greatest supported program counter.                            | Fixed to `2^32 - DEFAULT_PC_STEP = 0xffff_fffc`.                     |
 | `LIMB_BITS`                  | The number of bits in a limb for RISC-V memory emulation.          | Fixed to 8.                                                          |
 | `ADDR_SPACE_OFFSET`          | The index of the first writable address space.                     | Fixed to 1.                                                          |
 | `addr_space_height`          | The base 2 log of the number of writable address spaces supported. | Configurable, must satisfy `addr_space_height <= F::bits() - 2`      |
@@ -67,7 +67,7 @@ The state of the virtual machine consists of the following components:
 The **initial state** of the virtual machine consists of:
 
 - Program ROM - immutable throughout VM execution
-- `pc_0` - starting byte program counter
+- `pc_0` - starting program counter
 - Initial data memory
 - No user public outputs
 - Input stream
@@ -206,7 +206,7 @@ a transition function on the mutable parts of the VM state:
 
 which must satisfy the following conditions:
 
-- Let `from_pc` be the byte program counter at the start of instruction execution. It must be the
+- Let `from_pc` be the program counter at the start of instruction execution. It must be the
   byte address of a valid instruction in the program ROM.
 - The execution must match the instruction from the program ROM.
 - The execution has full read/write access to the data memory, except address space `0` must be read-only.
@@ -215,11 +215,11 @@ which must satisfy the following conditions:
 - Full read/write access to the hint stream.
 - Deferral states are pre-computed at initialization with input-to-raw-input mappings. During execution, deferral
   functions may update a `DeferralState` by storing raw outputs and their commitments, which are as specified [here](/specs/architecture/deferral).
-- The byte program counter is set to a new `to_pc` at the end of instruction execution.
+- The program counter is set to a new `to_pc` at the end of instruction execution.
   Instructions are only considered valid if `to_pc` is the byte address of a valid instruction in the program ROM.
 
-ℹ️ Notes for extension developers: Runtime execution uses byte PCs, while AIR traces and buses use
-`pc_idx`. New instructions must reject overflow and misalignment before converting a byte PC to an index.
+ℹ️ Notes for extension developers: Runtime execution uses program counters, while AIR traces and buses use
+`pc_idx`. New instructions must reject overflow and misalignment before converting a program counter to an index.
 
 ### Guest Instruction Execution
 

--- a/docs/vocs/docs/pages/specs/openvm/isa.mdx
+++ b/docs/vocs/docs/pages/specs/openvm/isa.mdx
@@ -117,7 +117,7 @@ pc_idx = pc / DEFAULT_PC_STEP
 ### Data Memory
 
 Data memory is a random access memory (RAM) which supports read and write operations. Memory is comprised of addressable
-cells which represent a single field element indexed by **address space** and **cell pointer**.
+cells indexed by **address space** and **cell pointer**. The number of bits stored in a cell depends on the address space.
 The number of supported address spaces, the cell layout, and the size of each address space are configurable.
 
 - Valid address spaces not used for immediates lie in `[1, 1 + 2^addr_space_height)` for configuration constant `addr_space_height`.

--- a/docs/vocs/docs/pages/specs/openvm/isa.mdx
+++ b/docs/vocs/docs/pages/specs/openvm/isa.mdx
@@ -29,12 +29,12 @@ OpenVM depends on the following parameters, some of which are fixed and some of 
 | ---------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------- |
 | `F`                          | The field over which the VM operates.                              | Currently fixed to Baby Bear, but may change to another 31-bit field. |
 | `PC_IDX_BITS`                | The number of bits in the circuit PC index.                        | Fixed to 30.                                                         |
-| `DEFAULT_PC_STEP`            | The byte distance between sequential instructions.                | Fixed to 4.                                                          |
+| `DEFAULT_PC_STEP`            | The byte distance between sequential instructions.                 | Fixed to 4.                                                          |
 | `MAX_ALLOWED_PC`             | The greatest supported byte program counter.                       | Fixed to `2^32 - DEFAULT_PC_STEP = 0xffff_fffc`.                     |
 | `LIMB_BITS`                  | The number of bits in a limb for RISC-V memory emulation.          | Fixed to 8.                                                          |
 | `ADDR_SPACE_OFFSET`          | The index of the first writable address space.                     | Fixed to 1.                                                          |
 | `addr_space_height`          | The base 2 log of the number of writable address spaces supported. | Configurable, must satisfy `addr_space_height <= F::bits() - 2`      |
-| `pointer_max_bits`           | The maximum number of bits in a pointer.                           | Configurable, must satisfy `pointer_max_bits <= F::bits() - 2`       |
+| `pointer_max_bits`           | The maximum number of bits in a cell pointer.                      | Configurable up to 32; fixed to 31 by the default RV64 configuration. |
 | `num_public_values`          | The number of user public values.                                  | Configurable, must equal `8` times a nonzero power of two.           |
 | `MAX_HINT_BUFFER_DWORDS_BITS` | The maximum number of bits for hint buffer dword count. This determines `MAX_HINT_BUFFER_DWORDS = 2^MAX_HINT_BUFFER_DWORDS_BITS - 1` = 1,023 dwords (≈8KB), the maximum dwords per `HINT_BUFFER_RV64` instruction. | Fixed to 10. |
 
@@ -108,34 +108,26 @@ case, `d` is suggested to be set to `1`. This also may not be constrained, thoug
 ### Program Counter
 
 There is a single special purpose register `pc` for the program counter. It is a 32-bit byte address
-that must be a multiple of `DEFAULT_PC_STEP` and at most `MAX_ALLOWED_PC`, so the full aligned
-32-bit byte address space is supported.
-
-Because an arbitrary 32-bit value does not fit uniquely in one BabyBear element, circuits represent
-the byte PC by dividing out its two fixed alignment bits:
+that must be a multiple of `DEFAULT_PC_STEP` and at most `MAX_ALLOWED_PC`. Circuits use the PC index:
 
 ```
 pc_idx = pc / DEFAULT_PC_STEP
 ```
 
-The resulting 30-bit `pc_idx` fits in one field element. Program trace columns, program- and
-execution-bus messages, connector public values, and the executable commitment all carry the PC
-index. Runtime execution and preflight records continue to use byte PCs and convert at circuit
-boundaries.
-
 ### Data Memory
 
 Data memory is a random access memory (RAM) which supports read and write operations. Memory is comprised of addressable
-cells which represent a single field element indexed by **address space** and **pointer**. The number of supported
-address spaces and the size of each address space are configurable constants.
+cells which represent a single field element indexed by **address space** and **cell pointer**.
+The number of supported address spaces, the cell layout, and the size of each address space are configurable.
 
 - Valid address spaces not used for immediates lie in `[1, 1 + 2^addr_space_height)` for configuration constant `addr_space_height`.
-- Valid pointers are field elements that lie in `[0, 2^pointer_max_bits)`, for
-  configuration constant `pointer_max_bits`. When accessing an address out of `[0, 2^pointer_max_bits)`, the VM should
-  panic.
-- For the register address space (address space `1`), valid pointers lie in `[0, 256)`, corresponding to 32 registers with 8 byte limbs each.
-These configuration constants must satisfy `addr_space_height, pointer_max_bits <= F::bits() - 2`. We use the following notation
-to denote cells in memory:
+- Each address space configures `num_cells`. Valid cell pointers are smaller than both `num_cells`
+  and `2^pointer_max_bits`. The current implementation supports `16 <= pointer_max_bits <= 32`.
+- The default RV64 register and user-memory address spaces use u16 cells. User memory contains
+  `2^31` cells, or `2^32` guest bytes. The register address space contains 128 cells for 32
+  eight-byte registers.
+
+We use the following notation to denote cells in memory:
 
 - `[a]_d` denotes the single-cell value at pointer location `a` in address space `d`. This is a single
   field element.
@@ -149,11 +141,12 @@ to. Address space `0` is considered a read-only array with `[a]_0 = a` for any `
 #### Memory Accesses and Block Accesses
 
 VM instructions can access (read or write) a contiguous list of cells (called a **block**) in a single address space.
-The block size is fixed to constant size `8` across all instructions in the ISA.
-All block accesses must be at pointers that are a multiple of the block size (`8`).
+Memory-bus blocks contain `BLOCK_FE_WIDTH = 4` cells and use `block_index = cell_pointer / 4`. In
+the RV64 register and user-memory address spaces, one block contains 8 guest bytes and starts at an
+8-byte-aligned guest address.
 However, RISC-V instructions like `lb`, `lh`, `sb`, and `sh` still work despite having minimum
 block size requirements equal to the size of the access (1 byte for `lb`/`sb`, 2 bytes for `lh`/`sh`) because these
-instructions are implemented by doing a block access of size 8.
+instructions are implemented by doing an 8-byte block access (4 u16 cells).
 Block accesses are not supported for address space `0`.
 
 #### Address Spaces
@@ -166,8 +159,8 @@ introduce additional address spaces:
 | Address Space | Name        | Notes and Constraints                                                             |
 | ------------- | ----------- | --------------------------------------------------------------------------------- |
 | `0`           | Immediates  | Address space `0` is reserved for denoting immediates, and we define `[a]_0 = a`. |
-| `1`           | Registers   | Elements are constrained to lie in `[0, 2^LIMB_BITS)` for `LIMB_BITS = 8`.        |
-| `2`           | User Memory | Elements are constrained to lie in `[0, 2^LIMB_BITS)` for `LIMB_BITS = 8`.        |
+| `1`           | Registers   | u16 cells, each packing two adjacent guest register bytes.                        |
+| `2`           | User Memory | u16 cells, each packing two adjacent guest memory bytes.                          |
 | `3`           | User IO     | Elements are constrained to lie in `[0, 2^LIMB_BITS)` for `LIMB_BITS = 8`.        |
 | `4`           | Deferral    | Elements are typically full native field elements.                                |
 
@@ -213,8 +206,8 @@ a transition function on the mutable parts of the VM state:
 
 which must satisfy the following conditions:
 
-- Let `from_pc` be the program counter at the start of the instruction execution. The `from_pc` must be the address of a
-  valid instruction in the program ROM.
+- Let `from_pc` be the byte program counter at the start of instruction execution. It must be the
+  byte address of a valid instruction in the program ROM.
 - The execution must match the instruction from the program ROM.
 - The execution has full read/write access to the data memory, except address space `0` must be read-only.
 - User public outputs can be set at any index in `[0, num_public_values)`.
@@ -222,13 +215,11 @@ which must satisfy the following conditions:
 - Full read/write access to the hint stream.
 - Deferral states are pre-computed at initialization with input-to-raw-input mappings. During execution, deferral
   functions may update a `DeferralState` by storing raw outputs and their commitments, which are as specified [here](/specs/architecture/deferral).
-- The program counter is set to a new `to_pc` at the end of the instruction execution.
-  Instructions are only considered valid if `to_pc` is the address of a valid instruction in the program ROM.
+- The byte program counter is set to a new `to_pc` at the end of instruction execution.
+  Instructions are only considered valid if `to_pc` is the byte address of a valid instruction in the program ROM.
 
-ℹ️ Notes for extension developers: Runtime execution and preflight records use byte PCs, while AIR
-trace columns and buses use `pc_idx = byte_pc / DEFAULT_PC_STEP`. Sequential AIR transitions advance
-`pc_idx` by one. New instructions must reject byte-PC overflow and any destination that is not
-`DEFAULT_PC_STEP`-aligned before converting it to an index.
+ℹ️ Notes for extension developers: Runtime execution uses byte PCs, while AIR traces and buses use
+`pc_idx`. New instructions must reject overflow and misalignment before converting a byte PC to an index.
 
 ### Guest Instruction Execution
 
@@ -260,9 +251,8 @@ new extension to be compatible with some extensions, you need select some compat
 
 ## OpenVM Instruction Set
 
-We now specify instructions supported by the default VM extensions shipping with OpenVM. Unless
-otherwise specified, instructions set `to_pc = from_pc + DEFAULT_PC_STEP`. We will use the
-following notation:
+We now specify instructions supported by the default VM extensions shipping with OpenVM. Unless otherwise specified,
+instructions will set `to_pc = from_pc + DEFAULT_PC_STEP`. We will use the following notation:
 
 - `u64(x)` where `x: [F; 8]` consists of 8 bytes will mean the casting from little-endian bytes in 2's complement to
   unsigned 64-bit integer.
@@ -273,6 +263,8 @@ following notation:
 - `i32(c)` where `c` is a field element will mean `c.as_canonical_u32()` if `c.as_canonical_u32() < F::modulus() / 2` or
   `c.as_canonical_u32() - F::modulus() as i32` otherwise.
 - `decompose(c)` where `c` is a field element means `c.as_canonical_u32().to_le_bytes()`.
+- In RV64 notation, `[ptr:N]_1` and `[ptr:N]_2` denote `N` guest bytes starting at byte address
+  `ptr`. Adapters pack each adjacent byte pair into one u16 memory cell.
 - `r64{0}(a) := u32([a:8]_1)` means reading the 64-bit register at `[a:8]_1` and interpreting it as a `u32` pointer (the upper 4 bytes must be zero).
 
 In the specification, operands marked with `_` are not used and should be set to zero. Trailing unused operands should
@@ -309,10 +301,9 @@ additional user IO opcodes and phantom sub-instructions to support input and deb
 OpenVM opcode corresponding to a RV64IM opcode by appending `_RV64`.
 
 The RV64IM extension uses address space `0` for immediates, address space `1` for registers, and address space `2` for
-memory. As explained [here](#address-spaces), cells in address spaces `1` and `2` are constrained to be bytes, and all
-instructions preserve this constraint.
+memory. Address spaces `1` and `2` use u16 cells, with each cell storing two guest bytes.
 
-The `i`th RISC-V register is represented by the block `[8 * i:8]_1` of 8 limbs in address space `1`. All memory
+The `i`th RISC-V register is represented by the block `[8 * i:8]_1` of 8 bytes in address space `1`. All memory
 addresses in address space `1` behave uniformly, and in particular writes to the block `[0:8]_1` corresponding to the
 RISC-V register `x0` are allowed in the RV64IM extension. However, as detailed
 in [RV64IM Transpilation](/specs/reference/transpiler#rv64im-extension), any OpenVM program transpiled from a RV64IM ELF will
@@ -361,13 +352,14 @@ The operand `g` must be a boolean. We let `sign_extend(decompose(c)[0:2], g)` de
 the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering
 the 32 bits as the 2’s complement of an `i32`.
 
-We will use shorthand `r64{c,g}(b) := u32([b:8]_1) + sign_extend(decompose(c)[0:2], g)` as `i32`. This reads the 64-bit register `[b:8]_1` as a `u32` pointer (upper 4 bytes must be zero), then performs
-signed 32-bit addition. For consistency with other notation,
+We use the shorthand `r64{c,g}(b) := u32([b:8]_1) + sign_extend(decompose(c)[0:2], g)`. This reads
+the 64-bit register `[b:8]_1` as a u32 byte pointer (the upper 4 bytes must be zero), then adds the
+signed immediate without wrapping. For consistency with other notation,
 we define the shorthand `r64{c}(b)` to mean `r64{c,g}(b)` where `g` is set to the most significant bit of `c`.
 
-Memory access to `ptr: i32` in address space `e` is only valid if `0 <= ptr < 2^pointer_max_bits` and
-`ptr` is naturally aligned (i.e., `ptr` must be divisible by the data size in bytes), in
-which case it is an access to `F::from_u32(ptr as u32)`.
+Memory access to `ptr = r64{c,g}(b)` in address space `e` is only valid if the full access lies in
+the configured memory range, which is `[0, 2^32)` by default. An access uses one or two aligned
+8-byte blocks. Address arithmetic must not wrap.
 The data size is `1` for LOADB_RV64, LOADBU_RV64, STOREB_RV64, `2` for LOADH_RV64, LOADHU_RV64, STOREH_RV64, `4` for LOADW_RV64, STOREW_RV64, and `8` for LOADD_RV64, STORED_RV64.
 
 All load/store instructions always do block accesses of block size `8`, even for LOADB_RV64 and STOREB_RV64.
@@ -398,28 +390,23 @@ For branch instructions, we fix `d = e = 1`. For jump instructions, we fix `d = 
 | BGE_RV64   | `a,b,c,1,1`      | `if(i64([a:8]_1) >= i64([b:8]_1)) pc += c`                                                                                                                                                                                                                                                                                                                                  |
 | BLTU_RV64  | `a,b,c,1,1`      | `if(u64([a:8]_1) < u64([b:8]_1)) pc += c`                                                                                                                                                                                                                                                                                                                                   |
 | BGEU_RV64  | `a,b,c,1,1`      | `if(u64([a:8]_1) >= u64([b:8]_1)) pc += c`                                                                                                                                                                                                                                                                                                                                  |
-| JAL_RV64   | `a,_,c,1,_,f`    | If `f!=0`, write the 64-bit link value `u64(pc) + 4` to `[a:8]_1`; then set `pc += c`. The operand `f` is assumed to be boolean. The PC update is always done regardless of `f`'s value. Here `i32(c)` must be in `[-2^24, 2^24)`. The target must remain in the 32-bit PC address space and be 4-byte aligned. |
+| JAL_RV64   | `a,_,c,1,_,f`    | If `f!=0`, write the 64-bit link value `u64(pc) + 4` to `[a:8]_1`; then set `pc += c`. The operand `f` is assumed to be boolean. The PC update is always done regardless of `f`'s value. Here `i32(c)` must be in `[-2^20, 2^20)`. The target must remain in the 32-bit PC address space and be 4-byte aligned. |
 | JALR_RV64  | `a,b,c,1,_,f,g` | Let `raw_target = u32([b:8]_1) + sign_extend(decompose(c)[0:2], g)`. If `f!=0`, write the 64-bit link value `u64(pc) + 4` to `[a:8]_1`; then set `pc = raw_target & !1`. The operands `f` and `g` are assumed to be boolean. The PC update is always done regardless of `f`'s value. The masked target must be in the 32-bit PC address space and be 4-byte aligned. Here `u32(c)` must be in `[0, 2^16)`. |
 | LUI_RV64   | `a,_,c,1,_,1`    | `[a:8]_1 = sign_extend(u32(c) << 12)`. Here `i32(c)` must be in `[0, 2^20)`. |
 | AUIPC_RV64 | `a,_,c,1,_,_`    | `[a:8]_1 = u64(pc) + sign_extend(u32(c) << 8)`, computed as a 64-bit value. Here `i32(c)` must be in `[0, 2^24)`. |
 
-For branch and JAL_RV64 instructions, `i32(c)` is a signed byte offset in `[-2^24, 2^24)`.
-A taken target is valid only if integer addition places it in `[0, MAX_ALLOWED_PC]` on a
-`DEFAULT_PC_STEP`-aligned address. The circuit constrains
-`to_pc_idx = from_pc_idx + i32(c) / DEFAULT_PC_STEP`. A misaligned encoding is not rejected merely
-because it occurs in the executable's text, which may contain embedded data; it is rejected if
-execution actually uses it as a control-flow target.
+For branch instructions, `i32(c)` is a signed byte offset in `[-2^12, 2^12)`; for JAL_RV64, it is in
+`[-2^20, 2^20)`. A taken target must be in `[0, MAX_ALLOWED_PC]` and aligned to `DEFAULT_PC_STEP`.
 
 For JALR_RV64, we treat `c` in `[0, 2^16)` as a raw encoding of 16-bits.
 The operand `g` must be a boolean. We let `sign_extend(decompose(c)[0:2], g)` denote the `i32` defined by first taking
-the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering the 32 bits as the 2's complement of an `i32`. It is then added to the register value `u32([b:8]_1)` (the upper 4 bytes of the 64-bit register must be zero) without wrapping the implemented address space. JALR clears bit 0 before validation; bit 1 must be zero so that the resulting PC is 4-byte aligned. The circuit decomposes the resulting 30-bit PC index into a low 14-bit limb and a high 16-bit limb for this arithmetic.
+the unsigned integer encoding of `c` as 16 bits, then sign extending it to 32 bits using the sign bit `g`, and considering the 32 bits as the 2's complement of an `i32`. It is then added to the register value `u32([b:8]_1)` (the upper 4 bytes of the 64-bit register must be zero) without wrapping. JALR clears bit 0 before checking that the target is in range and 4-byte aligned.
 
 For LUI_RV64, we are treating `c` in `[0, 2^20)` as a raw encoding of 20-bits.
 For AUIPC_RV64, we are treating `c` in `[0, 2^24)` as a raw encoding of 24-bits.
 The instruction does not need to interpret whether the register is signed or unsigned.
-For AUIPC_RV64, the circuit reconstructs the byte PC from `pc_idx` before adding the immediate.
-Negative results are sign-extended to 64 bits, while a positive carry becomes bit 32 of the
-64-bit result. For example, `0xfffffff8 + 0x1000 = 0x1_00000ff8` is valid.
+For AUIPC_RV64, the result is a 64-bit sum. For example,
+`0xfffffff8 + 0x1000 = 0x1_00000ff8` is valid.
 
 Note that AUIPC_RV64 does not have any condition for the register write.
 
@@ -508,7 +495,7 @@ construction into its constituent operations: absorbing input (XOR-in) and permu
 these opcodes can be used to implement the full Keccak-256 hash function, including incremental/streaming hashing. The
 opcodes themselves do not perform padding or squeezing.
 
-The extension operates on address spaces `1` and `2`, meaning all memory cells are constrained to be bytes.
+The extension uses RV64 registers in address space `1` and user memory in address space `2`.
 
 The Keccak-f[1600] state is a 200-byte buffer in address space `2`. The absorption rate is 136 bytes (1088 bits),
 corresponding to a capacity of 512 bits for Keccak-256.
@@ -524,8 +511,8 @@ In the instructions below, let `buf = r64{0}(a)`, `inp = r64{0}(b)`, and `len = 
 
 The SHA-2 extension exposes single-block compression instructions for SHA-256 and SHA-512. These are sufficient to
 implement the SHA-256, SHA-384, and SHA-512 hash functions: SHA-384 uses `SHA512_UPDATE_RV64` with the SHA-384 initial
-state and final 48-byte truncation. The extension operates on address spaces `1` and `2`, meaning all memory cells are
-constrained to be bytes. State buffers store 8 words in little-endian order, the destination pointer (`a`) may alias
+state and final 48-byte truncation. The extension uses RV64 registers in address space `1` and user
+memory in address space `2`. State buffers store 8 words in little-endian order, the destination pointer (`a`) may alias
 the state pointer (`b`), and these instructions do not perform padding.
 
 | Name        | Operands    | Description                                                                                                                                                              |
@@ -535,9 +522,9 @@ the state pointer (`b`), and these instructions do not perform padding.
 
 ### BigInt Extension
 
-The BigInt extension supports operations on 256-bit signed and unsigned integers. The extension operates on address
-spaces `1` and `2`, meaning all memory cells are constrained to be bytes. Pointers to the representation of the elements
-are read from address space `1` and the elements themselves are read/written from address space `2`.
+The BigInt extension supports operations on 256-bit signed and unsigned integers. Pointers to the
+representation of the elements are read from address space `1` and the elements themselves are
+read/written from address space `2`.
 
 **Note:** These instructions are not the same as instructions on 256-bit registers.
 
@@ -582,8 +569,7 @@ The algebra extension supports modular arithmetic over arbitrary fields and thei
 configured to specify a list of supported moduli. The configuration of each supported positive integer modulus `N`
 includes the associated configuration parameter `N::NUM_LIMBS` (defined below).
 
-The instructions perform operations on unsigned big integers representing elements in the modulus. The extension
-operates on address spaces `1` and `2`, meaning all memory cells are constrained to be bytes. Pointers to the
+The instructions perform operations on unsigned big integers representing elements in the modulus. Pointers to the
 representation of the elements are read from address space `1` and the elements themselves are read/written from address
 space `2`.
 
@@ -659,12 +645,12 @@ equation `C: y^2 = x^3 + C::A * x + C::B` where `C::A` and `C::B` are constants 
 the definitions of the
 curve arithmetic operations do not depend on `C::B`. The VM configuration will specify a list of supported curves. For
 each Weierstrass curve `C`, the coordinate size is determined by `C::Fp::NUM_LIMBS` from the coordinate field. The
-extension operates on address spaces `1` and `2`, meaning all memory cells are constrained to be bytes.
+extension uses address spaces `1` and `2`.
 
 An affine curve point `EcPoint(x, y)` is a pair of `x,y` where each element is an array of `C::Fp::NUM_LIMBS` elements each
 with `LIMB_BITS = 8` bits. When the coordinate field `C::Fp` of `C` is prime, the format of `x,y` is guaranteed to be
 the same as the format used in the [modular arithmetic instructions](#modular-arithmetic). A curve point will be
-represented as `2 * C::Fp::NUM_LIMBS` contiguous cells in memory.
+represented as `2 * C::Fp::NUM_LIMBS` contiguous guest bytes in memory.
 
 We use the following notation below:
 
@@ -688,8 +674,8 @@ r64_ec_point(a) -> EcPoint {
 
 The pairing extension supports opcodes tailored to accelerate pairing checks using the optimal Ate pairing over certain
 classes of pairing friendly elliptic curves. For a curve `C` to be supported, the VM must have enabled instructions for
-`C::Fp` and `C::Fp2`. The currently supported curves are BN254 and BLS12-381. The extension operates on address spaces
-`1` and `2`, meaning all memory cells are constrained to be bytes.
+`C::Fp` and `C::Fp2`. The currently supported curves are BN254 and BLS12-381. The extension uses address spaces `1` and
+`2`.
 
 #### Phantom Sub-Instructions
 

--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -16,9 +16,12 @@ We define a RISC-V **machine code block** to be a 32-bit aligned contiguous sequ
 
 The transpiler is configured upon construction with the set of VM extensions to support. In order to be supported by the transpiler, a VM extension must specify a set of RISC-V machine code blocks and rules for mapping each code block to a sequence of _potentially multiple_ [OpenVM instructions](/specs/openvm/isa#openvm-instruction-set). Extensions may also modify the executable's initial memory image.
 
+In this section, `[ptr:N]_1` and `[ptr:N]_2` denote `N` guest bytes starting at byte address `ptr`.
+The RV64 adapters pack each adjacent byte pair into one u16 memory cell.
+
 The transpilation rules must satisfy:
 
-- A read or write to the RISC-V program counter corresponds to a read or write to the OpenVM byte program counter of the same value. This includes the implicit read of the program counter to fetch the instruction from program code, as well as any implicit `pc += 4` advancement in some RISC-V instructions. Circuit traces and buses represent that byte address as the PC index `pc_idx = byte_pc / DEFAULT_PC_STEP`.
+- A read or write to the RISC-V program counter corresponds to a read or write to the OpenVM byte program counter of the same value. This includes the implicit read of the program counter to fetch the instruction from program code, as well as any implicit `pc += 4` advancement in some RISC-V instructions.
 - A RISC-V 64-bit register `x{i}` read or write access corresponds to an OpenVM memory access at `[8 * i: 8]_1` **except** for writes to `x0`, see [below](#register-x0-handling). The 64-bits of `x{i}` are represented as 8 little-endian bytes in OpenVM memory.
   - A RISC-V code block must **never** map to any OpenVM instruction that changes the value of `[0:8]_1` in OpenVM memory.
 - A RISC-V user memory access of the `j`th byte at address `addr` corresponds to an OpenVM memory access at `[addr + j]_2`.
@@ -27,12 +30,12 @@ The transpilation rules must satisfy:
 The above requirements, together with the invariants of the OpenVM ISA, imply that transpilation will only be valid for programs where:
 
 - Every program address is a multiple of `DEFAULT_PC_STEP` and is at most `MAX_ALLOWED_PC = 2^32 - DEFAULT_PC_STEP`.
-- The program does not access memory outside the range `[0, 2^pointer_max_bits)`: programs that attempt such accesses will fail to execute.
+- Every RISC-V user-memory access lies entirely in the configured memory range, which is
+  `[0, 2^32)` by default. Address underflow or overflow fails during execution or trace generation.
 
-The transpiler decodes every machine-code word in executable text, which may include embedded data.
-It therefore does not reject a word solely because it decodes as a branch or jump with a misaligned
-offset. Runtime execution and trace generation reject the target if that control-flow operation is
-actually executed (or, for a conditional branch, actually taken).
+The transpiler does not reject a word solely because it decodes to a misaligned branch or jump
+target. Execution and trace generation reject the target if it is reached; a conditional branch
+fails only when taken.
 
 A transpiler configuration is only considered valid if there are no two transpilation rules that may map the same RISC-V code block to different OpenVM instructions.
 

--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -7,7 +7,7 @@ The OpenVM framework supports transpilation of a RISC-V ELF consisting of the RV
 The transpiler is a function that converts a [RISC-V ELF](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc) into an OpenVM executable, where an **OpenVM executable** is defined as the following pieces of data:
 
 - Program ROM
-- Starting byte program counter `pc_0`
+- Starting program counter `pc_0`
 - Initial data memory
 
 The OpenVM executable forms a part of the [initial VM state](/specs/openvm/isa#virtual-machine-state).

--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -7,7 +7,7 @@ The OpenVM framework supports transpilation of a RISC-V ELF consisting of the RV
 The transpiler is a function that converts a [RISC-V ELF](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc) into an OpenVM executable, where an **OpenVM executable** is defined as the following pieces of data:
 
 - Program ROM
-- Starting program counter `pc_0`
+- Starting byte program counter `pc_0`
 - Initial data memory
 
 The OpenVM executable forms a part of the [initial VM state](/specs/openvm/isa#virtual-machine-state).
@@ -18,7 +18,7 @@ The transpiler is configured upon construction with the set of VM extensions to 
 
 The transpilation rules must satisfy:
 
-- A read or write to the RISC-V program counter corresponds to a read or write to the program counter of the same value in OpenVM. This includes the implicit read of the program counter to fetch the instruction from program code, as well as any implicit `pc += 4` advancement in some RISC-V instructions.
+- A read or write to the RISC-V program counter corresponds to a read or write to the OpenVM byte program counter of the same value. This includes the implicit read of the program counter to fetch the instruction from program code, as well as any implicit `pc += 4` advancement in some RISC-V instructions. Circuit traces and buses represent that byte address as the PC index `pc_idx = byte_pc / DEFAULT_PC_STEP`.
 - A RISC-V 64-bit register `x{i}` read or write access corresponds to an OpenVM memory access at `[8 * i: 8]_1` **except** for writes to `x0`, see [below](#register-x0-handling). The 64-bits of `x{i}` are represented as 8 little-endian bytes in OpenVM memory.
   - A RISC-V code block must **never** map to any OpenVM instruction that changes the value of `[0:8]_1` in OpenVM memory.
 - A RISC-V user memory access of the `j`th byte at address `addr` corresponds to an OpenVM memory access at `[addr + j]_2`.
@@ -26,8 +26,13 @@ The transpilation rules must satisfy:
 
 The above requirements, together with the invariants of the OpenVM ISA, imply that transpilation will only be valid for programs where:
 
-- The program code does not have program address greater than or equal to `2^PC_BITS`.
+- Every program address is a multiple of `DEFAULT_PC_STEP` and is at most `MAX_ALLOWED_PC = 2^32 - DEFAULT_PC_STEP`.
 - The program does not access memory outside the range `[0, 2^pointer_max_bits)`: programs that attempt such accesses will fail to execute.
+
+The transpiler decodes every machine-code word in executable text, which may include embedded data.
+It therefore does not reject a word solely because it decodes as a branch or jump with a misaligned
+offset. Runtime execution and trace generation reject the target if that control-flow operation is
+actually executed (or, for a conditional branch, actually taken).
 
 A transpiler configuration is only considered valid if there are no two transpilation rules that may map the same RISC-V code block to different OpenVM instructions.
 

--- a/docs/vocs/docs/pages/specs/reference/transpiler.mdx
+++ b/docs/vocs/docs/pages/specs/reference/transpiler.mdx
@@ -21,7 +21,7 @@ The RV64 adapters pack each adjacent byte pair into one u16 memory cell.
 
 The transpilation rules must satisfy:
 
-- A read or write to the RISC-V program counter corresponds to a read or write to the OpenVM byte program counter of the same value. This includes the implicit read of the program counter to fetch the instruction from program code, as well as any implicit `pc += 4` advancement in some RISC-V instructions.
+- A read or write to the RISC-V program counter corresponds to a read or write to the OpenVM program counter of the same value. This includes the implicit read of the program counter to fetch the instruction from program code, as well as any implicit `pc += 4` advancement in some RISC-V instructions.
 - A RISC-V 64-bit register `x{i}` read or write access corresponds to an OpenVM memory access at `[8 * i: 8]_1` **except** for writes to `x0`, see [below](#register-x0-handling). The 64-bits of `x{i}` are represented as 8 little-endian bytes in OpenVM memory.
   - A RISC-V code block must **never** map to any OpenVM instruction that changes the value of `[0:8]_1` in OpenVM memory.
 - A RISC-V user memory access of the `j`th byte at address `addr` corresponds to an OpenVM memory access at `[addr + j]_2`.

--- a/extensions/riscv/circuit/src/README.md
+++ b/extensions/riscv/circuit/src/README.md
@@ -9,10 +9,11 @@ The RV64IM chips is composed of two main components: an adapter chip and a core 
 - The adapter chip adapts the core chip's I/O to the VM's expected format and manages interactions with the VM.
 - The core chip is responsible for implementing the logic of the RISC-V instructions.
 
-Runtime execution and preflight records use 32-bit byte program counters. Circuit traces represent
-each byte PC as the 30-bit index `pc_idx = byte_pc / DEFAULT_PC_STEP`. In the circuit statements
-below, `from_pc_idx` and `to_pc_idx` denote circuit PC indices. A normal four-byte instruction
-advances the index by one, while branch and jump immediates remain byte offsets.
+Runtime execution and preflight use 32-bit byte PCs. Circuit traces use
+`pc_idx = byte_pc / DEFAULT_PC_STEP`; the statements below use `from_pc_idx` and `to_pc_idx`.
+
+RV64 memory uses 32-bit byte addresses. Load/store adapters use one or two aligned 8-byte blocks and
+enforce the configured pointer bound.
 
 ## Circuit statements
 
@@ -115,7 +116,8 @@ Given
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
-- A memory read from the RV64 memory address space is performed at address `val(rs1) + imm`
+- The full access at `val(rs1) + imm` fits within the configured pointer bound without wrapping
+- One or two aligned memory blocks are read from the RV64 memory address space
 - A memory write to register `rd` is performed if `rd` is not `x0`
 - The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
@@ -131,7 +133,8 @@ This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
-- A memory write to the RV64 memory address space (`2`) is performed at address `val(rs1) + imm`
+- The full access at `val(rs1) + imm` fits within the configured pointer bound without wrapping
+- One or two aligned memory blocks are written in the RV64 memory address space (`2`)
 - The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 8. Reveal
@@ -214,13 +217,16 @@ This circuit proves that:
 - `a[i] == b[i] | c[i]` for `or`, and the equivalent operation with the sign-extended immediate for `ori`
 - `a[i] == b[i] & c[i]` for `and`, and the equivalent operation with the sign-extended immediate for `andi`
 
+Branch immediates are byte offsets. A taken branch target must be aligned and in range; an untaken
+branch ignores its encoded target.
+
 #### 3. [Branch Eq](./branch_eq/core.rs)
 
 Given:
 
 - `a` and `b` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^BYTE_BITS)`
 - `opcode_beq_flag` and `opcode_bne_flag` indicate if the instruction is `beq` or `bne`
-- `imm` is the immediate value
+- `imm` is the signed byte-offset immediate
 - `to_pc_idx` is the destination circuit PC index
 
 This circuit proves that:
@@ -234,7 +240,7 @@ Given:
 
 - `a` and `b` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^BYTE_BITS)`
 - Flags indicating if the instruction is one of `blt`, `bltu`, `bge`, `bgeu`
-- `imm` is the immediate value
+- `imm` is the signed byte-offset immediate
 - `to_pc_idx` is the destination circuit PC index
 
 This circuit proves that:
@@ -298,8 +304,8 @@ Given:
 
 This circuit proves that:
 
-- `raw_target_bit0 + 4 * compose(to_pc_idx_limbs) == compose(rs1) + imm` as a low-32-bit
-  addition with boolean carries; a byte target with bit 1 set (misaligned) is unsatisfiable
+- `raw_target_bit0 + 4 * compose(to_pc_idx_limbs) == compose(rs1) + imm` as a non-wrapping u32
+  addition; a byte target with bit 1 set (misaligned) is unsatisfiable
 - The destination PC index is `compose(to_pc_idx_limbs)`, so the least significant bit of the
   byte target is cleared as required by `jalr`
 - `compose(rd) == 4 * (pc_idx + 1)`, including the possible bit-32 carry

--- a/extensions/riscv/circuit/src/README.md
+++ b/extensions/riscv/circuit/src/README.md
@@ -9,6 +9,11 @@ The RV64IM chips is composed of two main components: an adapter chip and a core 
 - The adapter chip adapts the core chip's I/O to the VM's expected format and manages interactions with the VM.
 - The core chip is responsible for implementing the logic of the RISC-V instructions.
 
+Runtime execution and preflight records use 32-bit byte program counters. Circuit traces represent
+each byte PC as the 30-bit index `pc_idx = byte_pc / DEFAULT_PC_STEP`. In the circuit statements
+below, `from_pc_idx` and `to_pc_idx` denote circuit PC indices. A normal four-byte instruction
+advances the index by one, while branch and jump immediates remain byte offsets.
+
 ## Circuit statements
 
 This section outlines the specific statements that each circuit is designed to prove.
@@ -24,14 +29,14 @@ For further details, including the underlying constraints and assumptions, pleas
 Given
 
 - `rs1`, `rs2`, and `rd` are register addresses
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
 - A memory write to register `rd` is performed with the result of the operation
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 2. ALU immediate adapters
 
@@ -42,14 +47,14 @@ Given
 
 - `rs1` and `rd` are register addresses
 - `imm` is the immediate operand supplied by the core
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory write to register `rd` is performed with the result of the operation
 - The immediate supplied by the core is bound to the instruction on the execution bus
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 3. ALU W adapters
 
@@ -61,7 +66,7 @@ Given
 - `rs1` and `rd` are register addresses
 - The register adapter also receives the `rs2` register address
 - The immediate adapter receives the immediate operand from the core
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
@@ -69,35 +74,35 @@ This circuit proves the following:
 - The register adapter reads `rs2` and preserves its upper 32 bits for the read interaction
 - The immediate adapter binds the immediate supplied by the core to the instruction on the execution bus
 - The low 32-bit result is sign-extended to a full 64-bit u16-cell register write by constraining the result sign bit from the most significant low-word limb
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 4. [Branch adapter](./adapters/branch.rs)
 
 Given
 
 - `rs1`, `rs2`, and `rd` are register addresses
-- `from_pc` is the current program address
-- `to_pc` is the destination program address
+- `from_pc_idx` is the current circuit PC index
+- `to_pc_idx` is the destination circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `to_pc`.
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `to_pc_idx`.
 
 #### 5. [JALR adapter](./adapters/jalr.rs)
 
 Given
 
 - `rd`, `rs1` are register addresses
-- `from_pc` is the current program address
-- `to_pc` is the destination program address
+- `from_pc_idx` is the current circuit PC index
+- `to_pc_idx` is the destination circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory write to register `rd` is performed if `rd` is not `x0`
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `to_pc`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `to_pc_idx`
 
 #### 6. [Load adapter](./adapters/load.rs)
 
@@ -105,14 +110,14 @@ Given
 
 - `rd`, `rs1` are register addresses
 - `imm` is an immediate value
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from the RV64 memory address space is performed at address `val(rs1) + imm`
 - A memory write to register `rd` is performed if `rd` is not `x0`
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 7. [Store adapter](./adapters/store.rs)
 
@@ -120,14 +125,14 @@ Given
 
 - `rs1`, `rs2` are register addresses
 - `imm` is an immediate value
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
 - A memory write to the RV64 memory address space (`2`) is performed at address `val(rs1) + imm`
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 8. Reveal
 
@@ -136,41 +141,41 @@ Given
 - `rs1` is the public-values base-address register
 - `rs2` is the source register
 - `imm` is an immediate value
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
 - Memory reads from registers `rs1` and `rs2` are performed
 - Eight bytes from `rs2` are written at `val(rs1) + imm` in the public-values address space (`3`)
 - The destination is constrained to an eight-byte-aligned, in-bounds address
-- The dedicated reveal instruction is correctly fetched at `from_pc`, and the program counter is set to `from_pc + 4`
+- The dedicated reveal instruction is correctly fetched at `from_pc_idx`, and the PC index is set to `from_pc_idx + 1`
 
 #### 9. [Multiplication adapter](./adapters/mul.rs)
 
 Given
 
 - `rd`, `rs1`, `rs2` are register addresses
-- `from_pc` is the current program address
+- `from_pc_idx` is the current circuit PC index
 
 This circuit proves the following:
 
 - A memory read from register `rs1` is performed
 - A memory read from register `rs2` is performed
 - A memory write to register `rd` is performed with the result of the multiplication
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `from_pc + 4`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `from_pc_idx + 1`
 
 #### 10. [Rdwrite adapter](./adapters/rdwrite.rs)
 
 Given
 
 - `rd` is a register address
-- `from_pc` is the current program address
-- `to_pc` is the destination program address
+- `from_pc_idx` is the current circuit PC index
+- `to_pc_idx` is the destination circuit PC index
 
 This circuit proves the following:
 
 - A memory write to register `rd` is performed if `rd` is not `x0`
-- The instruction is correctly fetched from the program ROM at address `from_pc` and the program counter is set to `to_pc`
+- The instruction is correctly fetched from the program ROM at `from_pc_idx` and the PC index is set to `to_pc_idx`
 
 ### Core
 
@@ -216,12 +221,12 @@ Given:
 - `a` and `b` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^BYTE_BITS)`
 - `opcode_beq_flag` and `opcode_bne_flag` indicate if the instruction is `beq` or `bne`
 - `imm` is the immediate value
-- `to_pc` is the destination program address
+- `to_pc_idx` is the destination circuit PC index
 
 This circuit proves that:
 
-- If `opcode_beq_flag` is true and `a` is equal to `b`, then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
-- If `opcode_bne_flag` is true and `a` is not equal to `b`, then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
+- If `opcode_beq_flag` is true and `a` is equal to `b`, then `to_pc_idx == pc_idx + imm / 4`, otherwise `to_pc_idx == pc_idx + 1`
+- If `opcode_bne_flag` is true and `a` is not equal to `b`, then `to_pc_idx == pc_idx + imm / 4`, otherwise `to_pc_idx == pc_idx + 1`
 
 #### 4. [Branch Lt](./branch_lt/core.rs)
 
@@ -230,14 +235,14 @@ Given:
 - `a` and `b` are decompositions of the operands, with their limbs assumed to be in the range `[0, 2^BYTE_BITS)`
 - Flags indicating if the instruction is one of `blt`, `bltu`, `bge`, `bgeu`
 - `imm` is the immediate value
-- `to_pc` is the destination program address
+- `to_pc_idx` is the destination circuit PC index
 
 This circuit proves that:
 
-- If the instruction is `blt` and `compose(a) < compose(b)` (signed comparison), then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
-- If the instruction is `bltu` and `compose(a) < compose(b)` (unsigned comparison), then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
-- If the instruction is `bge` and `compose(a) >= compose(b)` (signed comparison), then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
-- If the instruction is `bgeu` and `compose(a) >= compose(b)` (unsigned comparison), then `to_pc == pc + imm`, otherwise `to_pc == pc + 4`
+- If the instruction is `blt` and `compose(a) < compose(b)` (signed comparison), then `to_pc_idx == pc_idx + imm / 4`, otherwise `to_pc_idx == pc_idx + 1`
+- If the instruction is `bltu` and `compose(a) < compose(b)` (unsigned comparison), then `to_pc_idx == pc_idx + imm / 4`, otherwise `to_pc_idx == pc_idx + 1`
+- If the instruction is `bge` and `compose(a) >= compose(b)` (signed comparison), then `to_pc_idx == pc_idx + imm / 4`, otherwise `to_pc_idx == pc_idx + 1`
+- If the instruction is `bgeu` and `compose(a) >= compose(b)` (unsigned comparison), then `to_pc_idx == pc_idx + imm / 4`, otherwise `to_pc_idx == pc_idx + 1`
 
 #### 5. [Divrem](./divrem/core.rs)
 
@@ -264,21 +269,19 @@ Given:
 
 - `rd` is the decomposition of the result
 - `imm` is the immediate value
-- `to_pc` is the destination program address
+- `to_pc_idx` is the destination circuit PC index
 - `opcode` indicates the operation to be performed
 
 This circuit proves that:
 
-- Each limb of `rd` is in the range `[0, 2^BYTE_BITS)`
-- If `opcode` is `jal`, then (with `pc` and `to_pc` as pc *indices*, i.e. byte pcs divided by 4,
-  and `imm` a 4-byte-aligned byte offset)
-  - `to_pc == pc + imm / 4`
-  - `compose(rd) == 4 * (pc + 1)`, the byte return address; the low u16 limb of `rd` is a
-    multiple of 4 whose quotient is in the range `[0, 2^PC_IDX_LOW_BITS)`, which pins the
-    decomposition and keeps the return address inside the 32-bit PC address space
-  - The upper register cells of `rd` are zero (return addresses are zero-extended)
+- Each low-32-bit limb of `rd` is in the range `[0, 2^U16_BITS)`
+- If `opcode` is `jal`, with `imm` a 4-byte-aligned byte offset:
+  - `to_pc_idx == pc_idx + imm / 4`
+  - `compose(rd) == 4 * (pc_idx + 1)`, including the possible bit-32 carry. At
+    `pc_idx == 2^PC_IDX_BITS - 1`, the link value is `2^32`.
+  - The uppermost u16 limb of `rd` is zero.
 - If `opcode` is `lui`, then
-  - `to_pc == pc + 1`
+  - `to_pc_idx == pc_idx + 1`
   - `compose(rd) == imm * 2^12`, sign-extended into the upper register cells
 
 #### 7. [JALR](./jalr/core.rs)
@@ -288,21 +291,21 @@ Given:
 - `rs1` is the decomposition of the operand, with its limbs assumed to be in the range `[0, 2^BYTE_BITS)`
 - `rd` is the decomposition of the result
 - `imm` is the immediate value
-- `to_pc_least_sig_bit` is the least significant bit of `compose(rs1) + imm`
-- `to_pc_limbs` is the decomposition of the destination pc *index* (the byte target divided
-  by 4), where `to_pc_limbs[0]` is its low `PC_IDX_LOW_BITS` bits and `to_pc_limbs[1]` its
-  high u16 limb
+- `raw_target_bit0` is the least significant bit of `compose(rs1) + imm`
+- `to_pc_idx_limbs` is the decomposition of the destination PC index, where
+  `to_pc_idx_limbs[0]` is its low `PC_IDX_LOW_BITS` bits and `to_pc_idx_limbs[1]` its high
+  u16 limb
 
 This circuit proves that:
 
-- `to_pc_least_sig_bit + 4 * compose(to_pc_limbs) == compose(rs1) + imm` as a low-32-bit
+- `raw_target_bit0 + 4 * compose(to_pc_idx_limbs) == compose(rs1) + imm` as a low-32-bit
   addition with boolean carries; a byte target with bit 1 set (misaligned) is unsatisfiable
-- The destination pc index is `compose(to_pc_limbs)`, so the least significant bit of the
+- The destination PC index is `compose(to_pc_idx_limbs)`, so the least significant bit of the
   byte target is cleared as required by `jalr`
-- `compose(rd) == 4 * (pc + 1)`, the byte return address (with `pc` the pc index); the low
-  u16 limb of `rd` is a multiple of 4 whose quotient is in the range `[0, 2^PC_IDX_LOW_BITS)`
-- The high u16 limb of `rd` and `to_pc_limbs[1]` are in the range `[0, 2^16)`
-- `to_pc_limbs[0]` is in the range `[0, 2^PC_IDX_LOW_BITS)`
+- `compose(rd) == 4 * (pc_idx + 1)`, including the possible bit-32 carry
+- The high u16 limb of the low 32 bits of `rd` and `to_pc_idx_limbs[1]` are in the range
+  `[0, 2^16)`; the bit-32 carry of `rd` is boolean and its uppermost u16 limb is zero
+- `to_pc_idx_limbs[0]` is in the range `[0, 2^PC_IDX_LOW_BITS)`
 
 #### 8. [AUIPC](./auipc/core.rs)
 
@@ -310,14 +313,14 @@ Given:
 
 - `rd` is the decomposition of the result
 - `imm_limbs` are the decomposition of the immediate value
-- `pc_limbs` are the decomposition of the program counter
+- `pc_limbs` are the u16 decomposition of the byte PC reconstructed from `pc_idx`
 
 This circuit proves that:
 
-- `compose(rd) == compose(pc_limbs) + compose(imm_limbs) * 2^8` mod `2^32`, with negative
-  results sign-extended into the upper register cells and results at or above `2^32`
-  unsatisfiable
-- `compose(pc_limbs) == 4 * pc`, the byte pc for the pc index `pc`: the low u16 limb is
+- The low 32 bits of `rd` equal `compose(pc_limbs) + compose(imm_limbs) * 2^8` modulo
+  `2^32`. A negative result is sign-extended into the upper register cells; a positive carry
+  is written as bit 32.
+- `compose(pc_limbs) == 4 * pc_idx`: the low u16 limb is
   `4 * pc_idx_low` with `pc_idx_low` in the range `[0, 2^PC_IDX_LOW_BITS)` and the high u16
   limb in the range `[0, 2^16)`
 

--- a/extensions/riscv/circuit/src/README.md
+++ b/extensions/riscv/circuit/src/README.md
@@ -9,8 +9,8 @@ The RV64IM chips is composed of two main components: an adapter chip and a core 
 - The adapter chip adapts the core chip's I/O to the VM's expected format and manages interactions with the VM.
 - The core chip is responsible for implementing the logic of the RISC-V instructions.
 
-Runtime execution and preflight use 32-bit byte PCs. Circuit traces use
-`pc_idx = byte_pc / DEFAULT_PC_STEP`; the statements below use `from_pc_idx` and `to_pc_idx`.
+Runtime execution and preflight use 32-bit program counters. Circuit traces use
+`pc_idx = pc / DEFAULT_PC_STEP`; the statements below use `from_pc_idx` and `to_pc_idx`.
 
 RV64 memory uses 32-bit byte addresses. Load/store adapters use one or two aligned 8-byte blocks and
 enforce the configured pointer bound.
@@ -319,7 +319,7 @@ Given:
 
 - `rd` is the decomposition of the result
 - `imm_limbs` are the decomposition of the immediate value
-- `pc_limbs` are the u16 decomposition of the byte PC reconstructed from `pc_idx`
+- `pc_limbs` are the u16 decomposition of the program counter reconstructed from `pc_idx`
 
 This circuit proves that:
 

--- a/extensions/riscv/circuit/src/hintstore/README.md
+++ b/extensions/riscv/circuit/src/hintstore/README.md
@@ -12,15 +12,18 @@ which is also the row that will send messages to the program and execution buses
 multiplicities, is marked with `is_buffer_start = 1` (and it is the only row within the rows for that
 instruction with `is_buffer_start = 1`).
 
-On the starting row, a memory address `mem_ptr` is read from the RV64 register. Since pointers are required to fit in `pointer_max_bits` (≤ 32) bits, only the low `4` limbs are materialized as `mem_ptr_limbs`; the upper `4` bytes of the 8-byte register are hardcoded to zero in the memory bus interaction. The AIR range-checks the scaled `mem_ptr_limbs[3] * (1 << (32 - pointer_max_bits))` to an 8-bit lookup. The scaling constrains `mem_ptr < 2^pointer_max_bits` and requires `pointer_max_bits ∈ (24, 32]`. The preflight executor additionally asserts that the upper 32 bits of the rs1 read are zero.
+On the starting row, `mem_ptr` is read from an RV64 register. It must be an 8-byte-aligned address
+in the configured memory range. The AIR range-checks its two u16 limbs and converts the byte address
+to a memory-bus block index.
 
-On each row in the same HINT_BUFFER_RV64 instruction, the chip does a write of 8 bytes to `[mem_ptr:8]_2` and increments `mem_ptr += 8`.
-Under the invariant that timestamp is always increasing and the memory bus does not contain any invalid writes at previous timestamps, an attempted memory write access to `mem_ptr > 2^{pointer_max_bits} - 8` will not be able to balance the memory bus: it would require a send at an earlier timestamp to an out of bounds memory address, which the invariant prevents.
-Only the starting `mem_ptr` is range checked: since each row will increment `mem_ptr` by `8`, an out
-of bounds memory access will occur, causing an imbalance in the memory bus, before `mem_ptr` overflows the field.
+On each row in the same HINT_BUFFER_RV64 instruction, the chip writes 8 bytes to `[mem_ptr:8]_2` and
+increments the block index. Execution rejects a buffer past the 32-bit RV64 range. Postflight
+enforces the configured memory range, and the AIR enforces the configured pointer bound.
 
-On the starting row, `rem_dwords` is also read from memory. `rem_dwords` is bounded by
-`2^MAX_HINT_BUFFER_DWORDS_BITS` (= 2^10), so only the low 2 limbs are materialized as `rem_words_limbs`; the upper 6 bytes of the 8-byte register are hardcoded to zero in the memory bus interaction. The AIR range-checks the scaled `rem_words_limbs[1] * (1 << (16 - MAX_HINT_BUFFER_DWORDS_BITS))` to an 8-bit lookup. This constrains `rem_dwords < 2^MAX_HINT_BUFFER_DWORDS_BITS` and requires `MAX_HINT_BUFFER_DWORDS_BITS ∈ [8, 16)`.
+The first HINT_BUFFER_RV64 row also reads `rem_dwords`. It must fit in
+`MAX_HINT_BUFFER_DWORDS_BITS` (= 10) bits, and the upper register cells must be zero.
 On each row with `is_buffer = 1`, the `rem_dwords` is decremented by `1`.
 
-Note: we constrain that when the current instruction ends then `rem_dwords` is 1. However, we don't constrain that when `rem_dwords` is 1 then we have to end the current instruction. The only way to exploit this if we to do some multiple of `p` number of additional illegal `is_buffer = 1` rows where `p` is the prime modulus of `F`. However, when doing `p` additional rows we will always reach an illegal `mem_ptr` at some point which prevents this exploit.
+The AIR requires `rem_dwords = 1` when the instruction ends, but not the converse. Exploiting this
+would require a multiple of `p` extra rows, where `p` is the modulus of `F`; the configured address
+bound prevents that many 8-byte increments.


### PR DESCRIPTION
## Summary

- document runtime program counters as aligned u32 byte addresses and circuit program counters as the single 30-bit index `pc_idx = byte_pc / DEFAULT_PC_STEP`
- document full-u32 RV64 memory as guest byte addresses backed by u16 cells, with memory-bus addresses carrying one aligned block index
- clarify PC and memory alignment, overflow, complete-access-span checks, executable commitments, continuation public values, and taken branch/jump behavior
- document valid bit-32 RV64 register results for AUIPC and JAL/JALR link addresses at the top of the PC range
- update only the VM, verifier, continuation, ISA, memory, transpiler, guest-programming, SDK, hint-store, and RV64 circuit documentation affected by the merged implementations

The implementation changes are already present on `develop-v2.1.0` through #3104 and #3108; this PR now contains only the two documentation commits.

## Testing

- `cd docs/vocs && pnpm install --frozen-lockfile && pnpm build`
- `codespell` on all changed documentation files
- `git diff --check origin/develop-v2.1.0...HEAD`

Closes INT-9122
Closes INT-9123
Closes INT-8078
