### PR TITLE
fix(cli): require proof extension separator

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -200,16 +200,40 @@ pub fn resolve_proof_path(proof: &Option<PathBuf>, extension: &str) -> Result<Pa
 
 pub fn get_files_with_ext(dir: &Path, extension: &str) -> Result<Vec<PathBuf>> {
     let dir = dir.canonicalize()?;
+    let suffix = format!(".{extension}");
     let mut files = Vec::new();
     for entry in read_dir(dir)? {
         let path = entry?.path();
         if path.is_file()
             && path
-                .to_str()
-                .is_some_and(|path_str| path_str.ends_with(extension))
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(&suffix))
         {
             files.push(path);
         }
     }
     Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::write;
+
+    use tempfile::tempdir;
+
+    use super::get_files_with_ext;
+    use crate::default::APP_PROOF_EXT;
+
+    #[test]
+    fn get_files_with_ext_requires_extension_separator() {
+        let dir = tempdir().unwrap();
+        let proof = dir.path().join("guest").with_extension(APP_PROOF_EXT);
+        write(&proof, []).unwrap();
+        write(dir.path().join("zapp.proof"), []).unwrap();
+
+        let files = get_files_with_ext(dir.path(), APP_PROOF_EXT).unwrap();
+
+        assert_eq!(files, vec![proof.canonicalize().unwrap()]);
+    }
 }


### PR DESCRIPTION
## Summary

- require the separator before compound proof extensions during auto-discovery
- match against the file name rather than the full path
- add a regression covering a canonical proof beside a misleading suffix match

## Motivation

When `--proof` is omitted, `resolve_proof_path` auto-discovers proof artifacts such as `*.app.proof`. The current predicate checks `path.ends_with("app.proof")`, so an unrelated file such as `zapp.proof` is also treated as an app proof.

If `guest.app.proof` and `zapp.proof` coexist, verification fails with a misleading `multiple .app.proof files found` error. With only the misleading file present, the CLI can try to deserialize the wrong artifact.

Proof outputs are created with `PathBuf::with_extension`, which always inserts the separator. Matching `.{extension}` preserves that contract for app, STARK, and EVM proofs.

## Checks

- failure-before-fix regression: returned both files instead of the single canonical proof
- fixed regression harness: 1 passed
- `cargo +nightly-2026-01-18 fmt --all -- --check`
- `git diff --check`

The focused Cargo test was also attempted locally, but this Windows host is outside `cargo-openvm`'s supported Linux/macOS targets and its unrelated `aws-lc-sys` build requires a C toolchain before tests can run.