### PR TITLE
chore: prover assert check that all AIRs are required for cached pks

### DIFF
--- a/crates/continuations/src/prover/deferral/hook/mod.rs
+++ b/crates/continuations/src/prover/deferral/hook/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         deferral::hook::{DeferralHookCircuit, DeferralHookTraceGen, DeferralIoCommit},
         Circuit,
     },
-    prover::{keygen_all_required, trace_heights_tracing_info},
+    prover::{assert_all_airs_required, keygen_all_required, trace_heights_tracing_info},
     CommitBytes, VkCommitBytes, SC,
 };
 
@@ -130,6 +130,7 @@ where
         PB::Matrix: Clone,
         PB::Commitment: Into<CommitBytes>,
     {
+        assert_all_airs_required(&pk);
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {

--- a/crates/continuations/src/prover/deferral/inner/mod.rs
+++ b/crates/continuations/src/prover/deferral/inner/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         deferral::inner::{DeferralInnerCircuit, DeferralInnerTraceGen},
         Circuit,
     },
-    prover::{keygen_all_required, trace_heights_tracing_info},
+    prover::{assert_all_airs_required, keygen_all_required, trace_heights_tracing_info},
     SC,
 };
 
@@ -139,6 +139,7 @@ where
         S: VerifierTraceGen<PB, SC, EngineDeviceCtx<E>>,
         T: DeferralInnerTraceGen<PB, EngineDeviceCtx<E>>,
     {
+        assert_all_airs_required(&pk);
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {

--- a/crates/continuations/src/prover/inner/mod.rs
+++ b/crates/continuations/src/prover/inner/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         inner::{InnerCircuit, InnerTraceGen, ProofsType, VerifierCircuitType},
         Circuit,
     },
-    prover::{keygen_all_required, trace_heights_tracing_info},
+    prover::{assert_all_airs_required, keygen_all_required, trace_heights_tracing_info},
     SC,
 };
 
@@ -161,6 +161,7 @@ where
         S: VerifierTraceGen<PB, SC, EngineDeviceCtx<E>>,
         T: InnerTraceGen<PB, EngineDeviceCtx<E>>,
     {
+        assert_all_airs_required(&pk);
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {

--- a/crates/continuations/src/prover/root/mod.rs
+++ b/crates/continuations/src/prover/root/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         root::{RootCircuit, RootTraceGen},
         Circuit,
     },
-    prover::{keygen_all_required, trace_heights_tracing_info},
+    prover::{assert_all_airs_required, keygen_all_required, trace_heights_tracing_info},
     CommitBytes, RootSC, VkCommitBytes, SC,
 };
 
@@ -150,6 +150,7 @@ impl<S: AggregationSubCircuit, T> RootProver<S, T> {
         <E::PB as ProverBackend>::Val: Field + PrimeField32,
         <E::PB as ProverBackend>::Matrix: Clone,
     {
+        assert_all_airs_required(&pk);
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {

--- a/crates/continuations/src/prover/utils.rs
+++ b/crates/continuations/src/prover/utils.rs
@@ -10,6 +10,14 @@ use openvm_stark_backend::{
 
 use crate::circuit::Circuit;
 
+/// Panics if any AIR in the proving key is not marked as required.
+pub fn assert_all_airs_required<SC: StarkProtocolConfig>(pk: &MultiStarkProvingKey<SC>) {
+    assert!(
+        pk.per_air.iter().all(|air_pk| air_pk.vk.is_required),
+        "cached proving key must have all AIRs marked as required"
+    );
+}
+
 /// Generates keys with every AIR marked as required.
 pub fn keygen_all_required<E: StarkEngine>(
     engine: &E,

--- a/guest-libs/verify-stark/circuit/src/prover/mod.rs
+++ b/guest-libs/verify-stark/circuit/src/prover/mod.rs
@@ -8,7 +8,10 @@ use openvm_circuit::system::memory::{
 use openvm_continuations::prover::debug_constraints;
 use openvm_continuations::{
     circuit::{deferral::DeferralMerkleProofs, Circuit},
-    prover::{keygen_all_required, DeferralCircuitProver, DeferralCircuitProverKey},
+    prover::{
+        assert_all_airs_required, keygen_all_required, DeferralCircuitProver,
+        DeferralCircuitProverKey,
+    },
     CommitBytes, VkCommitBytes, SC,
 };
 use openvm_cpu_backend::CpuBackend;
@@ -183,6 +186,7 @@ where
         T: DeferredVerifyTraceGen<PB, EngineDeviceCtx<E>>,
         PB::Matrix: Clone,
     {
+        assert_all_airs_required(&pk);
         let verifier_circuit = S::new(
             child_vk.clone(),
             VerifierConfig {


### PR DESCRIPTION
Resolves INT-9260, INT-9264. In a previous commit, we modified keygen to mark each verifier circuit AIR as required. This commit modifies the provers to check that cached pks were generated with this change, avoiding a footgun.