### PR TITLE
chore: make certified-verifier CI more robust

### DIFF
--- a/.github/actions/lean-toolchain/action.yml
+++ b/.github/actions/lean-toolchain/action.yml
@@ -1,0 +1,28 @@
+name: "Setup Lean toolchain"
+description: "Installs elan and the Lean toolchain used to build the certified verifier."
+
+inputs:
+  toolchain:
+    description: "Lean toolchain to install."
+    required: false
+    default: "leanprover/lean4:v4.26.0"
+
+outputs:
+  toolchain:
+    description: "Lean toolchain installed by this action."
+    value: ${{ steps.install.outputs.toolchain }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Lean toolchain
+      id: install
+      shell: bash
+      env:
+        LEAN_TOOLCHAIN: ${{ inputs.toolchain }}
+      run: |
+        curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+        echo "LEAN_TOOLCHAIN=$LEAN_TOOLCHAIN" >> "$GITHUB_ENV"
+        echo "toolchain=$LEAN_TOOLCHAIN" >> "$GITHUB_OUTPUT"
+        "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"

--- a/.github/workflows/certified-verifier.yml
+++ b/.github/workflows/certified-verifier.yml
@@ -18,6 +18,7 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
+      - ".github/actions/lean-toolchain/**"
       - ".github/actions/sccache/**"
       - ".github/workflows/certified-verifier.yml"
       - "ci/scripts/check_swirl_verifier_c.sh"
@@ -28,7 +29,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  LEAN_TOOLCHAIN: leanprover/lean4:v4.26.0
 
 jobs:
   openvm-tests:
@@ -40,18 +40,14 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
+      - uses: actions/checkout@v5
+      - id: lean-toolchain
+        uses: ./.github/actions/lean-toolchain
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
@@ -97,18 +93,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install Lean toolchain
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
-
+      - uses: actions/checkout@v5
+      - id: lean-toolchain
+        uses: ./.github/actions/lean-toolchain
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
 
       - name: Check out current swirl-rbr-fv
         id: checkout-swirl
@@ -120,7 +112,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: swirl-rbr-fv/.lake
-          key: ${{ runner.os }}-swirl-rbr-fv-${{ steps.checkout-swirl.outputs.revision }}-${{ env.LEAN_TOOLCHAIN }}
+          key: ${{ runner.os }}-swirl-rbr-fv-${{ steps.checkout-swirl.outputs.revision }}-${{ steps.lean-toolchain.outputs.toolchain }}
 
       - name: Build upstream Lean verifier executables
         working-directory: swirl-rbr-fv

--- a/.github/workflows/certified-verifier.yml
+++ b/.github/workflows/certified-verifier.yml
@@ -12,6 +12,8 @@ on:
       - "crates/toolchain/build/**"
       - "crates/cli/**"
       - "crates/certified-verifier/**"
+      - "crates/continuations/**"
+      - "crates/recursion/**"
       - "crates/sdk/**"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -38,6 +40,12 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
+      - name: Install Lean toolchain
+        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
+        run: |
+          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -50,13 +58,6 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
 
       - name: Build cargo-openvm
         run: |
@@ -96,6 +97,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install Lean toolchain
+        run: |
+          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
+
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -109,12 +116,6 @@ jobs:
           git clone --filter=blob:none git@github.com:axiom-crypto/swirl-rbr-fv.git swirl-rbr-fv
           echo "revision=$(git -C swirl-rbr-fv rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Install Lean toolchain
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
-
       - name: Cache swirl-rbr-fv Lean build
         uses: actions/cache@v4
         with:
@@ -124,8 +125,9 @@ jobs:
       - name: Build upstream Lean verifier executables
         working-directory: swirl-rbr-fv
         run: |
-          lake build swirl_verify
-          lake build swirl_dump_proof
+          test "$(tr -d '\r\n' < lean-toolchain)" = "$LEAN_TOOLCHAIN"
+          elan run "$LEAN_TOOLCHAIN" lake build swirl_verify
+          elan run "$LEAN_TOOLCHAIN" lake build swirl_dump_proof
 
       - name: Check vendored C against Lean-generated C
         run: bash ci/scripts/check_swirl_verifier_c.sh swirl-rbr-fv

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,12 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
+      - name: Install Lean toolchain
+        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
+        run: |
+          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -51,13 +57,6 @@ jobs:
           nvidia-smi
           nvidia-smi -L
           echo "CUDA_ARCH=86,89,120" >> $GITHUB_ENV
-
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
 
       - name: Build documentation
         run: cargo +nightly-2026-01-18 doc --workspace --no-deps --exclude "openvm-benchmarks*" --exclude "*-tests" --features "cuda"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/actions/lean-toolchain/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
     inputs:
@@ -18,7 +19,6 @@ on:
 
 env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
-  LEAN_TOOLCHAIN: leanprover/lean4:v4.26.0
 
 jobs:
   docs:
@@ -34,18 +34,13 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/lean-toolchain
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       - uses: ./.github/actions/sccache

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -8,8 +8,6 @@ on:
 concurrency:
   group: ${{ github.workflow_ref }}-lints-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
-env:
-  LEAN_TOOLCHAIN: leanprover/lean4:v4.26.0
 jobs:
   changes:
     name: Detect CUDA changes
@@ -36,6 +34,7 @@ jobs:
               - '.cargo/config.toml'
               - 'scripts/gpu_driver_setup.sh'
               - '.github/workflows/lints.yml'
+              - '.github/actions/lean-toolchain/**'
               - '.github/actions/sccache/**'
               - '.github/actions/rust-cache-cuda/**'
   lint:
@@ -46,18 +45,13 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/lean-toolchain
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@v2
         with:
           skip: Cargo.lock,./docs/vocs/pnpm-lock.yaml,*.txt,./crates/toolchain/openvm/src/memcpy.s,./crates/toolchain/openvm/src/memset.s,./audits/*.pdf
@@ -130,18 +124,13 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/lean-toolchain
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/sccache
       - uses: Swatinem/rust-cache@v2
@@ -170,18 +159,13 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/lean-toolchain
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTUP_PERMIT_COPY_RENAME: "1"

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -46,6 +46,12 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
+      - name: Install Lean toolchain
+        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
+        run: |
+          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -62,13 +68,6 @@ jobs:
         with:
           cache-on-failure: true
           key: v1
-
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
 
       - name: Run fmt
         run: |
@@ -131,6 +130,12 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
+      - name: Install Lean toolchain
+        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
+        run: |
+          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -143,13 +148,6 @@ jobs:
         with:
           cache-on-failure: true
           key: v1
-
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
 
       - name: Generate docs
         # full docs with dependencies are built by docs.yml on main/tags
@@ -172,6 +170,12 @@ jobs:
       - uses: runs-on/action@v2
         with:
           sccache: s3
+      - name: Install Lean toolchain
+        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
+        run: |
+          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -188,12 +192,6 @@ jobs:
       - uses: ./.github/actions/rust-cache-cuda
         with:
           cache-on-failure: true
-      - name: Install Lean toolchain
-        # openvm-certified-verifier's build.rs needs leanc from the toolchain that generated csrc/.
-        run: |
-          curl -sSf https://elan.lean-lang.org/elan-init.sh | sh -s -- -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$LEAN_TOOLCHAIN"
       - name: Verify GPU setup
         run: |
           nvidia-smi


### PR DESCRIPTION
Resolves INT-9268, INT-9270, INT-9274.

## Summary

  - Run certified-verifier CI when recursion or continuations code changes.
  - Require the upstream verifier’s lean-toolchain to match the pinned Lean 4.26.0 toolchain.
  - Explicitly regenerate the vendored C closure with the pinned toolchain via elan run.
  - Install Lean before repository authentication in certified-verifier, docs, and lint workflows.