### PR TITLE
fix: enforce trusted certified-verifier builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow_ref }}-build-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  LEAN_TOOLCHAIN: leanprover/lean4:v4.26.0
-
 jobs:
   lint:
     name: Cargo build
@@ -31,13 +28,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
 
       - name: Run build
         run: cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,45 @@ members = [
   "crates/static-verifier",
   "scripts",
 ]
+# Keep this in sync with `members`, except for `openvm-certified-verifier`. That crate requires the
+# pinned Lean toolchain and is built and tested by `.github/workflows/certified-verifier.yml`.
+default-members = [
+  "benchmarks/execute",
+  "benchmarks/prove",
+  "benchmarks/utils",
+  "crates/prof",
+  "crates/cli",
+  "crates/sdk",
+  "crates/sdk-config",
+  "crates/circuits/*",
+  "crates/circuits/primitives/derive",
+  "crates/toolchain/*",
+  "crates/toolchain/instructions/derive",
+  "crates/continuations",
+  "crates/recursion",
+  "crates/recursion/derive",
+  "crates/verify",
+  "crates/vm",
+  "crates/vm/derive",
+  "crates/static-verifier",
+  "extensions/rv32-adapters",
+  "extensions/algebra/*",
+  "extensions/bigint/*",
+  "extensions/deferral/*",
+  "extensions/ecc/*",
+  "extensions/keccak256/*",
+  "extensions/pairing/*",
+  "extensions/rv32im/*",
+  "extensions/sha2/*",
+  "guest-libs/ff_derive",
+  "guest-libs/k256",
+  "guest-libs/p256",
+  "guest-libs/keccak256",
+  "guest-libs/pairing",
+  "guest-libs/sha2",
+  "guest-libs/verify-stark/*",
+  "scripts",
+]
 exclude = ["crates/sdk/example", "benchmarks/guest/**"]
 resolver = "2"
 

--- a/crates/certified-verifier/README.md
+++ b/crates/certified-verifier/README.md
@@ -31,10 +31,8 @@ cargo build -p openvm-certified-verifier
 cargo build -p openvm-sdk --features certified-verifier
 ```
 
-Overrides: `SWIRL_LEANC=<path to leanc>` picks the compiler explicitly.
-`SWIRL_VERIFY_BIN=<path>` selects an externally built verifier and is
-also honored at runtime. The parser tests expect `swirl_dump_proof` to
-be next to that verifier.
+The build always invokes `leanc` through the pinned elan toolchain. Compiler
+and verifier binary overrides are intentionally unsupported.
 
 ## Regenerating csrc/
 

--- a/crates/certified-verifier/build.rs
+++ b/crates/certified-verifier/build.rs
@@ -15,23 +15,14 @@ use std::{
 const LEAN_TOOLCHAIN: &str = "leanprover/lean4:v4.26.0";
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SWIRL_VERIFY_BIN");
-    println!("cargo:rerun-if-env-changed=SWIRL_LEANC");
+    println!("cargo:rerun-if-env-changed=ELAN_HOME");
+    println!("cargo:rerun-if-env-changed=PATH");
     println!("cargo:rerun-if-changed=csrc");
-
-    // Escape hatch: point at externally built sibling executables and
-    // skip the vendored C build entirely.
-    if let Ok(path) = env::var("SWIRL_VERIFY_BIN") {
-        if !path.is_empty() {
-            println!("cargo:rustc-env=SWIRL_VERIFY_BIN={path}");
-            return;
-        }
-    }
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let csrc = manifest_dir.join("csrc");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let leanc = find_leanc();
+    ensure_pinned_leanc();
 
     let mut sources = Vec::new();
     collect_c_files(&csrc, &mut sources);
@@ -44,7 +35,6 @@ fn main() {
         let jobs = std::thread::available_parallelism().map_or(4, |n| n.get());
         let mut handles = Vec::new();
         for chunk in sources.chunks(sources.len().div_ceil(jobs)) {
-            let leanc = &leanc;
             let csrc = &csrc;
             let out_dir = &out_dir;
             handles.push(scope.spawn(move || {
@@ -83,7 +73,6 @@ fn main() {
         .collect();
     link_args.extend(obj_strs.iter().map(String::as_str));
     run(leanc(&link_args));
-    println!("cargo:rustc-env=SWIRL_VERIFY_BIN={}", bin.display());
 
     let dump_main = csrc.join("Tools/SwirlDumpProof.c");
     let dump_obj = out_dir.join("dump_Tools_SwirlDumpProof.o");
@@ -111,52 +100,26 @@ fn main() {
     ]));
 }
 
-/// Locate `leanc`: `SWIRL_LEANC` env override, then the pinned toolchain
-/// via elan, then whatever `leanc` is on PATH.
-#[allow(clippy::type_complexity)]
-fn find_leanc() -> Box<dyn Fn(&[&str]) -> Command + Sync> {
-    if let Ok(path) = env::var("SWIRL_LEANC") {
-        if !path.is_empty() {
-            return Box::new(move |args| {
-                let mut cmd = Command::new(&path);
-                cmd.args(args);
-                cmd
-            });
-        }
-    }
-    let elan_works = Command::new("elan")
-        .args(["run", LEAN_TOOLCHAIN, "leanc", "--version"])
-        .output()
-        .is_ok_and(|o| o.status.success());
-    if elan_works {
-        return Box::new(|args| {
-            let mut cmd = Command::new("elan");
-            cmd.args(["run", LEAN_TOOLCHAIN, "leanc"]);
-            cmd.args(args);
-            cmd
-        });
-    }
-    let plain_works = Command::new("leanc")
-        .arg("--version")
-        .output()
-        .is_ok_and(|o| o.status.success());
-    if plain_works {
-        println!(
-            "cargo:warning=using `leanc` from PATH; the vendored C expects \
-             toolchain {LEAN_TOOLCHAIN} — install it via elan for a \
-             reproducible build"
-        );
-        return Box::new(|args| {
-            let mut cmd = Command::new("leanc");
-            cmd.args(args);
-            cmd
-        });
-    }
-    panic!(
-        "building `openvm-certified-verifier` needs `leanc` (Lean toolchain \
-        {LEAN_TOOLCHAIN}). Install elan (https://github.com/leanprover/elan) \
-         and run `elan toolchain install {LEAN_TOOLCHAIN}`, set SWIRL_LEANC \
-         to a leanc binary, or set SWIRL_VERIFY_BIN to a prebuilt verifier."
+fn leanc(args: &[&str]) -> Command {
+    let mut cmd = Command::new("elan");
+    cmd.args(["run", LEAN_TOOLCHAIN, "leanc"]);
+    cmd.args(args);
+    cmd
+}
+
+fn ensure_pinned_leanc() {
+    let output = leanc(&["--version"]).output().unwrap_or_else(|e| {
+        panic!(
+            "building `openvm-certified-verifier` needs Lean toolchain \
+             {LEAN_TOOLCHAIN}, but failed to run `elan`: {e}. Install elan \
+             (https://github.com/leanprover/elan) and run \
+             `elan toolchain install {LEAN_TOOLCHAIN}`."
+        )
+    });
+    assert!(
+        output.status.success(),
+        "failed to run `leanc` from Lean toolchain {LEAN_TOOLCHAIN}: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
     );
 }
 

--- a/crates/certified-verifier/src/harness.rs
+++ b/crates/certified-verifier/src/harness.rs
@@ -10,8 +10,7 @@
 //! The upstream crate's `build.rs` runs `lake build swirl_verify`
 //! against the Lean sources; here the crate's `build.rs` instead
 //! compiles the vendored Lean-generated C (`csrc/`) with `leanc` and
-//! bakes the resulting exe path in. A `SWIRL_VERIFY_BIN` env var
-//! overrides at runtime (and skips the C build at build time).
+//! bakes the resulting exe path in.
 
 use std::{
     io::{self, Write},
@@ -19,16 +18,10 @@ use std::{
     process::{Command, Stdio},
 };
 
-/// Resolve the `swirl_verify` Lean executable: the `SWIRL_VERIFY_BIN`
-/// env var if set, otherwise the exe compiled from the vendored C
+/// Resolve the `swirl_verify` Lean executable compiled from the vendored C
 /// sources by this crate's `build.rs`.
 pub fn swirl_verify_bin() -> PathBuf {
-    if let Ok(path) = std::env::var("SWIRL_VERIFY_BIN") {
-        if !path.is_empty() {
-            return PathBuf::from(path);
-        }
-    }
-    PathBuf::from(env!("SWIRL_VERIFY_BIN"))
+    PathBuf::from(env!("OUT_DIR")).join("swirl_verify")
 }
 
 /// Spawn the Lean verifier exe, write `bytes` to its stdin, and return

--- a/crates/certified-verifier/src/lib.rs
+++ b/crates/certified-verifier/src/lib.rs
@@ -21,7 +21,7 @@
 //! `leanprover/lean4:v4.26.0`) are vendored under `csrc/` and compiled
 //! by this crate's `build.rs` with `leanc` (see `README.md` in this
 //! crate's directory). The resulting exe is resolved by
-//! [`swirl_verify_bin`]; override with the `SWIRL_VERIFY_BIN` env var.
+//! [`swirl_verify_bin`].
 
 pub mod harness;
 pub mod magic;

--- a/crates/certified-verifier/tests/wire_roundtrip.rs
+++ b/crates/certified-verifier/tests/wire_roundtrip.rs
@@ -9,13 +9,12 @@
 
 use std::{
     io::Write,
-    path::PathBuf,
     process::{Command, Stdio},
 };
 
 use openvm_certified_verifier::{
-    write_proof, write_public_values, write_vk, MAGIC_PROOF, MAGIC_PUBLIC_VALUES, MAGIC_VK,
-    WIRE_VERSION,
+    swirl_verify_bin, write_proof, write_public_values, write_vk, MAGIC_PROOF, MAGIC_PUBLIC_VALUES,
+    MAGIC_VK, WIRE_VERSION,
 };
 use openvm_stark_backend::{
     keygen::types::MultiStarkVerifyingKey,
@@ -70,9 +69,7 @@ struct DumpOutcome {
 
 /// Pipe `stdin_bytes` to `swirl_dump_proof` and capture exit + output.
 fn run_swirl_dump_proof(stdin_bytes: &[u8]) -> DumpOutcome {
-    let mut dump_proof_bin = std::env::var_os("SWIRL_VERIFY_BIN")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(env!("SWIRL_VERIFY_BIN")));
+    let mut dump_proof_bin = swirl_verify_bin();
     dump_proof_bin.set_file_name("swirl_dump_proof");
     let mut child = Command::new(dump_proof_bin)
         .stdin(Stdio::piped())


### PR DESCRIPTION
Resolves INT-9271, INT-9272, INT-9278.

## Summary

- Require certified verifier builds to use leanc from the pinned `leanprover/lean4:v4.26.0` Elan toolchain.
- Remove `SWIRL_LEANC` and `SWIRL_VERIFY_BIN` escape hatches so arbitrary compilers or verifier executables cannot be substituted.
- Resolve the verifier executable directly from the build output.
- Exclude `openvm-certified-verifier` from the workspace’s default members so ordinary root builds do not require Lean.
- Keep direct verifier builds unconditional and retain dedicated CI coverage.
- Remove the now-redundant Lean installation from the general build workflow.
  
Note that defining `default_members` in `Cargo.toml` is the idiomatic way to exclude packages from `cargo build`; we do this in `stark-backend` for CUDA crates.