### PR TITLE
chore: CI to compare locked Rust verifier to lean

### DIFF
--- a/.github/workflows/fv-verifier.yml
+++ b/.github/workflows/fv-verifier.yml
@@ -18,6 +18,7 @@ on:
       - "rust-toolchain.toml"
       - ".github/actions/sccache/**"
       - ".github/workflows/fv-verifier.yml"
+      - "ci/scripts/check_swirl_verifier_extraction.sh"
       - "ci/scripts/check_swirl_verifier_c.sh"
 
 concurrency:
@@ -91,8 +92,9 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
+  # TODO[INT-9153]: update used repos and references
   swirl-rbr-fv-tests:
-    name: Generated C matches upstream
+    name: Locked Rust extraction and generated C consistency
     runs-on: ubuntu-latest
 
     steps:
@@ -108,6 +110,20 @@ jobs:
         run: |
           git clone --filter=blob:none git@github.com:axiom-crypto/swirl-rbr-fv.git swirl-rbr-fv
           echo "revision=$(git -C swirl-rbr-fv rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Route the private rust-to-lean clone through SSH
+        run: |
+          git config --global \
+            url."git@github.com:axiom-crypto/rust-to-lean".insteadOf \
+            "https://github.com/axiom-crypto/rust-to-lean"
+
+      - name: Install Rust extraction toolchain
+        run: |
+          source swirl-rbr-fv/verifier-lean/extraction/sources.lock
+          rustup toolchain install "$R2L_RUST_TOOLCHAIN" --profile minimal
+
+      - name: Check Lean model against OpenVM's locked Rust verifier
+        run: bash ci/scripts/check_swirl_verifier_extraction.sh swirl-rbr-fv
 
       - name: Install Lean toolchain
         run: |

--- a/ci/scripts/check_swirl_verifier_extraction.sh
+++ b/ci/scripts/check_swirl_verifier_extraction.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+openvm_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+swirl_dir="${1:?usage: check_swirl_verifier_extraction.sh <swirl-rbr-fv checkout>}"
+swirl_dir="$(cd "$swirl_dir" && pwd)"
+
+# Ask Cargo for the exact stark-backend source selected by this lockfile. The
+# precise Git revision is part of `source`; `cargo pkgid` only reports the
+# package identity and omits that revision.
+locked_source="$(
+  cd "$openvm_root"
+  cargo metadata --locked --format-version 1 | jq -er '
+    [.packages[] | select(.name == "openvm-stark-backend") | .source]
+    | if length == 1 then .[0]
+      else error("expected exactly one openvm-stark-backend package")
+      end
+  '
+)"
+if [[ ! "$locked_source" =~ \#([0-9a-f]{40})$ ]]; then
+  echo "Could not resolve the openvm-stark-backend revision from Cargo metadata:" >&2
+  echo "$locked_source" >&2
+  exit 1
+fi
+locked_revision="${BASH_REMATCH[1]}"
+
+echo "Checking the Lean model against OpenVM's locked stark-backend revision $locked_revision."
+"$swirl_dir/verifier-lean/extraction/verify.sh" --stark-backend-rev "$locked_revision"


### PR DESCRIPTION
Resolves INT-9061.

Adds a CI workflow to compare the locked `stark-backend` Rust verifier against the one used to formally verify the SWIRL verifier. OpenVM CI now checks that:

- The C verifier (i.e. `fv-verifier`) matches the one extracted from the handwritten Lean verifier
- The Rust verifier (i.e. locked `stark-backend`) extracts to the official extracted Lean verifier, which is proven to be semantically equivalent to the handwritten one